### PR TITLE
Unify machine-readable output formats and deterministic destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ complexipy path/to/code.py
 complexipy . --max-complexity-allowed 10
 
 # Save results to JSON/CSV
-complexipy . --output-json --output-csv
+complexipy . --output-format json --output-format csv
+
+# Write a GitLab report to a deterministic path
+complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
@@ -106,7 +109,7 @@ print(f"Complexity: {result.complexity}")
   with:
       paths: .
       max_complexity_allowed: 10
-      output_json: true
+      output_format: json
 ```
 
 </details>
@@ -118,12 +121,12 @@ Upload complexity violations as inline PR annotations using SARIF:
 
 ```yaml
 - name: Run complexipy
-  run: complexipy . --output-sarif --ignore-complexity
+  run: complexipy . --output-format sarif --output complexipy-results.sarif --ignore-complexity
 
 - name: Upload SARIF results
   uses: github/codeql-action/upload-sarif@v3
   with:
-      sarif_file: complexipy_results_*.sarif
+      sarif_file: complexipy-results.sarif
 ```
 
 </details>
@@ -138,8 +141,7 @@ complexity:
     image: python:3.11
     script:
         - pip install complexipy
-        - complexipy . --output-gitlab --ignore-complexity
-        - mv complexipy_results_*.gitlab.json complexipy-code-quality.json
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity
     artifacts:
         when: always
         reports:
@@ -192,10 +194,8 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
-output-csv = false
-output-json = false
-output-gitlab = false
-output-sarif = false
+output-format = ["json", "sarif"]
+output = "reports/"
 ```
 
 ```toml
@@ -211,10 +211,13 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
-output-csv = false
-output-json = false
-output-sarif = false
+output-format = ["json"]
+output = "complexipy-results.json"
 ```
+
+Legacy TOML keys such as `output-json = true` and CLI flags such as
+`--output-json` still work for now, but they are deprecated in favor of
+`output-format` and `--output-format`.
 
 ### CLI Options
 
@@ -230,11 +233,13 @@ output-sarif = false
 | `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
 | `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
 | `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
-| `--output-json`            | Save results as JSON                                                                                                                                             | `false` |
-| `--output-csv`             | Save results as CSV                                                                                                                                              | `false` |
-| `--output-gitlab`          | Save results as a GitLab Code Quality JSON report                                                                                                                | `false` |
+| `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                         | —       |
+| `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
 | `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
-| `--output-sarif`           | Save results as SARIF 2.1.0 (for GitHub Code Scanning and other SARIF-aware tools)                                                                               | `false` |
+| `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                       | `false` |
+| `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                        | `false` |
+| `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                     | `false` |
+| `--output-sarif`           | Deprecated alias for `--output-format sarif`                                                                                                                      | `false` |
 
 Example:
 

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -1,6 +1,5 @@
 import os
 import platform
-from datetime import datetime
 from importlib.metadata import (
     PackageNotFoundError,
 )
@@ -8,6 +7,7 @@ from importlib.metadata import (
     version as pkg_version,
 )
 from typing import (
+    Dict,
     List,  # It's important to use this to make it compatible with python 3.8, don't remove it
     Optional,
     Tuple,
@@ -25,6 +25,7 @@ from complexipy._complexipy import FileComplexity
 
 from .types import (
     ColorTypes,
+    OutputFormat,
     Sort,
 )
 from .utils.cache import remember_previous_functions
@@ -53,6 +54,24 @@ app = typer.Typer(name="complexipy")
 console = Console(color_system="auto")
 INVOCATION_PATH = os.getcwd()
 TOML_CONFIG = get_complexipy_toml_config(INVOCATION_PATH)
+DEFAULT_OUTPUT_FILENAMES = {
+    OutputFormat.csv: "complexipy-results.csv",
+    OutputFormat.json: "complexipy-results.json",
+    OutputFormat.gitlab: "complexipy-results.gitlab.json",
+    OutputFormat.sarif: "complexipy-results.sarif",
+}
+LEGACY_OUTPUT_FLAGS = {
+    OutputFormat.csv: "--output-csv",
+    OutputFormat.json: "--output-json",
+    OutputFormat.gitlab: "--output-gitlab",
+    OutputFormat.sarif: "--output-sarif",
+}
+LEGACY_OUTPUT_CONFIG_KEYS = {
+    OutputFormat.csv: "output-csv",
+    OutputFormat.json: "output-json",
+    OutputFormat.gitlab: "output-gitlab",
+    OutputFormat.sarif: "output-sarif",
+}
 
 
 def _version_callback(value: bool):
@@ -124,6 +143,22 @@ def main(
         "-s",
         help="Sort the output by complexity, it can be 'asc', 'desc' or 'name'. Default is 'asc'.",
     ),
+    output_format: Optional[List[str]] = typer.Option(
+        None,
+        "--output-format",
+        help=(
+            "Output format to emit. Repeat the flag to request multiple formats: "
+            "csv, json, gitlab, sarif."
+        ),
+    ),
+    output: Optional[str] = typer.Option(
+        None,
+        "--output",
+        help=(
+            "Destination file or directory for machine-readable output. "
+            "Use a directory when emitting multiple formats."
+        ),
+    ),
     output_csv: Optional[bool] = typer.Option(
         None,
         "--output-csv",
@@ -167,6 +202,13 @@ def main(
 ):
     global console
 
+    legacy_cli_output_flags = {
+        OutputFormat.csv: output_csv,
+        OutputFormat.json: output_json,
+        OutputFormat.gitlab: output_gitlab,
+        OutputFormat.sarif: output_sarif,
+    }
+
     (
         paths,
         max_complexity_allowed,
@@ -177,10 +219,8 @@ def main(
         failed,
         color,
         sort,
-        output_csv,
-        output_json,
-        output_gitlab,
-        output_sarif,
+        output_format,
+        output,
         exclude,
     ) = get_arguments_value(
         TOML_CONFIG,
@@ -193,6 +233,8 @@ def main(
         failed,
         color,
         sort,
+        output_format,
+        output,
         output_csv,
         output_json,
         output_gitlab,
@@ -206,16 +248,14 @@ def main(
         paths, quiet, exclude
     )
     files_complexities, failed_paths = result
-    current_time = datetime.today().strftime("%Y_%m_%d__%H-%M-%S")
-    output_csv_path = f"{INVOCATION_PATH}/complexipy_results_{current_time}.csv"
-    output_json_path = (
-        f"{INVOCATION_PATH}/complexipy_results_{current_time}.json"
+    emit_deprecated_output_warnings(
+        legacy_cli_output_flags,
+        TOML_CONFIG,
     )
-    output_gitlab_path = (
-        f"{INVOCATION_PATH}/complexipy_results_{current_time}.gitlab.json"
-    )
-    output_sarif_path = (
-        f"{INVOCATION_PATH}/complexipy_results_{current_time}.sarif"
+    output_formats = resolve_output_formats(
+        output_format,
+        legacy_cli_output_flags,
+        TOML_CONFIG,
     )
     output_snapshot_path = f"{INVOCATION_PATH}/complexipy-snapshot.json"
 
@@ -244,14 +284,8 @@ def main(
     )
 
     handle_results_storage(
-        output_csv,
-        output_csv_path,
-        output_json,
-        output_json_path,
-        output_gitlab,
-        output_gitlab_path,
-        output_sarif,
-        output_sarif_path,
+        output_formats,
+        output,
         files_complexities,
         sort.value,
         not failed,
@@ -325,14 +359,8 @@ def handle_console_settings(color: ColorTypes, quiet: bool):
 
 
 def handle_results_storage(
-    output_csv: bool,
-    output_csv_path: str,
-    output_json: bool,
-    output_json_path: str,
-    output_gitlab: bool,
-    output_gitlab_path: str,
-    output_sarif: bool,
-    output_sarif_path: str,
+    output_formats: List[OutputFormat],
+    output: Optional[str],
     files_complexities: List[FileComplexity],
     sort: str,
     show_details: bool,
@@ -340,40 +368,170 @@ def handle_results_storage(
 ) -> None:
     global console
 
-    if output_csv:
-        store_csv(
-            output_csv_path,
-            files_complexities,
-            sort,
-            show_details,
-            max_complexity,
-        )
-        console.print(f"Results saved at {output_csv_path}")
+    output_paths = resolve_output_paths(output_formats, output)
 
-    if output_json:
-        store_json(
-            output_json_path,
-            files_complexities,
-            show_details,
-            max_complexity,
-        )
-        console.print(f"Results saved at {output_json_path}")
+    for output_format in output_formats:
+        output_path = output_paths[output_format]
 
-    if output_gitlab:
-        store_gitlab(
-            output_gitlab_path,
-            files_complexities,
-            max_complexity,
-        )
-        console.print(f"Results saved at {output_gitlab_path}")
+        if output_format == OutputFormat.csv:
+            store_csv(
+                output_path,
+                files_complexities,
+                sort,
+                show_details,
+                max_complexity,
+            )
+        elif output_format == OutputFormat.json:
+            store_json(
+                output_path,
+                files_complexities,
+                show_details,
+                max_complexity,
+            )
+        elif output_format == OutputFormat.gitlab:
+            store_gitlab(
+                output_path,
+                files_complexities,
+                max_complexity,
+            )
+        elif output_format == OutputFormat.sarif:
+            store_sarif(
+                output_path,
+                files_complexities,
+                max_complexity,
+            )
 
-    if output_sarif:
-        store_sarif(
-            output_sarif_path,
-            files_complexities,
-            max_complexity,
+        console.print(f"Results saved at {output_path}")
+
+
+def emit_deprecated_output_warnings(
+    legacy_cli_output_flags: Dict[OutputFormat, Optional[bool]],
+    toml_config,
+) -> None:
+    global console
+
+    for output_format, flag_name in LEGACY_OUTPUT_FLAGS.items():
+        if legacy_cli_output_flags[output_format]:
+            console.print(
+                f"[yellow]Deprecated:[/yellow] {flag_name} will be removed "
+                f"in a future release. Use --output-format "
+                f"{output_format.value} instead."
+            )
+
+    if toml_config is None:
+        return
+
+    for output_format, config_key in LEGACY_OUTPUT_CONFIG_KEYS.items():
+        if bool(toml_config.get(config_key, False)):
+            console.print(
+                f"[yellow]Deprecated:[/yellow] `{config_key}` in TOML will "
+                f"be removed in a future release. Use `output-format = "
+                f'["{output_format.value}"]` instead.'
+            )
+
+
+def resolve_output_formats(
+    output_format_values: List[str],
+    legacy_cli_output_flags: Dict[OutputFormat, Optional[bool]],
+    toml_config,
+) -> List[OutputFormat]:
+    output_formats = []
+
+    for value in output_format_values:
+        try:
+            normalized = OutputFormat(value)
+        except ValueError as exc:
+            valid_values = ", ".join(
+                available.value for available in OutputFormat
+            )
+            raise typer.BadParameter(
+                f"Invalid output format '{value}'. Expected one of: "
+                f"{valid_values}."
+            ) from exc
+
+        if normalized not in output_formats:
+            output_formats.append(normalized)
+
+    for output_format in OutputFormat:
+        if legacy_cli_output_flags[output_format]:
+            output_formats.append(output_format)
+            continue
+
+        config_key = LEGACY_OUTPUT_CONFIG_KEYS[output_format]
+        if toml_config is not None and bool(toml_config.get(config_key, False)):
+            output_formats.append(output_format)
+
+    return list(dict.fromkeys(output_formats))
+
+
+def resolve_output_paths(
+    output_formats: List[OutputFormat],
+    output: Optional[str],
+) -> Dict[OutputFormat, str]:
+    if not output_formats:
+        return {}
+
+    if output is None:
+        return build_output_paths(INVOCATION_PATH, output_formats)
+
+    if output == "-":
+        raise typer.BadParameter(
+            "Writing machine-readable output to stdout is not supported."
         )
-        console.print(f"Results saved at {output_sarif_path}")
+
+    destination = os.path.abspath(output)
+    is_directory_hint = is_directory_output_hint(output)
+
+    if len(output_formats) > 1:
+        ensure_directory_destination(destination, is_directory_hint)
+        return build_output_paths(destination, output_formats)
+
+    output_format = output_formats[0]
+    if os.path.isdir(destination) or is_directory_hint:
+        os.makedirs(destination, exist_ok=True)
+        return build_output_paths(destination, [output_format])
+
+    parent_dir = os.path.dirname(destination)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
+    return {output_format: destination}
+
+
+def build_output_paths(
+    destination: str, output_formats: List[OutputFormat]
+) -> Dict[OutputFormat, str]:
+    return {
+        output_format: os.path.join(
+            destination,
+            DEFAULT_OUTPUT_FILENAMES[output_format],
+        )
+        for output_format in output_formats
+    }
+
+
+def is_directory_output_hint(output: str) -> bool:
+    return output.endswith(os.sep) or (
+        os.altsep is not None and output.endswith(os.altsep)
+    )
+
+
+def ensure_directory_destination(
+    destination: str, is_directory_hint: bool
+) -> None:
+    if os.path.exists(destination):
+        if not os.path.isdir(destination):
+            raise typer.BadParameter(
+                "When multiple output formats are selected, --output "
+                "must point to a directory."
+            )
+    elif not is_directory_hint:
+        raise typer.BadParameter(
+            "When multiple output formats are selected, --output must "
+            "point to a directory or end with a path separator."
+        )
+
+    os.makedirs(destination, exist_ok=True)
 
 
 def handle_snapshot(

--- a/complexipy/types.py
+++ b/complexipy/types.py
@@ -20,12 +20,21 @@ class Sort(str, Enum):
     file_name = "file_name"
 
 
+class OutputFormat(str, Enum):
+    csv = "csv"
+    json = "json"
+    gitlab = "gitlab"
+    sarif = "sarif"
+
+
 TOMLTypes = TypeVar(
     "TOMLTypes",
     int,
     bool,
+    str,
     List[str],
     ColorTypes,
+    OutputFormat,
     Sort,
 )
 

--- a/complexipy/utils/toml.py
+++ b/complexipy/utils/toml.py
@@ -5,6 +5,7 @@ import sys
 from typing import (
     List,  # It's important to use this to make it compatible with python 3.8, don't remove it
     Literal,
+    Optional,
     Tuple,
     cast,
     overload,
@@ -14,6 +15,7 @@ from typer import Exit
 
 from complexipy.types import (
     ColorTypes,
+    OutputFormat,
     Sort,
     TOMLBase,
     TOMLConfig,
@@ -37,18 +39,35 @@ def load_values_from_toml_key(
 ) -> Sort: ...
 @overload
 def load_values_from_toml_key(
-    key: Literal["paths", "exclude"], value: str | List[str]
+    key: Literal["paths", "exclude", "output-format"],
+    value: str | List[str],
 ) -> List[str]: ...
 @overload
 def load_values_from_toml_key(
     key: str,
-    value: int | bool | str | List[str] | Sort | ColorTypes | TOMLType,
-) -> int | bool | List[str] | ColorTypes | Sort | TOMLType: ...
+    value: int
+    | bool
+    | str
+    | List[str]
+    | Sort
+    | ColorTypes
+    | OutputFormat
+    | TOMLType,
+) -> (
+    int | bool | str | List[str] | ColorTypes | OutputFormat | Sort | TOMLType
+): ...
 
 
 def load_values_from_toml_key(
     key: str,
-    value: int | bool | str | List[str] | Sort | ColorTypes | TOMLType,
+    value: int
+    | bool
+    | str
+    | List[str]
+    | Sort
+    | ColorTypes
+    | OutputFormat
+    | TOMLType,
 ):
     """Normalize TOML values to expected runtime types.
 
@@ -67,7 +86,7 @@ def load_values_from_toml_key(
         elif isinstance(value, str):
             return Sort(value)
         return value
-    elif key in ("paths", "exclude"):
+    elif key in ("paths", "exclude", "output-format"):
         if isinstance(value, str):
             return [value]
         return value
@@ -182,6 +201,8 @@ def get_arguments_value(
     failed: bool | None,
     color: ColorTypes | None,
     sort_arg: Sort | None,
+    output_format: List[str] | None,
+    output: str | None,
     output_csv: bool | None,
     output_json: bool | None,
     output_gitlab: bool | None,
@@ -197,10 +218,8 @@ def get_arguments_value(
     bool,
     ColorTypes,
     Sort,
-    bool,
-    bool,
-    bool,
-    bool,
+    List[str],
+    str | None,
     List[str],
 ]:
     paths = get_argument_value(toml_config, "paths", paths, [])
@@ -237,8 +256,27 @@ def get_arguments_value(
     failed = cast(
         bool, get_argument_value(toml_config, "failed", failed, False)
     )
-    color = get_argument_value(toml_config, "color", color, ColorTypes.auto)
-    sort_arg = get_argument_value(toml_config, "sort", sort_arg, Sort.asc)
+    color = cast(
+        ColorTypes,
+        get_argument_value(toml_config, "color", color, ColorTypes.auto),
+    )
+    sort_arg = cast(
+        Sort,
+        get_argument_value(toml_config, "sort", sort_arg, Sort.asc),
+    )
+    if output_format is None:
+        if toml_config is None:
+            output_format = []
+        else:
+            output_format = cast(
+                List[str],
+                load_values_from_toml_key(
+                    "output-format",
+                    toml_config.get("output-format", []),
+                ),
+            )
+    if output is None and toml_config is not None:
+        output = cast(Optional[str], toml_config.get("output"))
     output_csv = cast(
         bool,
         get_argument_value(toml_config, "output-csv", output_csv, False),
@@ -267,9 +305,7 @@ def get_arguments_value(
         failed,
         color,
         sort_arg,
-        output_csv,
-        output_json,
-        output_gitlab,
-        output_sarif,
+        output_format,
+        output,
         exclude,
     )

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -65,7 +65,10 @@ complexipy path/to/code.py
 complexipy . --max-complexity-allowed 10
 
 # Guarda los resultados en JSON/CSV
-complexipy . --output-json --output-csv
+complexipy . --output-format json --output-format csv
+
+# Guarda un reporte de GitLab en una ruta determinista
+complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Analiza el directorio actual excluyendo ciertos archivos
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
@@ -106,7 +109,7 @@ print(f"Complexity: {result.complexity}")
   with:
     paths: .
     max_complexity_allowed: 10
-    output_json: true
+    output_format: json
 ```
 
 </details>
@@ -155,8 +158,8 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
-output-csv = false
-output-json = false
+output-format = ["json", "gitlab"]
+output = "reports/"
 ```
 
 ```toml
@@ -172,9 +175,13 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
-output-csv = false
-output-json = false
+output-format = ["json"]
+output = "complexipy-results.json"
 ```
+
+Las claves TOML heredadas como `output-json = true` y las flags de CLI como
+`--output-json` todavía funcionan por ahora, pero están deprecadas a favor de
+`output-format` y `--output-format`.
 
 ### Opciones de CLI
 
@@ -190,8 +197,12 @@ output-json = false
 | `--quiet`                  | Suprime la salida                                                                                                                                                                                           | `false`        |
 | `--ignore-complexity`      | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
 | `--version`                | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
-| `--output-json`            | Guarda los resultados como JSON                                                                                                                                                                             | `false`        |
-| `--output-csv`             | Guarda los resultados como CSV                                                                                                                                                                              | `false`        |
+| `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                              | —              |
+| `--output <path>`          | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                        | —              |
+| `--output-json`            | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
+| `--output-csv`             | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
+| `--output-gitlab`          | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
+| `--output-sarif`           | Alias deprecado de `--output-format sarif`                                                                                                                                                                  | `false`        |
 
 Ejemplo:
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -95,14 +95,24 @@ Guarda los resultados en JSON o CSV:
 
 ```bash
 # Salida JSON (guardada en complexipy-results.json)
-complexipy . --output-json
+complexipy . --output-format json
 
 # Salida CSV (guardada en complexipy-results.csv)
-complexipy . --output-csv
+complexipy . --output-format csv
 
 # Ambos
-complexipy . --output-json --output-csv
+complexipy . --output-format json --output-format csv
+
+# Destino explícito para un solo formato
+complexipy . --output-format gitlab --output complexipy-code-quality.json
+
+# Varios formatos escritos en un directorio
+complexipy . --output-format json --output-format sarif --output reports/
 ```
+
+Las flags heredadas como `--output-json` y las claves TOML como
+`output-json = true` siguen funcionando como alias deprecados por un ciclo de
+release.
 
 **Estructura de Salida JSON:**
 ```json
@@ -160,8 +170,8 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     failed = false
     color = "auto"
     sort = "asc"
-    output-csv = false
-    output-json = false
+    output-format = ["json", "gitlab"]
+    output = "reports/"
     ```
 
 === "pyproject.toml"
@@ -476,8 +486,7 @@ repos:
   image: python:3.11
   script:
     - pip install complexipy
-    - complexipy . --output-gitlab --ignore-complexity --max-complexity-allowed 15
-    - mv complexipy_results_*.gitlab.json complexipy-code-quality.json
+    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
   artifacts:
     when: always
     reports:
@@ -505,8 +514,7 @@ complexity_report:
   image: python:3.11
   script:
     - pip install complexipy
-    - complexipy . --output-gitlab --ignore-complexity --max-complexity-allowed 15
-    - mv complexipy_results_*.gitlab.json complexipy-code-quality.json
+    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
   artifacts:
     when: always
     reports:
@@ -568,7 +576,7 @@ complexipy src/ --failed
 
 ```bash
 # Generar datos históricos
-complexipy . --output-json
+complexipy . --output-format json
 # Hacer commit de complexipy-results.json para rastrear cambios a lo largo del tiempo
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,7 +64,10 @@ complexipy path/to/code.py
 complexipy . --max-complexity-allowed 10
 
 # Save results to JSON/CSV
-complexipy . --output-json --output-csv
+complexipy . --output-format json --output-format csv
+
+# Save a GitLab report to a deterministic path
+complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
@@ -105,7 +108,7 @@ print(f"Complexity: {result.complexity}")
   with:
     paths: .
     max_complexity_allowed: 10
-    output_json: true
+    output_format: json
 ```
 
 </details>
@@ -154,9 +157,8 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
-output-csv = false
-output-json = false
-output-gitlab = false
+output-format = ["json", "gitlab"]
+output = "reports/"
 ```
 
 ```toml
@@ -172,10 +174,13 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
-output-csv = false
-output-json = false
-output-gitlab = false
+output-format = ["json"]
+output = "complexipy-results.json"
 ```
+
+Legacy TOML keys such as `output-json = true` and CLI flags such as
+`--output-json` still work for now, but they are deprecated in favor of
+`output-format` and `--output-format`.
 
 ### CLI Options
 
@@ -191,9 +196,12 @@ output-gitlab = false
 | `--quiet` | Suppress output | `false` |
 | `--ignore-complexity` | Don't exit with error on threshold breach | `false` |
 | `--version` | Show installed complexipy version and exit | - |
-| `--output-json` | Save results as JSON | `false` |
-| `--output-csv` | Save results as CSV | `false` |
-| `--output-gitlab` | Save results as a GitLab Code Quality JSON report | `false` |
+| `--output-format <format>` | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`) | — |
+| `--output <path>` | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats | — |
+| `--output-json` | Deprecated alias for `--output-format json` | `false` |
+| `--output-csv` | Deprecated alias for `--output-format csv` | `false` |
+| `--output-gitlab` | Deprecated alias for `--output-format gitlab` | `false` |
+| `--output-sarif` | Deprecated alias for `--output-format sarif` | `false` |
 
 Example:
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -95,20 +95,29 @@ Save results to JSON, CSV, GitLab Code Quality, or SARIF:
 
 ```bash
 # JSON output (saved to complexipy-results.json)
-complexipy . --output-json
+complexipy . --output-format json
 
 # CSV output (saved to complexipy-results.csv)
-complexipy . --output-csv
+complexipy . --output-format csv
 
 # Both
-complexipy . --output-json --output-csv
+complexipy . --output-format json --output-format csv
+
+# Explicit destination for a single format
+complexipy . --output-format gitlab --output complexipy-code-quality.json
+
+# Multiple formats written into a directory
+complexipy . --output-format json --output-format sarif --output reports/
 
 # GitLab Code Quality report
-complexipy . --output-gitlab
+complexipy . --output-format gitlab
 
 # SARIF output
-complexipy . --output-sarif
+complexipy . --output-format sarif
 ```
+
+Legacy flags such as `--output-json` and TOML keys such as `output-json = true`
+still work as deprecated aliases for one release cycle.
 
 **JSON Output Structure:**
 ```json
@@ -166,8 +175,8 @@ complexipy loads configuration in this order (highest to lowest priority):
     failed = false
     color = "auto"
     sort = "asc"
-    output-csv = false
-    output-json = false
+    output-format = ["json", "gitlab"]
+    output = "reports/"
     ```
 
 === "pyproject.toml"
@@ -482,8 +491,7 @@ repos:
   image: python:3.11
   script:
     - pip install complexipy
-    - complexipy . --output-gitlab --ignore-complexity --max-complexity-allowed 15
-    - mv complexipy_results_*.gitlab.json complexipy-code-quality.json
+    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
   artifacts:
     when: always
     reports:
@@ -511,8 +519,7 @@ complexity_report:
   image: python:3.11
   script:
     - pip install complexipy
-    - complexipy . --output-gitlab --ignore-complexity --max-complexity-allowed 15
-    - mv complexipy_results_*.gitlab.json complexipy-code-quality.json
+    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
   artifacts:
     when: always
     reports:
@@ -574,7 +581,7 @@ complexipy src/ --failed
 
 ```bash
 # Generate historical data
-complexipy . --output-json
+complexipy . --output-format json
 # Commit complexipy-results.json to track changes over time
 ```
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -98,8 +98,8 @@ class TestGitlabOutput:
 
         assert result.exit_code == 1, result.output
 
-        output_files = list(tmp_path.glob("complexipy_results_*.gitlab.json"))
-        assert len(output_files) == 1
+        output_file = tmp_path / "complexipy-results.gitlab.json"
+        assert output_file.exists()
 
-        report = json.loads(output_files[0].read_text(encoding="utf-8"))
+        report = json.loads(output_file.read_text(encoding="utf-8"))
         assert len(report) == 1

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -55,6 +55,6 @@ class TestJsonOutput:
 
         assert result.exit_code == 0, result.output
 
-        output_files = list(tmp_path.glob("complexipy_results_*.json"))
-        assert len(output_files) == 1
-        assert output_files[0].read_bytes().endswith(b"\n")
+        output_file = tmp_path / "complexipy-results.json"
+        assert output_file.exists()
+        assert output_file.read_bytes().endswith(b"\n")

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from complexipy.utils.toml import get_arguments_value
+
+_SNIPPET = """\
+def simple(value):
+    if value:
+        return value
+    return 0
+"""
+
+
+class TestOutputCli:
+    def test_output_format_writes_explicit_file(self, tmp_path: Path, monkeypatch):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        output_file = tmp_path / "reports" / "report.json"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        result = runner.invoke(
+            main_module.app,
+            [
+                "--output-format",
+                "json",
+                "--output",
+                str(output_file),
+                str(source_file),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert output_file.exists()
+        assert json.loads(output_file.read_text(encoding="utf-8"))[0][
+            "function_name"
+        ] == "simple"
+
+    def test_multiple_output_formats_require_directory(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            [
+                "--output-format",
+                "json",
+                "--output-format",
+                "csv",
+                "--output",
+                str(tmp_path / "report.json"),
+                str(source_file),
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert not (tmp_path / "report.json").exists()
+
+    def test_multiple_output_formats_write_default_names_in_directory(
+        self,
+        tmp_path: Path,
+    ):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        output_dir = tmp_path / "reports"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            [
+                "--output-format",
+                "json",
+                "--output-format",
+                "csv",
+                "--output",
+                f"{output_dir}{Path('/').as_posix()}",
+                str(source_file),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (output_dir / "complexipy-results.json").exists()
+        assert (output_dir / "complexipy-results.csv").exists()
+
+
+class TestOutputToml:
+    def test_get_arguments_value_reads_new_output_keys(self):
+        values = get_arguments_value(
+            {
+                "paths": ["."],
+                "output-format": ["json", "gitlab"],
+                "output": "reports/",
+            },
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+
+        assert values[9] == ["json", "gitlab"]
+        assert values[10] == "reports/"


### PR DESCRIPTION
## What

This PR replaces the legacy per-format output flags with a shared output format and destination model while preserving backward compatibility.

## Why

`complexipy` needed a single output interface that supports multiple machine-readable formats and deterministic report paths without forcing CI users to rely on timestamped filenames or manual renames.

## Changes

- add a shared `OutputFormat` model and route machine-readable output through one dispatch path in the CLI
- add repeatable `--output-format` and `--output` support, including deterministic default filenames and directory handling for multi-format output
- preserve legacy `--output-json`, `--output-csv`, `--output-gitlab`, and `--output-sarif` flags plus TOML booleans as deprecated aliases mapped into the new model
- add tests for explicit output paths, multi-format directory validation, deterministic filenames, and TOML parsing
- update the README and English and Spanish docs to show the new interface and deterministic CI examples

Solves: #154