### PR TITLE
Add the latest pre-commit complexipy version to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ print(f"Complexity: {result.complexity}")
 ```yaml
 repos:
 - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-  rev: v3.0.0
+  rev: v4.2.0
   hooks:
     - id: complexipy
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,7 +105,7 @@ print(f"Complexity: {result.complexity}")
 ```yaml
 repos:
 - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-  rev: v3.0.0
+  rev: v4.2.0
   hooks:
     - id: complexipy
 ```


### PR DESCRIPTION
This pull request updates the documentation to use the latest version of the `complexipy-pre-commit` hook. The only change is updating the referenced version from `v3.0.0` to `v4.2.0` in the example configuration.

This allows using the `--max-complexity-allowed` argument in the pre-commit hook, avoiding unexpected behavior if using `v3.0.0` from the docs. 

Thanks for this amazing library ❤️ 

