### PR TITLE
fit(report|docs) Add -d params to be able to show only files with complexity above the max_complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ complexipy path/to/file.py           # Use complexipy to analyze a specific file
 complexipy path/to/file.py -c 20     # Use the -c option to set the maximum congnitive complexity, default is 15
 complexipy path/to/directory -c 0    # Set the maximum cognitive complexity to 0 to disable the exit with error
 complexipy path/to/directory -o      # Use the -o option to output the results to a CSV file, default is False
+complexipy path/to/directory -d low  # Use the -d option to set detail level, default is "normal". If set to "low" will show only files with complexity greater than the maximum complexity
 ```
 
 If the cognitive complexity of a file is greater than the maximum cognitive, then

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from complexipy import rust
 import csv
+from enum import Enum
 import os
 import re
 from rich.console import Console
@@ -12,6 +13,10 @@ root_dir = Path(__file__).resolve().parent.parent
 app = typer.Typer(name="complexipy")
 console = Console()
 version = "0.2.2"
+
+class DetailTypes(Enum):
+    low = "low"  # Show only files with complexity above the max_complexity
+    normal = "normal"  # Show all files with their complexity
 
 
 @app.command()
@@ -27,6 +32,9 @@ def main(
     ),
     output: bool = typer.Option(
         False, "--output", "-o", help="Output the results to a CSV file."
+    ),
+    details: DetailTypes = typer.Option(
+        DetailTypes.normal.value, "--details", "-d", help="Specify how detailed should be output."
     ),
 ):
     has_success = True
@@ -69,7 +77,7 @@ def main(
                 f"[red]{file.complexity}[/red]",
             )
             has_success = False
-        else:
+        elif details != DetailTypes.low or max_complexity == 0:
             table.add_row(
                 f"{file.path}",
                 f"[green]{file.file_name}[/green]",

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,6 +50,7 @@ complexipy path/to/file.py           # Use complexipy to analyze a specific file
 complexipy path/to/file.py -c 20     # Use the -c option to set the maximum congnitive complexity, default is 15
 complexipy path/to/directory -c 0    # Set the maximum cognitive complexity to 0 to disable the exit with error
 complexipy path/to/directory -o      # Use the -o option to output the results to a CSV file, default is False
+complexipy path/to/directory -d low  # Use the -d option to set detail level, default is "normal". If set to "low" will show only files with complexity greater than the maximum complexity
 ```
 
 If the cognitive complexity of a file is greater than the maximum cognitive, then


### PR DESCRIPTION
I've tried to use complexipy on some of my work projects and run into an issue, that when the project has many files it's quite hard to spot files with complexity above the threshold.

So I propose adding another command line option to switch between showing all the files and only "red" once. That also might be a nice option for using complexipy in pre-commit or ci/cd pipeline.