### PR TITLE
fix: snapshot watermark now determines exit code when active

### DIFF
--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -36,6 +36,7 @@ from .utils.output import (
     print_invalid_paths,
 )
 from .utils.snapshot import (
+    build_snapshot_map,
     handle_snapshot_file_creation,
     handle_snapshot_functions_load,
     handle_snapshot_watermark,
@@ -194,6 +195,9 @@ def main(
     snapshot_file_exists = os.path.exists(output_snapshot_path)
     snapshot_files = handle_snapshot_functions_load(output_snapshot_path)
     should_run_snapshot_watermark = snapshot_file_exists and not snapshot_ignore
+    active_snapshot_map = (
+        build_snapshot_map(snapshot_files) if should_run_snapshot_watermark else None
+    )
     watermark_success, watermark_messages = handle_snapshot_watermark(
         should_run_snapshot_watermark,
         snapshot_file_exists,
@@ -234,6 +238,7 @@ def main(
             ignore_complexity,
             max_complexity_allowed,
             previous_functions,
+            active_snapshot_map,
         )
         if platform.system() == "Windows":
             console.rule("Analysis completed!")

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -240,16 +240,20 @@ def main(
         else:
             console.rule(":tada: Analysis completed! :tada:")
 
-    has_success = (
-        handle_snapshot(
-            should_run_snapshot_watermark,
-            quiet,
-            watermark_messages,
-            output_snapshot_path,
-            watermark_success,
-        )
-        and has_success
+    snapshot_result = handle_snapshot(
+        should_run_snapshot_watermark,
+        quiet,
+        watermark_messages,
+        output_snapshot_path,
+        watermark_success,
     )
+    if should_run_snapshot_watermark:
+        # When the snapshot watermark is active, it is the authoritative
+        # success check. Functions exceeding the threshold that are already
+        # in the snapshot (and haven't regressed) should not cause a failure.
+        has_success = snapshot_result
+    else:
+        has_success = has_success and snapshot_result
 
     has_success = (
         print_invalid_paths(console, quiet, failed_paths) and has_success

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -28,12 +28,13 @@ def output_summary(
     ignore_complexity: bool,
     max_complexity: int,
     previous_functions: Optional[Dict[Tuple[str, str, str], int]],
+    snapshot_map: Optional[Dict[Tuple[str, str, str], int]] = None,
 ) -> bool:
     (
         file_entries,
         failing_functions,
         total_functions,
-    ) = build_output_rows(files, failed_only, sort, max_complexity)
+    ) = build_output_rows(files, failed_only, sort, max_complexity, snapshot_map)
     has_success = not failing_functions or ignore_complexity
 
     if failed_only and not file_entries:
@@ -138,6 +139,7 @@ def build_output_rows(
     failed_only: bool,
     sort: Sort,
     max_complexity: int,
+    snapshot_map: Optional[Dict[Tuple[str, str, str], int]] = None,
 ) -> tuple[
     List[dict[str, str | List[dict[str, str | int | bool | Tuple[str, str]]]]],
     dict[str, List[str]],
@@ -156,6 +158,11 @@ def build_output_rows(
         for function in sorted_functions:
             total_functions += 1
             passed = function.complexity <= max_complexity
+            if not passed and snapshot_map is not None:
+                key = (file.path, file.file_name, function.name)
+                prev = snapshot_map.get(key)
+                if prev is not None and function.complexity <= prev:
+                    passed = True
 
             if failed_only and passed:
                 continue

--- a/complexipy/utils/snapshot.py
+++ b/complexipy/utils/snapshot.py
@@ -56,7 +56,7 @@ def handle_snapshot_watermark(
             ],
         )
 
-    snapshot_map = _build_snapshot_map(snapshot_files)
+    snapshot_map = build_snapshot_map(snapshot_files)
     violations: List[str] = []
 
     for file_complexity in files_complexities:
@@ -89,7 +89,7 @@ def handle_snapshot_watermark(
     return True, []
 
 
-def _build_snapshot_map(
+def build_snapshot_map(
     snapshot_files: List[FileComplexity],
 ) -> Dict[Tuple[str, str, str], int]:
     snapshot_map: Dict[Tuple[str, str, str], int] = {}

--- a/tests/main.py
+++ b/tests/main.py
@@ -419,3 +419,11 @@ def hello_world(s: str) -> str:
             f"got {result_check.exit_code}.\n"
             f"Output:\n{result_check.output}"
         )
+        # The function should be displayed as PASSED (not FAILED) since it is
+        # grandfathered by the snapshot.
+        assert "PASSED" in result_check.output, (
+            f"Expected 'PASSED' in output.\nOutput:\n{result_check.output}"
+        )
+        assert "FAILED" not in result_check.output, (
+            f"Expected no 'FAILED' in output.\nOutput:\n{result_check.output}"
+        )


### PR DESCRIPTION
When a snapshot watermark is active and passes, functions that exceed the
complexity threshold but haven't regressed since the snapshot was taken
should not cause a non-zero exit code. Previously the watermark result was
ANDed with the regular threshold check, so any project with grandfathered
high-complexity functions would always exit 1 even when the watermark passed.

The fix makes the watermark result authoritative when it is active: if the
watermark passes the run succeeds; if it fails the run fails. The regular
threshold check continues to govern runs where no snapshot is active.

Closes #136