### PR TITLE
docs: sync CLI and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ complexipy . --output-format json --output-format csv
 # Write a GitLab report to a deterministic path
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
+# Compare complexity against a git reference
+complexipy . --diff HEAD~1
+
+# Include module-level script complexity as <module>
+complexipy . --check-script
+
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -80,7 +86,7 @@ complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 from complexipy import file_complexity, code_complexity
 
 # Analyze a file
-result = file_complexity("app.py")
+result = file_complexity("app.py", check_script=True)
 print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
@@ -95,7 +101,7 @@ def complex_function(data):
                 process(item)
 """
 
-result = code_complexity(snippet)
+result = code_complexity(snippet, check_script=True)
 print(f"Complexity: {result.complexity}")
 ```
 
@@ -196,6 +202,7 @@ sort = "asc"
 exclude = []
 output-format = ["json", "sarif"]
 output = "reports/"
+check-script = false
 ```
 
 ```toml
@@ -213,6 +220,7 @@ sort = "asc"
 exclude = []
 output-format = ["json"]
 output = "complexipy-results.json"
+check-script = false
 ```
 
 Legacy TOML keys such as `output-json = true` and CLI flags such as
@@ -229,13 +237,14 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 | `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
 | `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
 | `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
-| `--sort <asc\|desc\|name>` | Sort results                                                                                                                                                     | `asc`   |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                               | `asc`   |
 | `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
 | `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
 | `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
 | `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                         | —       |
 | `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
 | `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`           | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
 | `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                       | `false` |
 | `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                        | `false` |
 | `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                     | `false` |
@@ -302,6 +311,17 @@ Net: 1 regressed, 1 improved, 1 new
 
 The diff is appended after the normal analysis output and does not affect the exit code. Requires `git` to be available and the analysed paths to be inside a git repository.
 
+### Script Complexity
+
+Use `--check-script` when you also want to score module-level control flow, not just functions:
+
+```bash
+# Report top-level script logic as <module>
+complexipy scripts/bootstrap.py --check-script
+```
+
+The same capability is available in the Python API via `check_script=True` on both `file_complexity()` and `code_complexity()`.
+
 ### Inline Ignores
 
 You can explicitly ignore a known complex function inline, similar to Ruff's `C901` ignores:
@@ -319,8 +339,8 @@ Place `# complexipy: ignore` on the function definition line (or the line immedi
 
 ```python
 # Core functions
-file_complexity(path: str) -> FileComplexity
-code_complexity(source: str) -> CodeComplexity
+file_complexity(path: str, check_script: bool = False) -> FileComplexity
+code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 
 # Return types
 FileComplexity:

--- a/README.md
+++ b/README.md
@@ -229,26 +229,26 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 ### CLI Options
 
-| Flag                       | Description                                                                                                                                                      | Default |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
-| `--max-complexity-allowed` | Complexity threshold                                                                                                                                             | `15`    |
-| `--snapshot-create`        | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
-| `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
-| `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
-| `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
-| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                               | `asc`   |
-| `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
-| `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
-| `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
-| `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                         | —       |
-| `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
-| `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
-| `--check-script`           | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
-| `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                       | `false` |
-| `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                        | `false` |
-| `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                     | `false` |
-| `--output-sarif`           | Deprecated alias for `--output-format sarif`                                                                                                                      | `false` |
+| Flag                            | Description                                                                                                                                                      | Default |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
+| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
+| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
+| `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                     | `asc`   |
+| `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
+| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                        | `false` |
+| `--version`                     | Show installed complexipy version and exit                                                                                                                       | -       |
+| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                          | —       |
+| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
+| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
+| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
+| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
+| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
+| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
 
 Example:
 

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -70,6 +70,12 @@ complexipy . --output-format json --output-format csv
 # Guarda un reporte de GitLab en una ruta determinista
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
+# Compara la complejidad contra una referencia de git
+complexipy . --diff HEAD~1
+
+# Incluye la complejidad del script a nivel módulo como <module>
+complexipy . --check-script
+
 # Analiza el directorio actual excluyendo ciertos archivos
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -80,7 +86,7 @@ complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 from complexipy import file_complexity, code_complexity
 
 # Analiza un archivo
-result = file_complexity("app.py")
+result = file_complexity("app.py", check_script=True)
 print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
@@ -95,7 +101,7 @@ def complex_function(data):
                 process(item)
 """
 
-result = code_complexity(snippet)
+result = code_complexity(snippet, check_script=True)
 print(f"Complexity: {result.complexity}")
 ```
 
@@ -160,6 +166,7 @@ sort = "asc"
 exclude = []
 output-format = ["json", "gitlab"]
 output = "reports/"
+check-script = false
 ```
 
 ```toml
@@ -177,6 +184,7 @@ sort = "asc"
 exclude = []
 output-format = ["json"]
 output = "complexipy-results.json"
+check-script = false
 ```
 
 Las claves TOML heredadas como `output-json = true` y las flags de CLI como
@@ -193,12 +201,14 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 | `--snapshot-ignore`        | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
 | `--failed`                 | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
 | `--color <auto\|yes\|no>`  | Usa color                                                                                                                                                                                                   | `auto`         |
-| `--sort <asc\|desc\|name>` | Ordena los resultados                                                                                                                                                                                       | `asc`          |
+| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                 | `asc`          |
 | `--quiet`                  | Suprime la salida                                                                                                                                                                                           | `false`        |
 | `--ignore-complexity`      | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
 | `--version`                | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
 | `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                              | —              |
 | `--output <path>`          | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                        | —              |
+| `--diff <ref>`             | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                | —              |
+| `--check-script`           | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
 | `--output-json`            | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
 | `--output-csv`             | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
 | `--output-gitlab`          | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
@@ -236,6 +246,30 @@ El archivo de snapshot solo almacena las funciones cuya complejidad supera el um
 
 Usa `--snapshot-ignore` si necesitas omitir temporalmente el control de snapshot (por ejemplo, durante una refactorización o al regenerar la línea base).
 
+### Diff de Complejidad
+
+Compara la complejidad contra cualquier referencia de git para ver si una rama o commit mejoró o empeoró el código:
+
+```bash
+# Compara el working tree con el commit anterior
+complexipy . --diff HEAD~1
+
+# Compara contra una rama nombrada
+complexipy . --diff main
+```
+
+El diff se añade después de la salida normal del análisis y no afecta el código de salida. Requiere que `git` esté disponible y que las rutas analizadas estén dentro de un repositorio git.
+
+### Complejidad de Script
+
+Usa `--check-script` cuando también quieras medir el flujo de control a nivel de módulo, no solo las funciones:
+
+```bash
+complexipy scripts/bootstrap.py --check-script
+```
+
+La misma capacidad está disponible en la API de Python mediante `check_script=True` tanto en `file_complexity()` como en `code_complexity()`.
+
 ### Ignorar en Línea
 
 Puedes ignorar explícitamente una función compleja conocida en línea usando `# complexipy: ignore`:
@@ -255,8 +289,8 @@ Coloca `# complexipy: ignore` en la línea de definición de la función (o en l
 
 ```python
 # Funciones principales
-file_complexity(path: str) -> FileComplexity
-code_complexity(source: str) -> CodeComplexity
+file_complexity(path: str, check_script: bool = False) -> FileComplexity
+code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 
 # Tipos de retorno
 FileComplexity:

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -113,9 +113,9 @@ print(f"Complexity: {result.complexity}")
 ```yaml
 - uses: rohaquinlop/complexipy-action@v2
   with:
-    paths: .
-    max_complexity_allowed: 10
-    output_format: json
+      paths: .
+      max_complexity_allowed: 10
+      output_format: json
 ```
 
 </details>
@@ -125,10 +125,10 @@ print(f"Complexity: {result.complexity}")
 
 ```yaml
 repos:
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v4.2.0
-    hooks:
-      - id: complexipy
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v4.2.0
+      hooks:
+          - id: complexipy
 ```
 
 </details>
@@ -193,26 +193,26 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 
 ### Opciones de CLI
 
-| Opción                     | Descripción                                                                                                                                                                                                 | Predeterminado |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `--exclude`                | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
-| `--max-complexity-allowed` | Umbral de complejidad                                                                                                                                                                                       | `15`           |
-| `--snapshot-create`        | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
-| `--snapshot-ignore`        | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
-| `--failed`                 | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
-| `--color <auto\|yes\|no>`  | Usa color                                                                                                                                                                                                   | `auto`         |
-| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                 | `asc`          |
-| `--quiet`                  | Suprime la salida                                                                                                                                                                                           | `false`        |
-| `--ignore-complexity`      | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
-| `--version`                | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
-| `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                              | —              |
-| `--output <path>`          | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                        | —              |
-| `--diff <ref>`             | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                | —              |
-| `--check-script`           | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
-| `--output-json`            | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
-| `--output-csv`             | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
-| `--output-gitlab`          | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
-| `--output-sarif`           | Alias deprecado de `--output-format sarif`                                                                                                                                                                  | `false`        |
+| Opción                          | Descripción                                                                                                                                                                                                 | Predeterminado |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `--exclude`                     | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
+| `--max-complexity-allowed`      | Umbral de complejidad                                                                                                                                                                                       | `15`           |
+| `--snapshot-create`             | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
+| `--snapshot-ignore`             | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
+| `--failed`                      | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
+| `--color <auto\|yes\|no>`       | Usa color                                                                                                                                                                                                   | `auto`         |
+| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                       | `asc`          |
+| `--quiet`                       | Suprime la salida                                                                                                                                                                                           | `false`        |
+| `--ignore-complexity`           | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
+| `--version`                     | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
+| `--output-format <format>`      | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                                | —              |
+| `--output <path>`               | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                          | —              |
+| `--diff <ref>`                  | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                 | —              |
+| `--check-script`                | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
+| `--output-json`                 | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
+| `--output-csv`                  | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
+| `--output-gitlab`               | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
+| `--output-sarif`                | Alias deprecado de `--output-format sarif`                                                                                                                                                                  | `false`        |
 
 Ejemplo:
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -66,7 +66,7 @@ Ordenar por puntuación de complejidad:
 ```bash
 complexipy . --sort asc   # Ascendente (predeterminado)
 complexipy . --sort desc  # Descendente
-complexipy . --sort name  # Alfabéticamente por nombre de función
+complexipy . --sort file_name  # Alfabéticamente por nombre de archivo
 ```
 
 ### Excluir Archivos y Directorios
@@ -113,6 +113,27 @@ complexipy . --output-format json --output-format sarif --output reports/
 Las flags heredadas como `--output-json` y las claves TOML como
 `output-json = true` siguen funcionando como alias deprecados por un ciclo de
 release.
+
+### Diff de Complejidad
+
+Compara los resultados actuales contra cualquier referencia de git:
+
+```bash
+complexipy . --diff HEAD~1
+complexipy . --diff main
+complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
+```
+
+El diff se añade después de la salida normal del análisis y no afecta el código de salida. Esto requiere `git` y una ruta dentro de un repositorio.
+
+### Complejidad de Script
+
+Reporta el flujo de control a nivel módulo como una entrada sintética `<module>`:
+
+```bash
+complexipy scripts/bootstrap.py --check-script
+complexipy . --check-script --failed
+```
 
 **Estructura de Salida JSON:**
 ```json
@@ -172,6 +193,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     sort = "asc"
     output-format = ["json", "gitlab"]
     output = "reports/"
+    check-script = false
     ```
 
 === "pyproject.toml"
@@ -199,7 +221,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
 from complexipy import file_complexity
 
 # Analizar un archivo
-result = file_complexity("src/main.py")
+result = file_complexity("src/main.py", check_script=True)
 
 print(f"Total complexity: {result.complexity}")
 print(f"File path: {result.path}")
@@ -227,7 +249,7 @@ def calculate_discount(price, customer):
     return price
 """
 
-result = code_complexity(code)
+result = code_complexity(code, check_script=True)
 print(f"Complexity: {result.complexity}")
 
 for func in result.functions:

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -84,10 +84,7 @@ complexipy . --exclude tests --exclude migrations --exclude build
 complexipy . --exclude src/legacy/old_code.py
 ```
 
-!!! note "Cómo funciona la exclusión"
-    - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta)
-    - Las entradas inexistentes se ignoran silenciosamente
-    - Las rutas son relativas a cada ruta raíz proporcionada
+!!! note "Cómo funciona la exclusión" - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta) - Las entradas inexistentes se ignoran silenciosamente - Las rutas son relativas a cada ruta raíz proporcionada
 
 ### Formatos de Salida
 
@@ -136,23 +133,24 @@ complexipy . --check-script --failed
 ```
 
 **Estructura de Salida JSON:**
+
 ```json
 {
-  "files": [
-    {
-      "path": "src/main.py",
-      "complexity": 42,
-      "functions": [
+    "files": [
         {
-          "name": "process_data",
-          "complexity": 18,
-          "line_start": 10,
-          "line_end": 45
+            "path": "src/main.py",
+            "complexity": 42,
+            "functions": [
+                {
+                    "name": "process_data",
+                    "complexity": 18,
+                    "line_start": 10,
+                    "line_end": 45
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "total_complexity": 42
+    ],
+    "total_complexity": 42
 }
 ```
 
@@ -180,7 +178,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
 ### Configuraciones de Ejemplo
 
 === "complexipy.toml"
-    ```toml
+`toml
     paths = ["src", "tests"]
     max-complexity-allowed = 10
     exclude = ["migrations", "build"]
@@ -194,24 +192,24 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     output-format = ["json", "gitlab"]
     output = "reports/"
     check-script = false
-    ```
+    `
 
 === "pyproject.toml"
-    ```toml
+`toml
     [tool.complexipy]
     paths = ["src", "tests"]
     max-complexity-allowed = 10
     exclude = ["migrations", "build"]
     failed = true
     sort = "desc"
-    ```
+    `
 
 === ".complexipy.toml"
-    ```toml
+`toml
     # Archivo de configuración oculto para ajustes específicos del equipo
     max-complexity-allowed = 15
     exclude = ["venv", ".venv", "node_modules"]
-    ```
+    `
 
 ## API de Python
 
@@ -389,16 +387,16 @@ name: Complexity Check
 on: [push, pull_request]
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install complexipy
-        run: pip install complexipy
+            - name: Install complexipy
+              run: pip install complexipy
 
-      - name: Check complexity
-        run: complexipy . --max-complexity-allowed 15
+            - name: Check complexity
+              run: complexipy . --max-complexity-allowed 15
 ```
 
 El archivo de snapshot (`complexipy-snapshot.json`) debería ser commiteado al control de versiones.
@@ -412,6 +410,7 @@ complexipy . --snapshot-ignore
 ```
 
 Úsalo al:
+
 - Refactorizar múltiples archivos a la vez
 - Regenerar la línea base
 - Probar diferentes umbrales
@@ -420,15 +419,15 @@ complexipy . --snapshot-ignore
 
 ```json
 {
-  "version": "1.0",
-  "threshold": 15,
-  "functions": {
-    "src/legacy.py::old_function": {
-      "complexity": 23,
-      "line_start": 10,
-      "line_end": 50
+    "version": "1.0",
+    "threshold": 15,
+    "functions": {
+        "src/legacy.py::old_function": {
+            "complexity": 23,
+            "line_start": 10,
+            "line_end": 50
+        }
     }
-  }
 }
 ```
 
@@ -474,9 +473,9 @@ Usa la acción oficial:
 ```yaml
 - uses: rohaquinlop/complexipy-action@v2
   with:
-    paths: src tests
-    max_complexity_allowed: 15
-    output_json: true
+      paths: src tests
+      max_complexity_allowed: 15
+      output_json: true
 ```
 
 O ejecuta directamente:
@@ -484,8 +483,8 @@ O ejecuta directamente:
 ```yaml
 - name: Check complexity
   run: |
-    pip install complexipy
-    complexipy . --max-complexity-allowed 15
+      pip install complexipy
+      complexipy . --max-complexity-allowed 15
 ```
 
 ### Hook de Pre-commit
@@ -494,31 +493,31 @@ Agrega a `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v4.2.0
-    hooks:
-      - id: complexipy
-        args: [--max-complexity-allowed=15]
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v4.2.0
+      hooks:
+          - id: complexipy
+            args: [--max-complexity-allowed=15]
 ```
 
 ### GitLab CI
 
 ```yaml
 .complexipy_code_quality:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
-  artifacts:
-    when: always
-    reports:
-      codequality: complexipy-code-quality.json
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
+    artifacts:
+        when: always
+        reports:
+            codequality: complexipy-code-quality.json
 
 complexity:
-  extends: .complexipy_code_quality
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    extends: .complexipy_code_quality
+    rules:
+        - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
 Usa `--ignore-complexity` cuando tu objetivo principal sea publicar el reporte aunque existan violaciones. GitLab seguirá mostrando los hallazgos en el widget del merge request y en la interfaz del pipeline.
@@ -527,20 +526,20 @@ Si además quieres que el job falle cuando se supere el umbral, separa el flujo 
 
 ```yaml
 complexity_check:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --max-complexity-allowed 15
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --max-complexity-allowed 15
 
 complexity_report:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
-  artifacts:
-    when: always
-    reports:
-      codequality: complexipy-code-quality.json
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
+    artifacts:
+        when: always
+        reports:
+            codequality: complexipy-code-quality.json
 ```
 
 ## Integración con VS Code

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,12 @@ complexipy . --output-format json --output-format csv
 # Save a GitLab report to a deterministic path
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
+# Compare complexity against a git reference
+complexipy . --diff HEAD~1
+
+# Include module-level script complexity as <module>
+complexipy . --check-script
+
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -79,7 +85,7 @@ complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 from complexipy import file_complexity, code_complexity
 
 # Analyze a file
-result = file_complexity("app.py")
+result = file_complexity("app.py", check_script=True)
 print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
@@ -94,7 +100,7 @@ def complex_function(data):
                 process(item)
 """
 
-result = code_complexity(snippet)
+result = code_complexity(snippet, check_script=True)
 print(f"Complexity: {result.complexity}")
 ```
 
@@ -159,6 +165,7 @@ sort = "asc"
 exclude = []
 output-format = ["json", "gitlab"]
 output = "reports/"
+check-script = false
 ```
 
 ```toml
@@ -176,6 +183,7 @@ sort = "asc"
 exclude = []
 output-format = ["json"]
 output = "complexipy-results.json"
+check-script = false
 ```
 
 Legacy TOML keys such as `output-json = true` and CLI flags such as
@@ -192,12 +200,14 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 | `--snapshot-ignore` | Skip comparing against the snapshot even if it exists | `false` |
 | `--failed` | Show only functions above the complexity threshold | `false` |
 | `--color <auto\|yes\|no>` | Use color | `auto` |
-| `--sort <asc\|desc\|name>` | Sort results | `asc` |
+| `--sort <asc\|desc\|file_name>` | Sort results | `asc` |
 | `--quiet` | Suppress output | `false` |
 | `--ignore-complexity` | Don't exit with error on threshold breach | `false` |
 | `--version` | Show installed complexipy version and exit | - |
 | `--output-format <format>` | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`) | — |
 | `--output <path>` | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats | — |
+| `--diff <ref>` | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`) | — |
+| `--check-script` | Report module-level (script) complexity as a synthetic `<module>` entry | `false` |
 | `--output-json` | Deprecated alias for `--output-format json` | `false` |
 | `--output-csv` | Deprecated alias for `--output-format csv` | `false` |
 | `--output-gitlab` | Deprecated alias for `--output-format gitlab` | `false` |
@@ -235,6 +245,30 @@ The snapshot file only stores functions whose complexity exceeds the configured 
 
 Use `--snapshot-ignore` if you need to temporarily bypass the snapshot gate (for example during a refactor or while regenerating the baseline).
 
+### Complexity Diff
+
+Compare complexity against any git reference to see whether a branch or commit made things better or worse:
+
+```bash
+# Compare the working tree against the previous commit
+complexipy . --diff HEAD~1
+
+# Compare against a named branch
+complexipy . --diff main
+```
+
+The diff is appended after the normal analysis output and does not affect the exit code. Requires `git` to be available and the analysed paths to be inside a git repository.
+
+### Script Complexity
+
+Use `--check-script` when you also want to score module-level control flow, not just functions:
+
+```bash
+complexipy scripts/bootstrap.py --check-script
+```
+
+The same capability is available in the Python API via `check_script=True` on both `file_complexity()` and `code_complexity()`.
+
 ### Inline Ignores
 
 You can explicitly ignore a known complex function inline using `# complexipy: ignore`:
@@ -254,8 +288,8 @@ Place `# complexipy: ignore` on the function definition line (or the line immedi
 
 ```python
 # Core functions
-file_complexity(path: str) -> FileComplexity
-code_complexity(source: str) -> CodeComplexity
+file_complexity(path: str, check_script: bool = False) -> FileComplexity
+code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 
 # Return types
 FileComplexity:

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@
 Unlike traditional metrics like cyclomatic complexity, cognitive complexity accounts for nesting depth and control flow patterns that affect human comprehension. Inspired by [G. Ann Campbell's research](https://www.sonarsource.com/resources/cognitive-complexity/) at SonarSource, complexipy provides a fast, accurate implementation for Python.
 
 **Key benefits:**
+
 - **Human-focused** - Penalizes nesting, flow breaks, and human-unfriendly logic
 - **Actionable insights** - Identifies genuinely hard-to-maintain code
 - **Different from cyclomatic** - Measures readability while cyclomatic measures structural, testing, and branch density
@@ -112,9 +113,9 @@ print(f"Complexity: {result.complexity}")
 ```yaml
 - uses: rohaquinlop/complexipy-action@v2
   with:
-    paths: .
-    max_complexity_allowed: 10
-    output_format: json
+      paths: .
+      max_complexity_allowed: 10
+      output_format: json
 ```
 
 </details>
@@ -124,10 +125,10 @@ print(f"Complexity: {result.complexity}")
 
 ```yaml
 repos:
-- repo: https://github.com/rohaquinlop/complexipy-pre-commit
-  rev: v4.2.0
-  hooks:
-    - id: complexipy
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v4.2.0
+      hooks:
+          - id: complexipy
 ```
 
 </details>
@@ -192,26 +193,26 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 ### CLI Options
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--exclude` | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |  |
-| `--max-complexity-allowed` | Complexity threshold | `15` |
-| `--snapshot-create` | Save the current violations above the threshold into `complexipy-snapshot.json` | `false` |
-| `--snapshot-ignore` | Skip comparing against the snapshot even if it exists | `false` |
-| `--failed` | Show only functions above the complexity threshold | `false` |
-| `--color <auto\|yes\|no>` | Use color | `auto` |
-| `--sort <asc\|desc\|file_name>` | Sort results | `asc` |
-| `--quiet` | Suppress output | `false` |
-| `--ignore-complexity` | Don't exit with error on threshold breach | `false` |
-| `--version` | Show installed complexipy version and exit | - |
-| `--output-format <format>` | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`) | — |
-| `--output <path>` | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats | — |
-| `--diff <ref>` | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`) | — |
-| `--check-script` | Report module-level (script) complexity as a synthetic `<module>` entry | `false` |
-| `--output-json` | Deprecated alias for `--output-format json` | `false` |
-| `--output-csv` | Deprecated alias for `--output-format csv` | `false` |
-| `--output-gitlab` | Deprecated alias for `--output-format gitlab` | `false` |
-| `--output-sarif` | Deprecated alias for `--output-format sarif` | `false` |
+| Flag                            | Description                                                                                                                                                      | Default |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
+| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
+| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
+| `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                     | `asc`   |
+| `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
+| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                        | `false` |
+| `--version`                     | Show installed complexipy version and exit                                                                                                                       | -       |
+| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                 | —       |
+| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
+| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
+| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
+| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
+| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
+| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
 
 Example:
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -66,7 +66,7 @@ Sort by complexity score:
 ```bash
 complexipy . --sort asc   # Ascending (default)
 complexipy . --sort desc  # Descending
-complexipy . --sort name  # Alphabetically by function name
+complexipy . --sort file_name  # Alphabetically by file name
 ```
 
 ### Excluding Files and Directories
@@ -118,6 +118,27 @@ complexipy . --output-format sarif
 
 Legacy flags such as `--output-json` and TOML keys such as `output-json = true`
 still work as deprecated aliases for one release cycle.
+
+### Complexity Diff
+
+Compare current results against any git reference:
+
+```bash
+complexipy . --diff HEAD~1
+complexipy . --diff main
+complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
+```
+
+The diff is appended after the regular analysis output and does not affect the exit code. This requires `git` and a repository-backed path.
+
+### Script Complexity
+
+Report module-level control flow as a synthetic `<module>` entry:
+
+```bash
+complexipy scripts/bootstrap.py --check-script
+complexipy . --check-script --failed
+```
 
 **JSON Output Structure:**
 ```json
@@ -177,6 +198,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     sort = "asc"
     output-format = ["json", "gitlab"]
     output = "reports/"
+    check-script = false
     ```
 
 === "pyproject.toml"
@@ -204,7 +226,7 @@ complexipy loads configuration in this order (highest to lowest priority):
 from complexipy import file_complexity
 
 # Analyze a file
-result = file_complexity("src/main.py")
+result = file_complexity("src/main.py", check_script=True)
 
 print(f"Total complexity: {result.complexity}")
 print(f"File path: {result.path}")
@@ -232,7 +254,7 @@ def calculate_discount(price, customer):
     return price
 """
 
-result = code_complexity(code)
+result = code_complexity(code, check_script=True)
 print(f"Complexity: {result.complexity}")
 
 for func in result.functions:

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -84,10 +84,7 @@ complexipy . --exclude tests --exclude migrations --exclude build
 complexipy . --exclude src/legacy/old_code.py
 ```
 
-!!! note "How exclusion works"
-    - Entries resolve to existing directories (prefix match) or files (exact match)
-    - Non-existent entries are silently ignored
-    - Paths are relative to each provided root path
+!!! note "How exclusion works" - Entries resolve to existing directories (prefix match) or files (exact match) - Non-existent entries are silently ignored - Paths are relative to each provided root path
 
 ### Output Formats
 
@@ -141,23 +138,24 @@ complexipy . --check-script --failed
 ```
 
 **JSON Output Structure:**
+
 ```json
 {
-  "files": [
-    {
-      "path": "src/main.py",
-      "complexity": 42,
-      "functions": [
+    "files": [
         {
-          "name": "process_data",
-          "complexity": 18,
-          "line_start": 10,
-          "line_end": 45
+            "path": "src/main.py",
+            "complexity": 42,
+            "functions": [
+                {
+                    "name": "process_data",
+                    "complexity": 18,
+                    "line_start": 10,
+                    "line_end": 45
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "total_complexity": 42
+    ],
+    "total_complexity": 42
 }
 ```
 
@@ -394,16 +392,16 @@ name: Complexity Check
 on: [push, pull_request]
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install complexipy
-        run: pip install complexipy
+            - name: Install complexipy
+              run: pip install complexipy
 
-      - name: Check complexity
-        run: complexipy . --max-complexity-allowed 15
+            - name: Check complexity
+              run: complexipy . --max-complexity-allowed 15
 ```
 
 The snapshot file (`complexipy-snapshot.json`) should be committed to version control.
@@ -417,6 +415,7 @@ complexipy . --snapshot-ignore
 ```
 
 Use this when:
+
 - Refactoring multiple files at once
 - Regenerating the baseline
 - Testing different thresholds
@@ -425,15 +424,15 @@ Use this when:
 
 ```json
 {
-  "version": "1.0",
-  "threshold": 15,
-  "functions": {
-    "src/legacy.py::old_function": {
-      "complexity": 23,
-      "line_start": 10,
-      "line_end": 50
+    "version": "1.0",
+    "threshold": 15,
+    "functions": {
+        "src/legacy.py::old_function": {
+            "complexity": 23,
+            "line_start": 10,
+            "line_end": 50
+        }
     }
-  }
 }
 ```
 
@@ -479,9 +478,9 @@ Use the official action:
 ```yaml
 - uses: rohaquinlop/complexipy-action@v2
   with:
-    paths: src tests
-    max_complexity_allowed: 15
-    output_json: true
+      paths: src tests
+      max_complexity_allowed: 15
+      output_json: true
 ```
 
 Or run directly:
@@ -489,8 +488,8 @@ Or run directly:
 ```yaml
 - name: Check complexity
   run: |
-    pip install complexipy
-    complexipy . --max-complexity-allowed 15
+      pip install complexipy
+      complexipy . --max-complexity-allowed 15
 ```
 
 ### Pre-commit Hook
@@ -499,31 +498,31 @@ Add to `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v4.2.0
-    hooks:
-      - id: complexipy
-        args: [--max-complexity-allowed=15]
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v4.2.0
+      hooks:
+          - id: complexipy
+            args: [--max-complexity-allowed=15]
 ```
 
 ### GitLab CI
 
 ```yaml
 .complexipy_code_quality:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
-  artifacts:
-    when: always
-    reports:
-      codequality: complexipy-code-quality.json
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
+    artifacts:
+        when: always
+        reports:
+            codequality: complexipy-code-quality.json
 
 complexity:
-  extends: .complexipy_code_quality
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    extends: .complexipy_code_quality
+    rules:
+        - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
 Use `--ignore-complexity` when your main goal is to upload the report even if violations exist. GitLab will still display the findings in the merge request widget and pipeline UI.
@@ -532,20 +531,20 @@ If you also want the job to fail when the threshold is exceeded, split the workf
 
 ```yaml
 complexity_check:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --max-complexity-allowed 15
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --max-complexity-allowed 15
 
 complexity_report:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
-  artifacts:
-    when: always
-    reports:
-      codequality: complexipy-code-quality.json
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
+    artifacts:
+        when: always
+        reports:
+            codequality: complexipy-code-quality.json
 ```
 
 ## VS Code Integration


### PR DESCRIPTION
## What

Updates the README and English/Spanish docs so they match the current CLI, TOML, and Python API surface.

## Why

Several newer or changed options were either missing from the docs or documented with stale values, which made the public documentation drift from the actual behavior.

## Changes

- document `--check-script` in the README, English docs, and Spanish docs
- document `--diff` examples in the README and English/Spanish docs
- add `check-script = false` to TOML configuration examples
- update Python API signatures and examples to include the `check_script` parameter
- correct the documented sort value from `name` to `file_name`
- expand the usage guides in both languages to cover diff and script-complexity workflows
