### PR TITLE
feat(cli): #70 Add JSON output option for complexity analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "ruff_python_parser",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "tempfile",
  "wasm-bindgen",
  "web-sys",
@@ -749,6 +750,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ regex = "1.11.1"
 ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.13", package = "ruff_python_parser" }
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", tag = "0.11.13", package = "ruff_python_ast" }
 tempfile = "3.10.0"
+serde_json = "1.0"
 
 # Optional dependencies for Python
 pyo3 = { version = "0.19.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ complexipy path/to/file.py
 complexipy path/to/file.py -i
 
 # Output results to a CSV file
-complexipy path/to/directory -o
+complexipy path/to/directory -c
+
+# Output results to a JSON file
+complexipy path/to/directory -j
 
 # Show only files exceeding maximum complexity
 complexipy path/to/directory -d low
@@ -140,13 +143,14 @@ jobs:
 
 #### Action Inputs
 
-| Input   | Description                                                   | Required | Default                 |
-| ------- | ------------------------------------------------------------- | -------- | ----------------------- |
-| paths   | Paths to analyze. Can be local paths or a git repository URL. | Yes      | ${{ github.workspace }} |
-| output  | Generate results in a CSV file.                               | No       | false                   |
-| details | Output detail level (low or normal).                          | No       | normal                  |
-| quiet   | Suppress console output.                                      | No       | false                   |
-| sort    | Sort results by complexity (asc, desc, or name).              | No       | asc                     |
+| Input       | Description                                                   | Required | Default                 |
+| ----------- | ------------------------------------------------------------- | -------- | ----------------------- |
+| paths       | Paths to analyze. Can be local paths or a git repository URL. | Yes      | ${{ github.workspace }} |
+| output_csv  | Generate results in a CSV file.                               | No       | false                   |
+| output_json | Generate results in a JSON file.                              | No       | false                   |
+| details     | Output detail level (low or normal).                          | No       | normal                  |
+| quiet       | Suppress console output.                                      | No       | false                   |
+| sort        | Sort results by complexity (asc, desc, or name).              | No       | asc                     |
 
 #### Examples
 
@@ -157,20 +161,20 @@ Basic Usage:
     paths: '.'
 ```
 
-Custom Maximum Complexity:
-```yaml
-- uses: rohaquinlop/complexipy-action@v1
-  with:
-    paths: './src'
-    max_complexity: 20
-```
-
 Generate CSV Report:
 ```yaml
 - uses: rohaquinlop/complexipy-action@v1
   with:
     paths: '.'
-    output: true
+    output_csv: true
+```
+
+Generate JSON Report:
+```yaml
+- uses: rohaquinlop/complexipy-action@v1
+  with:
+    paths: '.'
+    output_json: true
 ```
 
 Analyze Specific Directory with Low Detail Output:
@@ -211,9 +215,11 @@ You can also trigger a manual analysis by:
 
 ### Options
 
-- `-i` or `--ignore-complexity`: Ignore the complexity threshold and show all functions.
+- `-c` or `--output-csv`: Output results to a CSV file named `complexipy.csv` in the current directory.
 
-- `-o` or `--output`: Output results to a CSV file named `complexipy.csv` in the current directory.
+- `-j` or `--output-json`: Output results to a JSON file named `complexipy.json` in the current directory.
+
+- `-i` or `--ignore-complexity`: Ignore the complexity threshold and show all functions.
 
 - `-d` or `--details`: Set detail level:
   - `normal` (default): Show all files and functions

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -33,8 +33,11 @@ def main(
     paths: List[str] = typer.Argument(
         help="Paths to the directories or files to analyze, it can be a local paths or a git repository URL.",
     ),
-    output: bool = typer.Option(
-        False, "--output", "-o", help="Output the results to a CSV file."
+    output_csv: bool = typer.Option(
+        False, "--output-csv", "-c", help="Output the results to a CSV file."
+    ),
+    output_json: bool = typer.Option(
+        False, "--output-json", "-j", help="Output the results to a JSON file."
     ),
     ignore_complexity: bool = typer.Option(
         False,
@@ -64,8 +67,9 @@ def main(
     files_complexities: List[FileComplexity] = _complexipy.main(paths)
     execution_time = time.time() - start_time
     output_csv_path = f"{invocation_path}/complexipy.csv"
+    output_json_path = f"{invocation_path}/complexipy.json"
 
-    if output:
+    if output_csv:
         _complexipy.output_csv(
             output_csv_path,
             files_complexities,
@@ -73,6 +77,14 @@ def main(
             details.value == DetailTypes.normal.value,
         )
         console.print(f"Results saved at {output_csv_path}")
+
+    if output_json:
+        _complexipy.output_json(
+            output_json_path,
+            files_complexities,
+            details.value == DetailTypes.normal.value,
+        )
+        console.print(f"Results saved at {output_json_path}")
 
     if not quiet:
         has_success = output_summary(

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,10 @@ complexipy path/to/file.py
 complexipy path/to/file.py -i
 
 # Output results to a CSV file
-complexipy path/to/directory -o
+complexipy path/to/directory -c
+
+# Output results to a JSON file
+complexipy path/to/directory -j
 
 # Show only files exceeding maximum complexity
 complexipy path/to/directory -d low
@@ -114,13 +117,14 @@ jobs:
 
 #### Action Inputs
 
-| Input   | Description                                                   | Required | Default                 |
-| ------- | ------------------------------------------------------------- | -------- | ----------------------- |
-| paths   | Paths to analyze. Can be local paths or a git repository URL. | Yes      | ${{ github.workspace }} |
-| output  | Generate results in a CSV file.                               | No       | false                   |
-| details | Output detail level (low or normal).                          | No       | normal                  |
-| quiet   | Suppress console output.                                      | No       | false                   |
-| sort    | Sort results by complexity (asc, desc, or name).              | No       | asc                     |
+| Input       | Description                                                   | Required | Default                 |
+| ----------- | ------------------------------------------------------------- | -------- | ----------------------- |
+| paths       | Paths to analyze. Can be local paths or a git repository URL. | Yes      | ${{ github.workspace }} |
+| output_csv  | Generate results in a CSV file.                               | No       | false                   |
+| output_json | Generate results in a JSON file.                              | No       | false                   |
+| details     | Output detail level (low or normal).                          | No       | normal                  |
+| quiet       | Suppress console output.                                      | No       | false                   |
+| sort        | Sort results by complexity (asc, desc, or name).              | No       | asc                     |
 
 #### Examples
 
@@ -136,7 +140,15 @@ Generate CSV Report:
 - uses: rohaquinlop/complexipy-action@v1
   with:
     paths: '.'
-    output: true
+    output_csv: true
+```
+
+Generate JSON Report:
+```yaml
+- uses: rohaquinlop/complexipy-action@v1
+  with:
+    paths: '.'
+    output_json: true
 ```
 
 Analyze Specific Directory with Low Detail Output:
@@ -179,8 +191,9 @@ You can also trigger a manual analysis by:
 
 | Option | Long form             | Description                                        | Default |
 | ------ | --------------------- | -------------------------------------------------- | ------- |
+| `-c`   | `--output-csv`        | Output results to CSV file                         | False   |
+| `-j`   | `--output-json`       | Output results to JSON file                        | False   |
 | `-i`   | `--ignore-complexity` | Ignore complexity threshold and show all functions | False   |
-| `-o`   | `--output`            | Output results to CSV file                         | False   |
 | `-d`   | `--details`           | Detail level (normal/low)                          | normal  |
 | `-q`   | `--quiet`             | Disable console output                             | False   |
 | `-s`   | `--sort`              | Sort order (asc/desc/name)                         | asc     |
@@ -189,6 +202,7 @@ You can also trigger a manual analysis by:
 
 - The program will exit with error code 1 if any function has a cognitive complexity greater than or equal to 15. Use the `-i` option to ignore this behavior.
 - CSV output is saved to `complexipy.csv` in the current directory.
+- JSON output is saved to `complexipy.json` in the current directory.
 - Detail level `low` shows only files/functions exceeding the maximum complexity.
 - Sort options:
   - `asc`: Sort by complexity (ascending)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod wasm;
 #[cfg(feature = "python")]
 use classes::{CodeComplexity, FileComplexity, FunctionComplexity};
 #[cfg(feature = "python")]
-use cognitive_complexity::utils::output_csv;
+use cognitive_complexity::utils::{output_csv, output_json};
 #[cfg(feature = "python")]
 use cognitive_complexity::{code_complexity, file_complexity, main};
 
@@ -24,6 +24,7 @@ fn _complexipy(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(file_complexity, m)?)?;
     m.add_function(wrap_pyfunction!(code_complexity, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv, m)?)?;
+    m.add_function(wrap_pyfunction!(output_json, m)?)?;
     m.add_class::<FileComplexity>()?;
     m.add_class::<FunctionComplexity>()?;
     m.add_class::<CodeComplexity>()?;


### PR DESCRIPTION
This pull request introduces JSON output functionality to the `complexipy` project, alongside existing CSV output, and updates dependencies to support these enhancements. Key changes include modifications to the CLI interface, the addition of a JSON output function, and updates to the Rust backend.

### CLI Enhancements:

* [`complexipy/main.py`](diffhunk://#diff-8f8c726720f3590f6ba7d987b35a212cdbc1b1f6861fb7abecb94da883c1cdd0L36-R40): Updated the `main` function to include options for JSON output (`--output-json`, `-j`) and adjusted the CSV output flag (`--output-csv`, `-c`). Added logic to handle saving results in JSON format. [[1]](diffhunk://#diff-8f8c726720f3590f6ba7d987b35a212cdbc1b1f6861fb7abecb94da883c1cdd0L36-R40) [[2]](diffhunk://#diff-8f8c726720f3590f6ba7d987b35a212cdbc1b1f6861fb7abecb94da883c1cdd0R70-R72) [[3]](diffhunk://#diff-8f8c726720f3590f6ba7d987b35a212cdbc1b1f6861fb7abecb94da883c1cdd0R81-R88)

### Rust Backend Updates:

* [`src/cognitive_complexity/utils.rs`](diffhunk://#diff-a7cc98c8ea2a68c32a6b38e62cbde2fbf59c18708617e1e5d7769de9a72de2b6R79-R116): Added a new `output_json` function to generate JSON output for function complexities. This function supports detailed and filtered results based on complexity thresholds.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R27): Registered the `output_json` function in the Python bindings, enabling its use in the Python interface.

### Dependency Updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R48): Added the `serde_json` crate to support JSON serialization in the Rust backend.
* [`src/cognitive_complexity/utils.rs`](diffhunk://#diff-a7cc98c8ea2a68c32a6b38e62cbde2fbf59c18708617e1e5d7769de9a72de2b6R9-R14): Imported necessary modules (`serde_json`, `std::fs::File`, and `std::io::Write`) to facilitate JSON file creation.