### PR TITLE
fix: #110 reduce error verbosity

### DIFF
--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -178,7 +178,7 @@ def print_invalid_paths(
         text = Text()
         text.append("error", style="bold red")
         text.append(f": Failed to process {failed_path}", style="bold white")
-        text.append(" - Please check syntax")
+        text.append(" - Please check file/folder exists or check syntax")
         console.print(text)
 
     return has_success

--- a/tests/main.py
+++ b/tests/main.py
@@ -28,6 +28,14 @@ class TestFiles:
         string_paths = [str(path) for path in paths]
         return _complexipy.main(string_paths, False, [])
 
+    def test_missing_path_is_reported(self):
+        missing = self.local_path / "this_file_does_not_exist.py"
+
+        files, failed = _complexipy.main([missing.as_posix()], False, [])
+
+        assert files == []
+        assert failed == [missing.as_posix()]
+
     def test_path(self):
         path = self.local_path / "src"
         files, _ = _complexipy.main([path.resolve().as_posix()], False, [])


### PR DESCRIPTION
This pull request improves how missing file and folder paths are handled and reported in the codebase. The changes ensure that missing paths are treated as user errors rather than causing panics, and provide clearer feedback to users. Additionally, the test suite is updated to verify this behavior.

**Error handling and reporting improvements:**

* Updated the error message in `print_invalid_paths` in `complexipy/utils/output.py` to clarify that failures may be due to missing files or folders, not just syntax issues.
* Refactored path existence checks in `src/cognitive_complexity/mod.rs` to use `Path::exists()` and `Path::is_dir()`, and to treat missing local paths as user errors by collecting them in a `failed_paths` list instead of panicking.
* Removed the use of `std::fs::metadata` from the `python_deps` module in `src/cognitive_complexity/mod.rs`, as path existence is now checked using `Path` methods.

**Testing improvements:**

* Added a test in `tests/main.py` to verify that missing paths are reported correctly in the output, ensuring the new error handling works as intended.