### PR TITLE
Introduce `# complexipy: ignore` syntax and deprecate `# noqa: complexipy`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -226,16 +226,18 @@ Use `--snapshot-ignore` if you need to temporarily bypass the snapshot gate (for
 
 ### Inline Ignores
 
-You can explicitly ignore a known complex function inline, similar to Ruff's `C901` ignores:
+You can explicitly ignore a known complex function inline using `# complexipy: ignore`:
 
 ```python
-def legacy_adapter(x, y):  # noqa: complexipy (safe wrapper)
+def legacy_adapter(x, y):  # complexipy: ignore (safe wrapper)
     if x and y:
         return x + y
     return 0
 ```
 
-Place `# noqa: complexipy` on the function definition line (or the line immediately above). An optional reason can be provided in parentheses or plain text, it’s ignored by the parser.
+Place `# complexipy: ignore` on the function definition line (or the line immediately above). An optional reason can be provided in parentheses, it’s ignored by the parser.
+
+> **Note:** The `# noqa: complexipy` syntax is deprecated. Tools like [yesqa](https://github.com/asottile/yesqa) strip unrecognized `# noqa` comments, which would silently remove your suppressions. Migrate to `# complexipy: ignore` to avoid this issue.
 
 ## API Reference
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -402,25 +402,33 @@ Use this when:
 
 ## Inline Ignores
 
-Suppress complexity warnings for specific functions:
+Suppress complexity warnings for specific functions using the `# complexipy: ignore` comment:
 
 ```python
-def complex_legacy_function():  # noqa: complexipy
+def complex_legacy_function():  # complexipy: ignore
     # Complex logic that can't be refactored yet
     pass
 
 # Or with a reason
-def another_complex_function():  # noqa: complexipy (technical debt: issue #123)
+def another_complex_function():  # complexipy: ignore (technical debt: issue #123)
     pass
 ```
 
-The ignore comment can also be on the line above:
+The ignore comment can also be placed on the line above the function definition:
 
 ```python
-# noqa: complexipy
+# complexipy: ignore
 def complex_function():
     pass
 ```
+
+!!! note "Deprecated Syntax"
+    The `# noqa: complexipy` syntax is deprecated and will be removed in a future version.
+    Please migrate to `# complexipy: ignore` instead.
+
+    **Why?** Tools like [yesqa](https://github.com/asottile/yesqa) automatically strip `# noqa`
+    comments that aren't recognized by flake8, which would silently remove your complexipy
+    suppressions. The new syntax avoids this conflict entirely.
 
 !!! warning "Use Sparingly"
     Inline ignores should be temporary. Document why the complexity is necessary and track technical debt.

--- a/src/cognitive_complexity/utils.rs
+++ b/src/cognitive_complexity/utils.rs
@@ -418,7 +418,9 @@ pub fn has_noqa_complexipy(line_number: u64, code: &str) -> bool {
 
     let contains_marker = |s: &str| -> bool {
         let lower = s.to_lowercase();
-        lower.contains("noqa: complexipy")
+        // New preferred syntax: # complexipy: ignore
+        // Deprecated syntax: # noqa: complexipy (kept for backwards compatibility)
+        lower.contains("complexipy: ignore") || lower.contains("noqa: complexipy")
     };
 
     if idx < lines.len() && contains_marker(lines[idx]) {

--- a/tests/main.py
+++ b/tests/main.py
@@ -176,6 +176,19 @@ def hello_world(s: str) -> str:
         total_complexity = sum([file.complexity for file in files])
         assert 0 == total_complexity
 
+    def test_complexipy_ignore(self):
+        path = self.local_path / "src/test_complexipy_ignore.py"
+        files, _ = _complexipy.main([path.resolve().as_posix()], False, [])
+        total_complexity = sum([file.complexity for file in files])
+        # The only complex function has a complexipy: ignore, so it is ignored.
+        assert 0 == total_complexity
+
+    def test_complexipy_ignore_with_decorator(self):
+        path = self.local_path / "src/test_complexipy_ignore_decorator.py"
+        files, _ = _complexipy.main([path.resolve().as_posix()], False, [])
+        total_complexity = sum([file.complexity for file in files])
+        assert 0 == total_complexity
+
     def test_exclude(self):
         path = self.local_path / "src"
         files, _ = _complexipy.main(

--- a/tests/src/test_complexipy_ignore.py
+++ b/tests/src/test_complexipy_ignore.py
@@ -1,0 +1,11 @@
+def ignored_complex_function(a, b):  # complexipy: ignore (legacy API wrapper; safe to skip)
+    if a and b:
+        return a + b
+    elif a or b:
+        return a or b
+    else:
+        return 0
+
+
+def not_ignored_function(a, b):
+    return range(a, b)

--- a/tests/src/test_complexipy_ignore_decorator.py
+++ b/tests/src/test_complexipy_ignore_decorator.py
@@ -1,0 +1,12 @@
+@staticmethod
+def ignored_decorated_function(a, b):  # complexipy: ignore
+    if a and b:
+        return a + b
+    elif a or b:
+        return a or b
+    else:
+        return 0
+
+
+def simple_function(a, b):
+    return range(a, b)


### PR DESCRIPTION
## Summary
This PR introduces a new `# complexipy: ignore` syntax for suppressing complexity warnings and deprecates the existing `# noqa: complexipy` syntax. The change addresses a compatibility issue where tools like [yesqa](https://github.com/asottile/yesqa) automatically strip unrecognized `# noqa` comments, which would silently remove complexipy suppressions.

## Key Changes
- **New ignore syntax**: Introduced `# complexipy: ignore` as the preferred way to suppress complexity warnings
- **Backwards compatibility**: The old `# noqa: complexipy` syntax continues to work but is marked as deprecated
- **Updated parser**: Modified `has_noqa_complexipy()` in `utils.rs` to recognize both syntaxes
- **Documentation updates**: Updated usage guide and main documentation to reflect the new syntax and explain the deprecation rationale
- **Test coverage**: Added test cases for the new `# complexipy: ignore` syntax with and without decorators

## Implementation Details
- The `has_noqa_complexipy()` function now checks for both `&#34;complexipy: ignore&#34;` and `&#34;noqa: complexipy&#34;` patterns (case-insensitive)
- Documentation includes a deprecation note explaining why the change was necessary and how to migrate
- The ignore comment can be placed either on the function definition line or on the line immediately above
- Optional reasons can be provided in parentheses after the ignore marker