### PR TITLE
json output should follow posix standard and have a final newline

### DIFF
--- a/src/cognitive_complexity/utils.rs
+++ b/src/cognitive_complexity/utils.rs
@@ -132,6 +132,12 @@ pub fn output_json(
             invocation_path, e
         ))
     })?;
+    file.write_all(b"\n").map_err(|e| {
+        PyIOError::new_err(format!(
+            "Failed to write JSON to {}: {}",
+            invocation_path, e
+        ))
+    })?;
 
     Ok(())
 }

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from complexipy._complexipy import main as _main
+from complexipy.utils.json import store_json
+
+
+_SNIPPET = """\
+def simple(value):
+    if value:
+        return value
+    return 0
+"""
+
+
+def _build_file_complexity(source_file: Path):
+    files, _ = _main([source_file.as_posix()], False, [])
+    return files
+
+
+class TestJsonOutput:
+    def test_json_has_single_final_newline(self, tmp_path: Path):
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+        output_file = tmp_path / "results.json"
+
+        store_json(
+            output_file.as_posix(),
+            _build_file_complexity(source_file),
+            show_details=True,
+            max_complexity=0,
+        )
+
+        content = output_file.read_bytes()
+
+        assert content.endswith(b"\n")
+        assert not content.endswith(b"\n\n")
+        assert json.loads(content.decode("utf-8"))[0]["function_name"] == "simple"
+
+    def test_cli_json_output_has_final_newline(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        result = runner.invoke(
+            main_module.app,
+            ["--output-json", str(source_file)],
+        )
+
+        assert result.exit_code == 0, result.output
+
+        output_files = list(tmp_path.glob("complexipy_results_*.json"))
+        assert len(output_files) == 1
+        assert output_files[0].read_bytes().endswith(b"\n")


### PR DESCRIPTION
## Summary

  - JSON output now finishes with a final newline, conforming with POSIX 3.206 standard
  - added tests accordingly

  ## Rationale
  - Sometimes people would produce a snapshot and check into source control, and it is annoying that the JSON produced by the tool does not have a final newline (GitHub complains about it, and it could break some linters or style checkers)
  - All json parsing tools should be able to correctly handle the final newline
  - CSV output **does** include the final newline

  ## Test
  - verified `maturin develop` compiles successfully
  - verified `pytest` passes


