### PR TITLE
fix(cli) #68: Enhance complexity analysis options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,8 @@ complexipy git_repository_url
 # Analyze a specific file
 complexipy path/to/file.py
 
-# Set maximum cognitive complexity (default: 15)
-complexipy path/to/file.py -c 20
-
-# Disable exit with error (by setting max complexity to 0)
-complexipy path/to/directory -c 0
+# Ignore complexity threshold and show all functions
+complexipy path/to/file.py -i
 
 # Output results to a CSV file
 complexipy path/to/directory -o
@@ -139,19 +136,17 @@ jobs:
       uses: rohaquinlop/complexipy-action@v1
       with:
         paths: '.'  # Analyze the entire repository
-        max_complexity: 15  # Set maximum allowed complexity
 ```
 
 #### Action Inputs
 
-| Input          | Description                                                      | Required | Default                 |
-| -------------- | ---------------------------------------------------------------- | -------- | ----------------------- |
-| paths          | Paths to analyze. Can be local paths or a git repository URL.    | Yes      | ${{ github.workspace }} |
-| max_complexity | Maximum allowed complexity per function. Set to 0 for unlimited. | No       | 15                      |
-| output         | Generate results in a CSV file.                                  | No       | false                   |
-| details        | Output detail level (low or normal).                             | No       | normal                  |
-| quiet          | Suppress console output.                                         | No       | false                   |
-| sort           | Sort results by complexity (asc, desc, or name).                 | No       | asc                     |
+| Input   | Description                                                   | Required | Default                 |
+| ------- | ------------------------------------------------------------- | -------- | ----------------------- |
+| paths   | Paths to analyze. Can be local paths or a git repository URL. | Yes      | ${{ github.workspace }} |
+| output  | Generate results in a CSV file.                               | No       | false                   |
+| details | Output detail level (low or normal).                          | No       | normal                  |
+| quiet   | Suppress console output.                                      | No       | false                   |
+| sort    | Sort results by complexity (asc, desc, or name).              | No       | asc                     |
 
 #### Examples
 
@@ -216,9 +211,7 @@ You can also trigger a manual analysis by:
 
 ### Options
 
-- `-c` or `--max-complexity`: Set the maximum cognitive complexity (default: 15).
-  If the cognitive complexity of a file exceeds this value, the program will exit with error code 1.
-  Set to 0 to disable this behavior.
+- `-i` or `--ignore-complexity`: Ignore the complexity threshold and show all functions.
 
 - `-o` or `--output`: Output results to a CSV file named `complexipy.csv` in the current directory.
 
@@ -232,6 +225,8 @@ You can also trigger a manual analysis by:
   - `asc` (default): Sort by complexity (ascending)
   - `desc`: Sort by complexity (descending)
   - `name`: Sort by name (ascending)
+
+**Note:** The program will exit with error code 1 if any function has a cognitive complexity greater than or equal to 15. Use the `-i` option to ignore this behavior.
 
 ## Use the library from python code
 

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -33,14 +33,14 @@ def main(
     paths: List[str] = typer.Argument(
         help="Paths to the directories or files to analyze, it can be a local paths or a git repository URL.",
     ),
-    max_complexity: int = typer.Option(
-        15,
-        "--max-complexity",
-        "-c",
-        help="The maximum complexity allowed per file, set this value as 0 to set it as unlimited. Default is 15.",
-    ),
     output: bool = typer.Option(
         False, "--output", "-o", help="Output the results to a CSV file."
+    ),
+    ignore_complexity: bool = typer.Option(
+        False,
+        "--ignore-complexity",
+        "-i",
+        help="Ignore the complexity and show all functions.",
     ),
     details: DetailTypes = typer.Option(
         DetailTypes.normal.value,
@@ -66,15 +66,20 @@ def main(
     output_csv_path = f"{invocation_path}/complexipy.csv"
 
     if output:
-        _complexipy.output_csv(output_csv_path, files_complexities, sort.value)
+        _complexipy.output_csv(
+            output_csv_path,
+            files_complexities,
+            sort.value,
+            details.value == DetailTypes.normal.value,
+        )
         console.print(f"Results saved at {output_csv_path}")
 
     if not quiet:
         has_success = output_summary(
-            console, files_complexities, max_complexity, details, sort
+            console, files_complexities, details, sort, ignore_complexity
         )
     if quiet:
-        has_success = has_success_functions(files_complexities, max_complexity)
+        has_success = has_success_functions(files_complexities)
 
     console.print(
         f"{len(files_complexities)} file{'s' if len(files_complexities) > 1 else ''} analyzed in {execution_time:.4f} seconds"

--- a/complexipy/utils.py
+++ b/complexipy/utils.py
@@ -22,17 +22,17 @@ from typing import (
 def output_summary(
     console: Console,
     files: List[FileComplexity],
-    max_complexity: int,
     details: DetailTypes,
     sort: Sort,
+    ignore_complexity: bool,
 ) -> bool:
     table, has_success, total_complexity, all_functions = create_table(
-        files, max_complexity, details, sort
+        files, details, sort, ignore_complexity
     )
 
     if details == DetailTypes.low and table.row_count < 1:
         console.print(
-            f"No function{'s' if len(files) > 1 else ''} were found with complexity greater than {max_complexity}."
+            f"No function{'s' if len(files) > 1 else ''} were found with complexity greater or equal to 15."
         )
     else:
         if len(all_functions) == 0:
@@ -52,9 +52,9 @@ def output_summary(
 
 def create_table(
     files: List[FileComplexity],
-    complexity: int,
     details: DetailTypes,
-    sort: bool = False,
+    sort: Sort,
+    ignore_complexity: bool,
 ) -> Tuple[Table, bool, int, List[Tuple[str, str, FunctionComplexity]]]:
     has_success = True
     all_functions: List[Tuple[str, str, FunctionComplexity]] = []
@@ -83,7 +83,7 @@ def create_table(
             all_functions.reverse()
 
     for function in all_functions:
-        if function[2].complexity > complexity and complexity != 0:
+        if function[2].complexity >= 15:
             table.add_row(
                 f"{function[0]}",
                 f"[green]{function[1]}[/green]",
@@ -91,19 +91,23 @@ def create_table(
                 f"[red]{function[2].complexity}[/red]",
             )
             has_success = False
-        elif details != DetailTypes.low or complexity == 0:
+        elif details != DetailTypes.low:
             table.add_row(
                 f"{function[0]}",
                 f"[green]{function[1]}[/green]",
                 f"[green]{function[2].name}[/green]",
                 f"[blue]{function[2].complexity}[/blue]",
             )
+
+    if ignore_complexity:
+        has_success = True
+
     return table, has_success, total_complexity, all_functions
 
 
-def has_success_functions(files: List[FileComplexity], complexity: int) -> bool:
+def has_success_functions(files: List[FileComplexity]) -> bool:
     for file in files:
         for function in file.functions:
-            if function.complexity > complexity and complexity != 0:
+            if function.complexity >= 15:
                 return False
     return True

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,11 +77,8 @@ complexipy git_repository_url
 # Analyze a specific file
 complexipy path/to/file.py
 
-# Set maximum cognitive complexity (default: 15)
-complexipy path/to/file.py -c 20
-
-# Disable exit with error (by setting max complexity to 0)
-complexipy path/to/directory -c 0
+# Ignore complexity threshold and show all functions
+complexipy path/to/file.py -i
 
 # Output results to a CSV file
 complexipy path/to/directory -o
@@ -113,19 +110,17 @@ jobs:
       uses: rohaquinlop/complexipy-action@v1
       with:
         paths: '.'  # Analyze the entire repository
-        max_complexity: 15  # Set maximum allowed complexity
 ```
 
 #### Action Inputs
 
-| Input          | Description                                                      | Required | Default                 |
-| -------------- | ---------------------------------------------------------------- | -------- | ----------------------- |
-| paths          | Paths to analyze. Can be local paths or a git repository URL.    | Yes      | ${{ github.workspace }} |
-| max_complexity | Maximum allowed complexity per function. Set to 0 for unlimited. | No       | 15                      |
-| output         | Generate results in a CSV file.                                  | No       | false                   |
-| details        | Output detail level (low or normal).                             | No       | normal                  |
-| quiet          | Suppress console output.                                         | No       | false                   |
-| sort           | Sort results by complexity (asc, desc, or name).                 | No       | asc                     |
+| Input   | Description                                                   | Required | Default                 |
+| ------- | ------------------------------------------------------------- | -------- | ----------------------- |
+| paths   | Paths to analyze. Can be local paths or a git repository URL. | Yes      | ${{ github.workspace }} |
+| output  | Generate results in a CSV file.                               | No       | false                   |
+| details | Output detail level (low or normal).                          | No       | normal                  |
+| quiet   | Suppress console output.                                      | No       | false                   |
+| sort    | Sort results by complexity (asc, desc, or name).              | No       | asc                     |
 
 #### Examples
 
@@ -134,14 +129,6 @@ Basic Usage:
 - uses: rohaquinlop/complexipy-action@v1
   with:
     paths: '.'
-```
-
-Custom Maximum Complexity:
-```yaml
-- uses: rohaquinlop/complexipy-action@v1
-  with:
-    paths: './src'
-    max_complexity: 20
 ```
 
 Generate CSV Report:
@@ -190,17 +177,17 @@ You can also trigger a manual analysis by:
 
 ### Options
 
-| Option | Long form          | Description                            | Default |
-| ------ | ------------------ | -------------------------------------- | ------- |
-| `-c`   | `--max-complexity` | Maximum cognitive complexity threshold | 15      |
-| `-o`   | `--output`         | Output results to CSV file             | False   |
-| `-d`   | `--details`        | Detail level (normal/low)              | normal  |
-| `-q`   | `--quiet`          | Disable console output                 | False   |
-| `-s`   | `--sort`           | Sort order (asc/desc/name)             | asc     |
+| Option | Long form             | Description                                        | Default |
+| ------ | --------------------- | -------------------------------------------------- | ------- |
+| `-i`   | `--ignore-complexity` | Ignore complexity threshold and show all functions | False   |
+| `-o`   | `--output`            | Output results to CSV file                         | False   |
+| `-d`   | `--details`           | Detail level (normal/low)                          | normal  |
+| `-q`   | `--quiet`             | Disable console output                             | False   |
+| `-s`   | `--sort`              | Sort order (asc/desc/name)                         | asc     |
 
 **Notes:**
 
-- If a file's complexity exceeds the maximum complexity, the program will exit with error code 1. Set to 0 to disable this behavior.
+- The program will exit with error code 1 if any function has a cognitive complexity greater than or equal to 15. Use the `-i` option to ignore this behavior.
 - CSV output is saved to `complexipy.csv` in the current directory.
 - Detail level `low` shows only files/functions exceeding the maximum complexity.
 - Sort options:

--- a/src/cognitive_complexity/utils.rs
+++ b/src/cognitive_complexity/utils.rs
@@ -9,7 +9,12 @@ use ruff_python_ast::{self as ast, Stmt};
 
 #[cfg(feature = "python")]
 #[pyfunction]
-pub fn output_csv(invocation_path: &str, functions_complexity: Vec<FileComplexity>, sort: &str) {
+pub fn output_csv(
+    invocation_path: &str,
+    functions_complexity: Vec<FileComplexity>,
+    sort: &str,
+    show_detailed_results: bool,
+) {
     let mut writer = Writer::from_path(invocation_path).unwrap();
 
     writer
@@ -21,7 +26,13 @@ pub fn output_csv(invocation_path: &str, functions_complexity: Vec<FileComplexit
 
         for file in functions_complexity {
             for function in file.functions {
-                all_functions.push((file.path.clone(), file.file_name.clone(), function));
+                if show_detailed_results {
+                    all_functions.push((file.path.clone(), file.file_name.clone(), function));
+                } else {
+                    if function.complexity >= 15 {
+                        all_functions.push((file.path.clone(), file.file_name.clone(), function));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
This pull request introduces changes to the `complexipy` tool to enhance its functionality and simplify its configuration. The key updates include replacing the `max_complexity` option with a new `ignore_complexity` flag, modifying how complexity thresholds are handled, and adding support for detailed results in CSV output.

### Updates to configuration options:

* [`complexipy/main.py`](diffhunk://#diff-8f8c726720f3590f6ba7d987b35a212cdbc1b1f6861fb7abecb94da883c1cdd0L36-R44): Removed `max_complexity` option and added an `ignore_complexity` flag to allow users to display all functions regardless of complexity. This simplifies the tool's usage by eliminating the need to specify numeric thresholds.

### Changes to complexity handling:

* [`complexipy/utils.py`](diffhunk://#diff-1e4d8c5267b35db3e0147ffe15a91df7e5fa69d6ce62b082fa8627df6afa998fL25-R35): Updated logic to use a fixed complexity threshold of 15 instead of a configurable `max_complexity` value, and incorporated the `ignore_complexity` flag to bypass complexity checks when enabled. [[1]](diffhunk://#diff-1e4d8c5267b35db3e0147ffe15a91df7e5fa69d6ce62b082fa8627df6afa998fL25-R35) [[2]](diffhunk://#diff-1e4d8c5267b35db3e0147ffe15a91df7e5fa69d6ce62b082fa8627df6afa998fL86-R111)

### Enhancements to CSV output:

* [`src/cognitive_complexity/utils.rs`](diffhunk://#diff-a7cc98c8ea2a68c32a6b38e62cbde2fbf59c18708617e1e5d7769de9a72de2b6L12-R17): Added support for detailed results in CSV output, controlled by a `show_detailed_results` parameter. This ensures that users can choose between exporting all functions or only those exceeding the complexity threshold. [[1]](diffhunk://#diff-a7cc98c8ea2a68c32a6b38e62cbde2fbf59c18708617e1e5d7769de9a72de2b6L12-R17) [[2]](diffhunk://#diff-a7cc98c8ea2a68c32a6b38e62cbde2fbf59c18708617e1e5d7769de9a72de2b6R29-R35)