### PR TITLE
Expose library commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,13 @@ docs/_build/
 # VSCode
 .vscode/
 
+# Emacs
+*~
+\#*\#
+*.dir-locals.el
+
 # Pyenv
 .python-version
+
+# Pyright LSP
+pyrightconfig.json

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -25,10 +25,12 @@ from rich.console import (
 import time
 import typer
 
+from typing import Any
+
 root_dir = Path(__file__).resolve().parent.parent
 app = typer.Typer(name="complexipy")
 console = Console()
-version = "0.4.0"
+version = "0.4.0dev"
 
 
 @app.command()
@@ -107,6 +109,12 @@ def main(
 
     if not has_success:
         raise typer.Exit(code=1)
+
+
+def compute(
+        code: str, max_complexity: int = 15, file_level: bool = True
+) -> Any:
+    return rust.compute(code, max_complexity, file_level)
 
 
 if __name__ == "__main__":

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -75,6 +75,9 @@ def main(
 
     console.rule(f":octopus: complexipy {version}")
     start_time = time.time()
+    # TODO: it seems that the max_complexity parameter is actually NOT used throught the
+    # rust part of the code: it's only used when writing to CSV.
+    # should we remove it from the main, file_complexity, and code_complexity functions?
     files: list[FileComplexity] = rust.main(
         path, is_dir, is_url, max_complexity, file_level
     )
@@ -108,7 +111,6 @@ def main(
 
 
 def code_complexity(
-    # TODO: do we need to include the max_complexity??
     code: str,
     max_complexity: int = 15,
     file_level: bool = True,

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -121,11 +121,11 @@ def code_complexity(
 def file_complexity(
     file_path: str, max_complexity: int = 15, file_level: bool = True
 ) -> FileComplexity:
-    path = Path(file_path).resolve()
+    path = Path(file_path)
     base_path = path.parent
     return rust.file_complexity(
-        file_path=str(path),
-        base_path=str(base_path),
+        file_path=path.resolve().as_posix(),
+        base_path=base_path.resolve().as_posix(),
         _max_complexity=max_complexity,
         _file_level=file_level,
     )

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -11,9 +11,7 @@ from .utils import (
 from complexipy import (
     rust,
 )
-from complexipy.rust import (
-    FileComplexity,
-)
+from complexipy.rust import FileComplexity, CodeComplexity
 import os
 from pathlib import (
     Path,
@@ -24,8 +22,6 @@ from rich.console import (
 )
 import time
 import typer
-
-from typing import Any
 
 root_dir = Path(__file__).resolve().parent.parent
 app = typer.Typer(name="complexipy")
@@ -111,10 +107,26 @@ def main(
         raise typer.Exit(code=1)
 
 
-def compute(
-        code: str, max_complexity: int = 15, file_level: bool = True
-) -> Any:
-    return rust.compute(code, max_complexity, file_level)
+def code_complexity(
+    # TODO: do we need to include the max_complexity??
+    code: str,
+    max_complexity: int = 15,
+    file_level: bool = True,
+) -> CodeComplexity:
+    return rust.code_complexity(code, max_complexity, file_level)
+
+
+def file_complexity(
+    file_path: str, max_complexity: int = 15, file_level: bool = True
+) -> FileComplexity:
+    path = Path(file_path).resolve()
+    base_path = path.parent
+    return rust.file_complexity(
+        file_path=str(path),
+        base_path=str(base_path),
+        _max_complexity=max_complexity,
+        _file_level=file_level,
+    )
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 
-dependencies = ["typer[all]"]
+dependencies = ["typer"]
 
 [project.scripts]
 complexipy = "complexipy.main:app"

--- a/src/classes/mod.rs
+++ b/src/classes/mod.rs
@@ -15,3 +15,10 @@ pub struct FileComplexity {
     pub functions: Vec<FunctionComplexity>,
     pub complexity: u64,
 }
+
+#[derive(Clone)]
+#[pyclass(module = "complexipy", get_all)]
+pub struct CodeComplexity {
+    pub functions: Vec<FunctionComplexity>,
+    pub complexity: u64,
+}

--- a/src/cognitive_complexity/mod.rs
+++ b/src/cognitive_complexity/mod.rs
@@ -77,7 +77,7 @@ pub fn main(
     } else {
         let parent_dir = path::Path::new(path).parent().unwrap().to_str().unwrap();
 
-        match cognitive_complexity(path, parent_dir, max_complexity, file_level) {
+        match file_complexity(path, parent_dir, max_complexity, file_level) {
             Ok(file_complexity) => ans.push(file_complexity),
             Err(e) => return Err(e),
         }
@@ -123,7 +123,7 @@ fn evaluate_dir(
         .par_iter()
         .map(|file_path| {
             pb.inc(1);
-            match cognitive_complexity(file_path, parent_dir, max_complexity, file_level) {
+            match file_complexity(file_path, parent_dir, max_complexity, file_level) {
                 Ok(file_complexity) => Ok(file_complexity),
                 Err(e) => Err(e),
             }
@@ -140,7 +140,7 @@ fn evaluate_dir(
 
 /// Calculate the cognitive complexity of a python file.
 #[pyfunction]
-pub fn cognitive_complexity(
+pub fn file_complexity(
     file_path: &str,
     base_path: &str,
     _max_complexity: usize,
@@ -152,7 +152,7 @@ pub fn cognitive_complexity(
 
     let code = std::fs::read_to_string(file_path)?;
 
-    let code_complexity = match cognitive_complexity_on_str(&code, _max_complexity, _file_level) {
+    let code_complexity = match code_complexity(&code, _max_complexity, _file_level) {
         Ok(v) => v,
         Err(e) => return Err(
 	    PyValueError::
@@ -169,7 +169,7 @@ pub fn cognitive_complexity(
 
 /// Calculate the cognitive complexity of a string of python code.
 #[pyfunction]
-pub fn cognitive_complexity_on_str(
+pub fn code_complexity(
     code: &str,
     _max_complexity: usize,
     _file_level: bool,

--- a/src/cognitive_complexity/mod.rs
+++ b/src/cognitive_complexity/mod.rs
@@ -152,8 +152,7 @@ pub fn cognitive_complexity(
 
     let code = std::fs::read_to_string(file_path)?;
 
-    // TODO: maybe this default propagation of errors could be a macro
-    let code_complexity = match compute(&code, _max_complexity, _file_level) {
+    let code_complexity = match cognitive_complexity_on_str(&code, _max_complexity, _file_level) {
         Ok(v) => v,
         Err(e) => return Err(
 	    PyValueError::
@@ -168,8 +167,9 @@ pub fn cognitive_complexity(
     })
 }
 
+/// Calculate the cognitive complexity of a string of python code.
 #[pyfunction]
-pub fn compute(
+pub fn cognitive_complexity_on_str(
     code: &str,
     _max_complexity: usize,
     _file_level: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@ mod cognitive_complexity;
 
 use classes::{FileComplexity, FunctionComplexity};
 use cognitive_complexity::main;
-use cognitive_complexity::cognitive_complexity_on_str;
+use cognitive_complexity::file_complexity;
+use cognitive_complexity::code_complexity;
 use cognitive_complexity::utils::{output_csv_file_level, output_csv_function_level};
 use pyo3::prelude::*;
 
@@ -11,8 +12,8 @@ use pyo3::prelude::*;
 #[pymodule]
 fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(main, m)?)?;
-    m.add_function(wrap_pyfunction!(cognitive_complexity)?)?;
-    m.add_function(wrap_pyfunction!(cognitive_complexity_on_str, m)?)?;
+    m.add_function(wrap_pyfunction!(file_complexity, m)?)?;
+    m.add_function(wrap_pyfunction!(code_complexity, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv_file_level, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv_function_level, m)?)?;
     m.add_class::<FileComplexity>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod cognitive_complexity;
 
 use classes::{FileComplexity, FunctionComplexity};
 use cognitive_complexity::main;
+use cognitive_complexity::compute;
 use cognitive_complexity::utils::{output_csv_file_level, output_csv_function_level};
 use pyo3::prelude::*;
 
@@ -10,6 +11,7 @@ use pyo3::prelude::*;
 #[pymodule]
 fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(main, m)?)?;
+    m.add_function(wrap_pyfunction!(compute, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv_file_level, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv_function_level, m)?)?;
     m.add_class::<FileComplexity>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod classes;
 mod cognitive_complexity;
 
-use classes::{FileComplexity, FunctionComplexity};
+use classes::{FileComplexity, FunctionComplexity, CodeComplexity};
 use cognitive_complexity::main;
 use cognitive_complexity::file_complexity;
 use cognitive_complexity::code_complexity;
@@ -18,5 +18,6 @@ fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(output_csv_function_level, m)?)?;
     m.add_class::<FileComplexity>()?;
     m.add_class::<FunctionComplexity>()?;
+    m.add_class::<CodeComplexity>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod cognitive_complexity;
 
 use classes::{FileComplexity, FunctionComplexity};
 use cognitive_complexity::main;
-use cognitive_complexity::compute;
+use cognitive_complexity::cognitive_complexity_on_str;
 use cognitive_complexity::utils::{output_csv_file_level, output_csv_function_level};
 use pyo3::prelude::*;
 
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 #[pymodule]
 fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(main, m)?)?;
-    m.add_function(wrap_pyfunction!(compute, m)?)?;
+    m.add_function(wrap_pyfunction!(cognitive_complexity_on_str, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv_file_level, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv_function_level, m)?)?;
     m.add_class::<FileComplexity>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use pyo3::prelude::*;
 #[pymodule]
 fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(main, m)?)?;
+    m.add_function(wrap_pyfunction!(cognitive_complexity)?)?;
     m.add_function(wrap_pyfunction!(cognitive_complexity_on_str, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv_file_level, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv_function_level, m)?)?;

--- a/tests/main.py
+++ b/tests/main.py
@@ -2,6 +2,8 @@ from complexipy import rust
 import unittest
 from pathlib import Path
 
+from complexipy.main import file_complexity, code_complexity
+
 
 class TestFiles(unittest.TestCase):
     local_path = Path(__file__).resolve().parent
@@ -101,6 +103,28 @@ class TestFiles(unittest.TestCase):
         files = rust.main(path.resolve().as_posix(), False, False, 15, True)
         total_complexity = sum([file.complexity for file in files])
         self.assertEqual(12, total_complexity)
+
+    def test_file_complexity(self):
+        path = "src/test_try_nested.py"
+        result = file_complexity(path)
+        self.assertEqual(12, result.complexity)
+
+    def test_code_complexity(self):
+        snippet = """\
+def hello_world(s: str) -> str:
+    ans = ""
+
+    def nested_func(s: str) -> str:
+        if s == "complexipy":
+            return "complexipy is awesome!"
+        return f"I don't know what to say, hello {s}(?)"
+
+    ans = nested_func(s)
+
+    return ans
+"""
+        result = code_complexity(snippet)
+        self.assertEqual(2, result.complexity)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hello and thank you for this really cool library!

I've tried using this from my python code, but I realized that I needed to expose some of the internal commands. 

I made a couple of changes, outlined below. If possible, I would also like to help expand this library so that it can cover other languages besides python.

## outline of changes
 - create a Rust function `code_complexity`, that computes the complexity on a string of python code
 - expose this function at the level of the python library
This way, we can evaluate the complexity on any string of code:
```python
complexity.main.code_complexity(my_snippet_of_code)
```
This is particularly useful in situations where we want to evaluate stand-alone snippets that might not be part of a file-system.

 - I thought the Rust function `cognitive_complexity` was also really useful as a library command, so I exposed it at the python level. Because of Rust's naming rules, it seems it wouldn't allow me to keep that name: it would clash with the module of the same name. So I renamed the function `function_complexity`, which I thought would clarify how it differs from `code_complexity`. I don't have a strong opinion on the function-names: feel free to propose better ones.

Let me know what you think and if there's any edits you'd like me to make before merging, thanks again!