### PR TITLE
fix(python): #57 fix output_summary function call

### DIFF
--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -69,7 +69,7 @@ def main(
 
     if not quiet:
         has_success = output_summary(
-            console, max_complexity, details, paths, sort
+            console, files_complexities, max_complexity, details, sort
         )
     if quiet:
         has_success = has_success_functions(files_complexities, max_complexity)


### PR DESCRIPTION
- The output_summary function call was missing the files_complexities argument.
- This commit fixes the function call by adding the missing argument.