### PR TITLE
fix: invalid results output paths on Windows

### DIFF
--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -177,7 +177,7 @@ def main(
         paths, quiet, exclude
     )
     files_complexities, failed_paths = result
-    current_time = datetime.today().strftime("%Y_%m_%d__%H:%M:%S")
+    current_time = datetime.today().strftime("%Y_%m_%d__%H-%M-%S")
     output_csv_path = f"{INVOCATION_PATH}/complexipy_results_{current_time}.csv"
     output_json_path = (
         f"{INVOCATION_PATH}/complexipy_results_{current_time}.json"


### PR DESCRIPTION
Replaces `:` character when generating CSV and JSON results files with `-` since `:` cannot be used in the file paths on Windows (except for the drive separator).

Unfortunately I was not able to test this as I could not really build the library on my system. I'm not familiary with `maturin`, when I ran the build with it it complained if failed to determine the python platform. I usually use `uv` to set up Python locally for each project. But I guess, given this is a trivial change, it should not be too difficult to check how it behaves.

Fixes: #119