### PR TITLE
feat: add --plain flag for machine-readable output

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ complexipy . --output-format json --output-format csv
 # Write a GitLab report to a deterministic path
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
+# Compare complexity against a git reference
+complexipy . --diff HEAD~1
+
+# Include module-level script complexity as <module>
+complexipy . --check-script
+
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -80,7 +86,7 @@ complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 from complexipy import file_complexity, code_complexity
 
 # Analyze a file
-result = file_complexity("app.py")
+result = file_complexity("app.py", check_script=True)
 print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
@@ -95,7 +101,7 @@ def complex_function(data):
                 process(item)
 """
 
-result = code_complexity(snippet)
+result = code_complexity(snippet, check_script=True)
 print(f"Complexity: {result.complexity}")
 ```
 
@@ -196,6 +202,7 @@ sort = "asc"
 exclude = []
 output-format = ["json", "sarif"]
 output = "reports/"
+check-script = false
 ```
 
 ```toml
@@ -213,6 +220,7 @@ sort = "asc"
 exclude = []
 output-format = ["json"]
 output = "complexipy-results.json"
+check-script = false
 ```
 
 Legacy TOML keys such as `output-json = true` and CLI flags such as
@@ -229,13 +237,14 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 | `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
 | `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
 | `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
-| `--sort <asc\|desc\|name>` | Sort results                                                                                                                                                     | `asc`   |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                               | `asc`   |
 | `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
 | `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
 | `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
 | `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                         | —       |
 | `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
 | `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`           | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
 | `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                       | `false` |
 | `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                        | `false` |
 | `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                     | `false` |
@@ -302,6 +311,17 @@ Net: 1 regressed, 1 improved, 1 new
 
 The diff is appended after the normal analysis output and does not affect the exit code. Requires `git` to be available and the analysed paths to be inside a git repository.
 
+### Script Complexity
+
+Use `--check-script` when you also want to score module-level control flow, not just functions:
+
+```bash
+# Report top-level script logic as <module>
+complexipy scripts/bootstrap.py --check-script
+```
+
+The same capability is available in the Python API via `check_script=True` on both `file_complexity()` and `code_complexity()`.
+
 ### Inline Ignores
 
 You can explicitly ignore a known complex function inline, similar to Ruff's `C901` ignores:
@@ -319,8 +339,8 @@ Place `# complexipy: ignore` on the function definition line (or the line immedi
 
 ```python
 # Core functions
-file_complexity(path: str) -> FileComplexity
-code_complexity(source: str) -> CodeComplexity
+file_complexity(path: str, check_script: bool = False) -> FileComplexity
+code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 
 # Return types
 FileComplexity:

--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Compare complexity against a git reference
 complexipy . --diff HEAD~1
-
-# Include module-level script complexity as <module>
-complexipy . --check-script
-
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -212,7 +208,6 @@ exclude = []
 check-script = false
 output-format = ["json", "sarif"]
 output = "reports/"
-check-script = false
 ```
 
 ```toml
@@ -231,7 +226,6 @@ exclude = []
 check-script = false
 output-format = ["json"]
 output = "complexipy-results.json"
-check-script = false
 ```
 
 Legacy TOML keys such as `output-json = true` and CLI flags such as
@@ -242,28 +236,28 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 ### CLI Options
 
-| Flag                            | Description                                                                                                                                                      | Default |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
-| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
-| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
-| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
-| `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
-| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
+| Flag                       | Description                                                                                                                                                      | Default |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--max-complexity-allowed` | Complexity threshold                                                                                                                                             | `15`    |
+| `--snapshot-create`        | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
+| `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
+| `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
 | `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                               | `asc`   |
-| `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
-| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                        | `false` |
-| `--version`                     | Show installed complexipy version and exit                                                                                                                       | -       |
-| `--top <n>`                     | Show only the `n` most complex functions, globally sorted by complexity descending                                                                               | —       |
-| `--plain`                       | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                    | `false` |
-| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                          | —       |
-| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
-| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
-| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
-| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
-| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
-| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
-| `--output-sarif`                | Deprecated alias for `--output-format sarif`          
+| `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
+| `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
+| `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
+| `--top <n>`                | Show only the `n` most complex functions, globally sorted by complexity descending                                                                               | —       |
+| `--plain`                  | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                    | `false` |
+| `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                          | —       |
+| `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
+| `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`           | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
+| `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
+| `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
+| `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
+| `--output-sarif`           | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -67,14 +67,20 @@ complexipy . --max-complexity-allowed 10
 # Save results to JSON/CSV
 complexipy . --output-format json --output-format csv
 
+# Show the top 5 most complex functions
+complexipy . --top 5
+
+# Emit plain text for scripting/AI agents
+complexipy . --plain
+
+# Include module-level script complexity as <module>
+complexipy . --check-script
+
 # Write a GitLab report to a deterministic path
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Compare complexity against a git reference
 complexipy . --diff HEAD~1
-
-# Include module-level script complexity as <module>
-complexipy . --check-script
 
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
@@ -200,9 +206,9 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
+check-script = false
 output-format = ["json", "sarif"]
 output = "reports/"
-check-script = false
 ```
 
 ```toml
@@ -218,37 +224,41 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
+check-script = false
 output-format = ["json"]
 output = "complexipy-results.json"
-check-script = false
 ```
 
 Legacy TOML keys such as `output-json = true` and CLI flags such as
 `--output-json` still work for now, but they are deprecated in favor of
 `output-format` and `--output-format`.
 
+`check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
+
 ### CLI Options
 
-| Flag                            | Description                                                                                                                                                      | Default |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
-| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
-| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
-| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
-| `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
-| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
-| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                     | `asc`   |
-| `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
-| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                        | `false` |
-| `--version`                     | Show installed complexipy version and exit                                                                                                                       | -       |
-| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                          | —       |
-| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
-| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
-| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
-| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
-| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
-| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
-| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
+| Flag                       | Description                                                                                                                                                      | Default |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--max-complexity-allowed` | Complexity threshold                                                                                                                                             | `15`    |
+| `--snapshot-create`        | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
+| `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
+| `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                               | `asc`   |
+| `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
+| `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
+| `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
+| `--top <n>`                | Show only the `n` most complex functions, globally sorted by complexity descending                                                                               | —       |
+| `--plain`                  | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                    | `false` |
+| `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                          | —       |
+| `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
+| `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`           | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
+| `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
+| `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
+| `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
+| `--output-sarif`           | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -229,26 +229,26 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 ### CLI Options
 
-| Flag                       | Description                                                                                                                                                      | Default |
-| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
-| `--max-complexity-allowed` | Complexity threshold                                                                                                                                             | `15`    |
-| `--snapshot-create`        | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
-| `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
-| `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
-| `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
-| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                               | `asc`   |
-| `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
-| `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
-| `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
-| `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                         | —       |
-| `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
-| `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
-| `--check-script`           | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
-| `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                       | `false` |
-| `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                        | `false` |
-| `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                     | `false` |
-| `--output-sarif`           | Deprecated alias for `--output-format sarif`                                                                                                                      | `false` |
+| Flag                            | Description                                                                                                                                                      | Default |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
+| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
+| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
+| `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                     | `asc`   |
+| `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
+| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                        | `false` |
+| `--version`                     | Show installed complexipy version and exit                                                                                                                       | -       |
+| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                          | —       |
+| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
+| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
+| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
+| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
+| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
+| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
 
 Example:
 

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -192,6 +192,12 @@ def main(
         "-sr",
         help="Output the results to a SARIF 2.1.0 file for use with GitHub Code Scanning and other SARIF-aware tools.",
     ),
+    top: Optional[int] = typer.Option(
+        None,
+        "--top",
+        "-t",
+        help="Show only the N most complex functions, sorted by complexity descending.",
+    ),
     plain: Optional[bool] = typer.Option(
         None,
         "--plain",
@@ -328,6 +334,7 @@ def main(
         active_snapshot_map,
         quiet,
         plain,
+        top,
     )
 
     snapshot_result = handle_snapshot(
@@ -385,6 +392,7 @@ def handle_display(
     active_snapshot_map: Optional[Dict],
     quiet: bool,
     plain: bool,
+    top: Optional[int] = None,
 ) -> bool:
     if files_complexities:
         previous_functions = remember_previous_functions(
@@ -396,16 +404,18 @@ def handle_display(
     if quiet:
         return has_success_functions(files_complexities, max_complexity_allowed)
 
+    effective_sort = Sort.desc if top is not None else sort
     has_success = output_summary(
         console,
         files_complexities,
         failed,
-        sort,
+        effective_sort,
         ignore_complexity,
         max_complexity_allowed,
         previous_functions,
         active_snapshot_map,
         plain,
+        top,
     )
     if not plain:
         if platform.system() == "Windows":

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -273,6 +273,9 @@ def main(
     if plain and quiet:
         raise typer.BadParameter("--plain and --quiet cannot be used together.")
 
+    if top is not None and top < 1:
+        raise typer.BadParameter("--top must be a positive integer.")
+
     handle_console_settings(color, quiet, plain)
 
     result: Tuple[List[FileComplexity], List[str]] = _complexipy.main(

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -317,34 +317,18 @@ def main(
         max_complexity_allowed,
     )
 
-    if files_complexities:
-        previous_functions = remember_previous_functions(
-            INVOCATION_PATH, paths, files_complexities
-        )
-    else:
-        previous_functions = None
-
-    if quiet:
-        has_success = has_success_functions(
-            files_complexities, max_complexity_allowed
-        )
-    else:
-        has_success = output_summary(
-            console,
-            files_complexities,
-            failed,
-            sort,
-            ignore_complexity,
-            max_complexity_allowed,
-            previous_functions,
-            active_snapshot_map,
-            plain,
-        )
-        if not plain:
-            if platform.system() == "Windows":
-                console.rule("Analysis completed!")
-            else:
-                console.rule(":tada: Analysis completed! :tada:")
+    has_success = handle_display(
+        console,
+        files_complexities,
+        paths,
+        failed,
+        sort,
+        ignore_complexity,
+        max_complexity_allowed,
+        active_snapshot_map,
+        quiet,
+        plain,
+    )
 
     snapshot_result = handle_snapshot(
         should_run_snapshot_watermark,
@@ -388,6 +372,47 @@ def handle_console_settings(
             console.rule("complexipy")
         else:
             console.rule(":octopus: complexipy")
+
+
+def handle_display(
+    console: Console,
+    files_complexities: List[FileComplexity],
+    paths: List[str],
+    failed: bool,
+    sort: Sort,
+    ignore_complexity: bool,
+    max_complexity_allowed: int,
+    active_snapshot_map: Optional[Dict],
+    quiet: bool,
+    plain: bool,
+) -> bool:
+    if files_complexities:
+        previous_functions = remember_previous_functions(
+            INVOCATION_PATH, paths, files_complexities
+        )
+    else:
+        previous_functions = None
+
+    if quiet:
+        return has_success_functions(files_complexities, max_complexity_allowed)
+
+    has_success = output_summary(
+        console,
+        files_complexities,
+        failed,
+        sort,
+        ignore_complexity,
+        max_complexity_allowed,
+        previous_functions,
+        active_snapshot_map,
+        plain,
+    )
+    if not plain:
+        if platform.system() == "Windows":
+            console.rule("Analysis completed!")
+        else:
+            console.rule(":tada: Analysis completed! :tada:")
+    return has_success
 
 
 def handle_results_storage(

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -192,6 +192,15 @@ def main(
         "-sr",
         help="Output the results to a SARIF 2.1.0 file for use with GitHub Code Scanning and other SARIF-aware tools.",
     ),
+    plain: Optional[bool] = typer.Option(
+        None,
+        "--plain",
+        help=(
+            "Use plain text output instead of rich formatting. "
+            "Each line is: <path> <function> <complexity> (space-separated). "
+            "Useful for AI agents and scripting. CLI-only flag (not supported in TOML)."
+        ),
+    ),
     check_script: Optional[bool] = typer.Option(
         None,
         "--check-script",
@@ -250,7 +259,15 @@ def main(
         check_script,
     )
 
-    handle_console_settings(color, quiet)
+    # --plain is intentionally CLI-only (not resolved via TOML) because it is
+    # a session-level display preference, not a project-wide default.
+    if plain is None:
+        plain = False
+
+    if plain and quiet:
+        raise typer.BadParameter("--plain and --quiet cannot be used together.")
+
+    handle_console_settings(color, quiet, plain)
 
     result: Tuple[List[FileComplexity], List[str]] = _complexipy.main(
         paths, quiet, exclude, check_script
@@ -321,11 +338,13 @@ def main(
             max_complexity_allowed,
             previous_functions,
             active_snapshot_map,
+            plain,
         )
-        if platform.system() == "Windows":
-            console.rule("Analysis completed!")
-        else:
-            console.rule(":tada: Analysis completed! :tada:")
+        if not plain:
+            if platform.system() == "Windows":
+                console.rule("Analysis completed!")
+            else:
+                console.rule(":tada: Analysis completed! :tada:")
 
     snapshot_result = handle_snapshot(
         should_run_snapshot_watermark,
@@ -352,8 +371,13 @@ def main(
         raise typer.Exit(code=1)
 
 
-def handle_console_settings(color: ColorTypes, quiet: bool):
+def handle_console_settings(
+    color: ColorTypes, quiet: bool, plain: bool = False
+):
     global console
+    if plain:
+        console = Console(color_system=None, highlight=False)
+        return
     if color == ColorTypes.no:
         console = Console(color_system=None)
     elif color == ColorTypes.yes:

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -116,9 +116,9 @@ def truncate_top_n(
 def output_file_entries(
     console: Console,
     file_entries: List[
-        dict[str, str | List[dict[str, str | int | bool | Tuple[str, str]]]]
+        Dict[str, str | List[Dict[str, str | int | bool | Tuple[str, str]]]]
     ],
-    failing_functions: dict[str, List[str]],
+    failing_functions: Dict[str, List[str]],
     ignore_complexity: bool,
     previous_functions: Optional[Dict[Tuple[str, str, str], int]],
     max_complexity: int,
@@ -160,7 +160,7 @@ def format_status_text(passed: bool) -> str:
 
 def output_delta_text(
     previous_functions: Optional[Dict[Tuple[str, str, str], int]],
-    function: dict[str, str | int | bool | Tuple[str, str]],
+    function: Dict[str, str | int | bool | Tuple[str, str]],
     max_complexity: int,
 ) -> str:
     delta_text = ""
@@ -211,21 +211,21 @@ def build_output_rows(
     sort: Sort,
     max_complexity: int,
     snapshot_map: Optional[Dict[Tuple[str, str, str], int]] = None,
-) -> tuple[
-    List[dict[str, str | List[dict[str, str | int | bool | Tuple[str, str]]]]],
-    dict[str, List[str]],
+) -> Tuple[
+    List[Dict[str, str | List[Dict[str, str | int | bool | Tuple[str, str]]]]],
+    Dict[str, List[str]],
     int,
 ]:
     file_entries: List[
-        dict[str, str | List[dict[str, str | int | bool | Tuple[str, str]]]]
+        Dict[str, str | List[Dict[str, str | int | bool | Tuple[str, str]]]]
     ] = []
-    failing_functions: dict[str, List[str]] = {}
+    failing_functions: Dict[str, List[str]] = {}
     total_functions = 0
 
     for file in files:
         sorted_functions = sort_functions(file.functions, sort)
         displayable_functions: List[
-            dict[str, str | int | bool | Tuple[str, str]]
+            Dict[str, str | int | bool | Tuple[str, str]]
         ] = []
 
         for function in sorted_functions:

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -100,6 +100,7 @@ def truncate_top_n(
             if not isinstance(function, str):
                 all_functions.append((str(entry["path"]), function))
 
+    all_functions.sort(key=lambda x: int(x[1]["complexity"]), reverse=True)
     top_functions = all_functions[:n]
 
     grouped: Dict[str, List[Dict[str, str | int | bool | Tuple[str, str]]]] = {}

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -30,6 +30,7 @@ def output_summary(
     previous_functions: Optional[Dict[Tuple[str, str, str], int]],
     snapshot_map: Optional[Dict[Tuple[str, str, str], int]] = None,
     plain: bool = False,
+    top: Optional[int] = None,
 ) -> bool:
     (
         file_entries,
@@ -39,6 +40,9 @@ def output_summary(
         files, failed_only, sort, max_complexity, snapshot_map
     )
     has_success = not failing_functions or ignore_complexity
+
+    if top is not None:
+        file_entries = truncate_top_n(file_entries, top)
 
     if plain:
         output_plain(console, file_entries)
@@ -80,6 +84,32 @@ def output_plain(
                 str(function["path"]), str(function["file_name"])
             )
             console.print(f"{path} {function['name']} {function['complexity']}")
+
+
+def truncate_top_n(
+    file_entries: List[
+        Dict[str, str | List[Dict[str, str | int | bool | Tuple[str, str]]]]
+    ],
+    n: int,
+) -> List[Dict[str, str | List[Dict[str, str | int | bool | Tuple[str, str]]]]]:
+    all_functions: List[
+        Tuple[str, Dict[str, str | int | bool | Tuple[str, str]]]
+    ] = []
+    for entry in file_entries:
+        for function in entry["functions"]:
+            if not isinstance(function, str):
+                all_functions.append((str(entry["path"]), function))
+
+    top_functions = all_functions[:n]
+
+    grouped: Dict[str, List[Dict[str, str | int | bool | Tuple[str, str]]]] = {}
+    for path, function in top_functions:
+        grouped.setdefault(path, []).append(function)
+
+    return [
+        {"path": path, "functions": functions}
+        for path, functions in grouped.items()
+    ]
 
 
 def output_file_entries(

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -29,6 +29,7 @@ def output_summary(
     max_complexity: int,
     previous_functions: Optional[Dict[Tuple[str, str, str], int]],
     snapshot_map: Optional[Dict[Tuple[str, str, str], int]] = None,
+    plain: bool = False,
 ) -> bool:
     (
         file_entries,
@@ -38,6 +39,10 @@ def output_summary(
         files, failed_only, sort, max_complexity, snapshot_map
     )
     has_success = not failing_functions or ignore_complexity
+
+    if plain:
+        output_plain(console, file_entries)
+        return has_success
 
     if failed_only and not file_entries:
         console.print(
@@ -59,6 +64,22 @@ def output_summary(
             max_complexity,
         )
     return has_success
+
+
+def output_plain(
+    console: Console,
+    file_entries: List[
+        Dict[str, str | List[Dict[str, str | int | bool | Tuple[str, str]]]]
+    ],
+) -> None:
+    for entry in file_entries:
+        for function in entry["functions"]:
+            if isinstance(function, str):
+                continue
+            path = normalize_path(
+                str(function["path"]), str(function["file_name"])
+            )
+            console.print(f"{path} {function['name']} {function['complexity']}")
 
 
 def output_file_entries(

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -103,14 +103,20 @@ def truncate_top_n(
     all_functions.sort(key=lambda x: int(x[1]["complexity"]), reverse=True)
     top_functions = all_functions[:n]
 
-    grouped: Dict[str, List[Dict[str, str | int | bool | Tuple[str, str]]]] = {}
+    # Preserve global descending order across files: emit a new entry whenever
+    # the path changes, rather than regrouping (which would collapse runs and
+    # lose the global rank order for multi-file results).
+    result: List[
+        Dict[str, str | List[Dict[str, str | int | bool | Tuple[str, str]]]]
+    ] = []
     for path, function in top_functions:
-        grouped.setdefault(path, []).append(function)
-
-    return [
-        {"path": path, "functions": functions}
-        for path, functions in grouped.items()
-    ]
+        if result and result[-1]["path"] == path:
+            functions_list = result[-1]["functions"]
+            if isinstance(functions_list, list):
+                functions_list.append(function)
+        else:
+            result.append({"path": path, "functions": [function]})
+    return result
 
 
 def output_file_entries(

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -67,14 +67,20 @@ complexipy . --max-complexity-allowed 10
 # Guarda los resultados en JSON/CSV
 complexipy . --output-format json --output-format csv
 
+# Muestra las 5 funciones más complejas
+complexipy . --top 5
+
+# Emite texto plano para scripts o agentes de IA
+complexipy . --plain
+
+# Incluye la complejidad del código a nivel de módulo como <module>
+complexipy . --check-script
+
 # Guarda un reporte de GitLab en una ruta determinista
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Compara la complejidad contra una referencia de git
 complexipy . --diff HEAD~1
-
-# Incluye la complejidad del script a nivel módulo como <module>
-complexipy . --check-script
 
 # Analiza el directorio actual excluyendo ciertos archivos
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
@@ -164,9 +170,9 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
+check-script = false
 output-format = ["json", "gitlab"]
 output = "reports/"
-check-script = false
 ```
 
 ```toml
@@ -182,37 +188,41 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
+check-script = false
 output-format = ["json"]
 output = "complexipy-results.json"
-check-script = false
 ```
 
 Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 `--output-json` todavía funcionan por ahora, pero están deprecadas a favor de
 `output-format` y `--output-format`.
 
+`check-script` está soportado en TOML. `--top` y `--plain` son flags solo de CLI.
+
 ### Opciones de CLI
 
-| Opción                          | Descripción                                                                                                                                                                                                 | Predeterminado |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `--exclude`                     | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
-| `--max-complexity-allowed`      | Umbral de complejidad                                                                                                                                                                                       | `15`           |
-| `--snapshot-create`             | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
-| `--snapshot-ignore`             | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
-| `--failed`                      | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
-| `--color <auto\|yes\|no>`       | Usa color                                                                                                                                                                                                   | `auto`         |
-| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                       | `asc`          |
-| `--quiet`                       | Suprime la salida                                                                                                                                                                                           | `false`        |
-| `--ignore-complexity`           | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
-| `--version`                     | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
-| `--output-format <format>`      | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                                | —              |
-| `--output <path>`               | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                          | —              |
-| `--diff <ref>`                  | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                 | —              |
-| `--check-script`                | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
-| `--output-json`                 | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
-| `--output-csv`                  | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
-| `--output-gitlab`               | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
-| `--output-sarif`                | Alias deprecado de `--output-format sarif`                                                                                                                                                                  | `false`        |
+| Opción                     | Descripción                                                                                                                                                                                                 | Predeterminado |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `--exclude`                | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
+| `--max-complexity-allowed` | Umbral de complejidad                                                                                                                                                                                       | `15`           |
+| `--snapshot-create`        | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
+| `--snapshot-ignore`        | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
+| `--failed`                 | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
+| `--color <auto\|yes\|no>`  | Usa color                                                                                                                                                                                                   | `auto`         |
+| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                   | `asc`          |
+| `--quiet`                  | Suprime la salida                                                                                                                                                                                           | `false`        |
+| `--ignore-complexity`      | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
+| `--version`                | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
+| `--top <n>`                | Muestra solo las `n` funciones más complejas, ordenadas globalmente por complejidad descendente                                                                                                             | —              |
+| `--plain`                  | Emite líneas de texto plano como `<path> <function> <complexity>`. No se puede combinar con `--quiet`                                                                                                      | `false`        |
+| `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                                | —              |
+| `--output <path>`          | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                          | —              |
+| `--diff <ref>`             | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                 | —              |
+| `--check-script`           | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
+| `--output-json`            | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
+| `--output-csv`             | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
+| `--output-gitlab`          | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
+| `--output-sarif`           | Alias deprecado de `--output-format sarif`                                                                                                                                                                  | `false`        |
 
 Ejemplo:
 

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -70,6 +70,12 @@ complexipy . --output-format json --output-format csv
 # Guarda un reporte de GitLab en una ruta determinista
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
+# Compara la complejidad contra una referencia de git
+complexipy . --diff HEAD~1
+
+# Incluye la complejidad del script a nivel módulo como <module>
+complexipy . --check-script
+
 # Analiza el directorio actual excluyendo ciertos archivos
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -80,7 +86,7 @@ complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 from complexipy import file_complexity, code_complexity
 
 # Analiza un archivo
-result = file_complexity("app.py")
+result = file_complexity("app.py", check_script=True)
 print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
@@ -95,7 +101,7 @@ def complex_function(data):
                 process(item)
 """
 
-result = code_complexity(snippet)
+result = code_complexity(snippet, check_script=True)
 print(f"Complexity: {result.complexity}")
 ```
 
@@ -160,6 +166,7 @@ sort = "asc"
 exclude = []
 output-format = ["json", "gitlab"]
 output = "reports/"
+check-script = false
 ```
 
 ```toml
@@ -177,6 +184,7 @@ sort = "asc"
 exclude = []
 output-format = ["json"]
 output = "complexipy-results.json"
+check-script = false
 ```
 
 Las claves TOML heredadas como `output-json = true` y las flags de CLI como
@@ -193,12 +201,14 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 | `--snapshot-ignore`        | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
 | `--failed`                 | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
 | `--color <auto\|yes\|no>`  | Usa color                                                                                                                                                                                                   | `auto`         |
-| `--sort <asc\|desc\|name>` | Ordena los resultados                                                                                                                                                                                       | `asc`          |
+| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                 | `asc`          |
 | `--quiet`                  | Suprime la salida                                                                                                                                                                                           | `false`        |
 | `--ignore-complexity`      | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
 | `--version`                | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
 | `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                              | —              |
 | `--output <path>`          | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                        | —              |
+| `--diff <ref>`             | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                | —              |
+| `--check-script`           | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
 | `--output-json`            | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
 | `--output-csv`             | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
 | `--output-gitlab`          | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
@@ -236,6 +246,30 @@ El archivo de snapshot solo almacena las funciones cuya complejidad supera el um
 
 Usa `--snapshot-ignore` si necesitas omitir temporalmente el control de snapshot (por ejemplo, durante una refactorización o al regenerar la línea base).
 
+### Diff de Complejidad
+
+Compara la complejidad contra cualquier referencia de git para ver si una rama o commit mejoró o empeoró el código:
+
+```bash
+# Compara el working tree con el commit anterior
+complexipy . --diff HEAD~1
+
+# Compara contra una rama nombrada
+complexipy . --diff main
+```
+
+El diff se añade después de la salida normal del análisis y no afecta el código de salida. Requiere que `git` esté disponible y que las rutas analizadas estén dentro de un repositorio git.
+
+### Complejidad de Script
+
+Usa `--check-script` cuando también quieras medir el flujo de control a nivel de módulo, no solo las funciones:
+
+```bash
+complexipy scripts/bootstrap.py --check-script
+```
+
+La misma capacidad está disponible en la API de Python mediante `check_script=True` tanto en `file_complexity()` como en `code_complexity()`.
+
 ### Ignorar en Línea
 
 Puedes ignorar explícitamente una función compleja conocida en línea usando `# complexipy: ignore`:
@@ -255,8 +289,8 @@ Coloca `# complexipy: ignore` en la línea de definición de la función (o en l
 
 ```python
 # Funciones principales
-file_complexity(path: str) -> FileComplexity
-code_complexity(source: str) -> CodeComplexity
+file_complexity(path: str, check_script: bool = False) -> FileComplexity
+code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 
 # Tipos de retorno
 FileComplexity:

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -81,10 +81,6 @@ complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Compara la complejidad contra una referencia de git
 complexipy . --diff HEAD~1
-
-# Incluye la complejidad del script a nivel módulo como <module>
-complexipy . --check-script
-
 # Analiza el directorio actual excluyendo ciertos archivos
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -176,7 +172,6 @@ exclude = []
 check-script = false
 output-format = ["json", "gitlab"]
 output = "reports/"
-check-script = false
 ```
 
 ```toml
@@ -195,7 +190,6 @@ exclude = []
 check-script = false
 output-format = ["json"]
 output = "complexipy-results.json"
-check-script = false
 ```
 
 Las claves TOML heredadas como `output-json = true` y las flags de CLI como
@@ -206,28 +200,28 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 
 ### Opciones de CLI
 
-| Opción                          | Descripción                                                                                                                                                                                                 | Predeterminado |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `--exclude`                     | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
-| `--max-complexity-allowed`      | Umbral de complejidad                                                                                                                                                                                       | `15`           |
-| `--snapshot-create`             | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
-| `--snapshot-ignore`             | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
-| `--failed`                      | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
-| `--color <auto\|yes\|no>`       | Usa color                                                                                                                                                                                                   | `auto`         |
+| Opción                     | Descripción                                                                                                                                                                                                 | Predeterminado |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `--exclude`                | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
+| `--max-complexity-allowed` | Umbral de complejidad                                                                                                                                                                                       | `15`           |
+| `--snapshot-create`        | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
+| `--snapshot-ignore`        | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
+| `--failed`                 | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
+| `--color <auto\|yes\|no>`  | Usa color                                                                                                                                                                                                   | `auto`         |
 | `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                   | `asc`          |
-| `--quiet`                       | Suprime la salida                                                                                                                                                                                           | `false`        |
-| `--ignore-complexity`           | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
-| `--version`                     | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
-| `--top <n>`                     | Muestra solo las `n` funciones más complejas, ordenadas globalmente por complejidad descendente                                                                                                             | —              |
-| `--plain`                       | Emite líneas de texto plano como `<path> <function> <complexity>`. No se puede combinar con `--quiet`                                                                                                      | `false`        |
-| `--output-format <format>`      | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                                | —              |
-| `--output <path>`               | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                          | —              |
-| `--diff <ref>`                  | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                 | —              |
-| `--check-script`                | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
-| `--output-json`                 | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
-| `--output-csv`                  | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
-| `--output-gitlab`               | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
-| `--output-sarif`                | Alias deprecado de `--output-format sarif`            
+| `--quiet`                  | Suprime la salida                                                                                                                                                                                           | `false`        |
+| `--ignore-complexity`      | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
+| `--version`                | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
+| `--top <n>`                | Muestra solo las `n` funciones más complejas, ordenadas globalmente por complejidad descendente                                                                                                             | —              |
+| `--plain`                  | Emite líneas de texto plano como `<path> <function> <complexity>`. No se puede combinar con `--quiet`                                                                                                      | `false`        |
+| `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                                | —              |
+| `--output <path>`          | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                          | —              |
+| `--diff <ref>`             | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                 | —              |
+| `--check-script`           | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
+| `--output-json`            | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
+| `--output-csv`             | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
+| `--output-gitlab`          | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
+| `--output-sarif`           | Alias deprecado de `--output-format sarif`                                                                                                                                                                  | `false`        |
 
 Ejemplo:
 

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -113,9 +113,9 @@ print(f"Complexity: {result.complexity}")
 ```yaml
 - uses: rohaquinlop/complexipy-action@v2
   with:
-    paths: .
-    max_complexity_allowed: 10
-    output_format: json
+      paths: .
+      max_complexity_allowed: 10
+      output_format: json
 ```
 
 </details>
@@ -125,10 +125,10 @@ print(f"Complexity: {result.complexity}")
 
 ```yaml
 repos:
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v4.2.0
-    hooks:
-      - id: complexipy
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v4.2.0
+      hooks:
+          - id: complexipy
 ```
 
 </details>
@@ -193,26 +193,26 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 
 ### Opciones de CLI
 
-| Opción                     | Descripción                                                                                                                                                                                                 | Predeterminado |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `--exclude`                | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
-| `--max-complexity-allowed` | Umbral de complejidad                                                                                                                                                                                       | `15`           |
-| `--snapshot-create`        | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
-| `--snapshot-ignore`        | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
-| `--failed`                 | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
-| `--color <auto\|yes\|no>`  | Usa color                                                                                                                                                                                                   | `auto`         |
-| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                 | `asc`          |
-| `--quiet`                  | Suprime la salida                                                                                                                                                                                           | `false`        |
-| `--ignore-complexity`      | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
-| `--version`                | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
-| `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                              | —              |
-| `--output <path>`          | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                        | —              |
-| `--diff <ref>`             | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                | —              |
-| `--check-script`           | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
-| `--output-json`            | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
-| `--output-csv`             | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
-| `--output-gitlab`          | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
-| `--output-sarif`           | Alias deprecado de `--output-format sarif`                                                                                                                                                                  | `false`        |
+| Opción                          | Descripción                                                                                                                                                                                                 | Predeterminado |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `--exclude`                     | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
+| `--max-complexity-allowed`      | Umbral de complejidad                                                                                                                                                                                       | `15`           |
+| `--snapshot-create`             | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
+| `--snapshot-ignore`             | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
+| `--failed`                      | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
+| `--color <auto\|yes\|no>`       | Usa color                                                                                                                                                                                                   | `auto`         |
+| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                       | `asc`          |
+| `--quiet`                       | Suprime la salida                                                                                                                                                                                           | `false`        |
+| `--ignore-complexity`           | No termina con error al superar el umbral                                                                                                                                                                   | `false`        |
+| `--version`                     | Muestra la versión instalada de complexipy y sale                                                                                                                                                           | -              |
+| `--output-format <format>`      | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                                | —              |
+| `--output <path>`               | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                          | —              |
+| `--diff <ref>`                  | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                                 | —              |
+| `--check-script`                | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                        | `false`        |
+| `--output-json`                 | Alias deprecado de `--output-format json`                                                                                                                                                                   | `false`        |
+| `--output-csv`                  | Alias deprecado de `--output-format csv`                                                                                                                                                                    | `false`        |
+| `--output-gitlab`               | Alias deprecado de `--output-format gitlab`                                                                                                                                                                 | `false`        |
+| `--output-sarif`                | Alias deprecado de `--output-format sarif`                                                                                                                                                                  | `false`        |
 
 Ejemplo:
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -96,7 +96,11 @@ complexipy . --exclude tests --exclude migrations --exclude build
 complexipy . --exclude src/legacy/old_code.py
 ```
 
-!!! note "Cómo funciona la exclusión" - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta) - Las entradas inexistentes se ignoran silenciosamente - Las rutas son relativas a cada ruta raíz proporcionada
+<!-- prettier-ignore -->
+!!! note "Cómo funciona la exclusión"
+    - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta)
+    - Las entradas inexistentes se ignoran silenciosamente
+    - Las rutas son relativas a cada ruta raíz proporcionada
 
 ### Formatos de Salida
 
@@ -214,7 +218,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
 
 <!-- prettier-ignore -->
 === "complexipy.toml"
-`toml
+    ```toml
     paths = ["src", "tests"]
     max-complexity-allowed = 10
     exclude = ["migrations", "build"]
@@ -228,26 +232,27 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     output-format = ["json", "gitlab"]
     output = "reports/"
     check-script = false
-    `
+    ```
 
 <!-- prettier-ignore -->
 === "pyproject.toml"
-`toml
+    ```toml
     [tool.complexipy]
     paths = ["src", "tests"]
     max-complexity-allowed = 10
     exclude = ["migrations", "build"]
     failed = true
     sort = "desc"
-    `
+    check-script = true
+    ```
 
 <!-- prettier-ignore -->
 === ".complexipy.toml"
-`toml
+    ```toml
     # Archivo de configuración oculto para ajustes específicos del equipo
     max-complexity-allowed = 15
     exclude = ["venv", ".venv", "node_modules"]
-    `
+    ```
 
 `check-script` está soportado en TOML. `--top` y `--plain` son flags solo de CLI.
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -66,7 +66,7 @@ Ordenar por puntuación de complejidad:
 ```bash
 complexipy . --sort asc   # Ascendente (predeterminado)
 complexipy . --sort desc  # Descendente
-complexipy . --sort name  # Alfabéticamente por nombre de función
+complexipy . --sort file_name  # Alfabéticamente por nombre de archivo
 ```
 
 ### Excluir Archivos y Directorios
@@ -113,6 +113,27 @@ complexipy . --output-format json --output-format sarif --output reports/
 Las flags heredadas como `--output-json` y las claves TOML como
 `output-json = true` siguen funcionando como alias deprecados por un ciclo de
 release.
+
+### Diff de Complejidad
+
+Compara los resultados actuales contra cualquier referencia de git:
+
+```bash
+complexipy . --diff HEAD~1
+complexipy . --diff main
+complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
+```
+
+El diff se añade después de la salida normal del análisis y no afecta el código de salida. Esto requiere `git` y una ruta dentro de un repositorio.
+
+### Complejidad de Script
+
+Reporta el flujo de control a nivel módulo como una entrada sintética `<module>`:
+
+```bash
+complexipy scripts/bootstrap.py --check-script
+complexipy . --check-script --failed
+```
 
 **Estructura de Salida JSON:**
 ```json
@@ -172,6 +193,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     sort = "asc"
     output-format = ["json", "gitlab"]
     output = "reports/"
+    check-script = false
     ```
 
 === "pyproject.toml"
@@ -199,7 +221,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
 from complexipy import file_complexity
 
 # Analizar un archivo
-result = file_complexity("src/main.py")
+result = file_complexity("src/main.py", check_script=True)
 
 print(f"Total complexity: {result.complexity}")
 print(f"File path: {result.path}")
@@ -227,7 +249,7 @@ def calculate_discount(price, customer):
     return price
 """
 
-result = code_complexity(code)
+result = code_complexity(code, check_script=True)
 print(f"Complexity: {result.complexity}")
 
 for func in result.functions:

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -4,16 +4,19 @@ Esta guía cubre todo lo que necesitas saber para usar complexipy de manera efec
 
 ## Instalación
 
+<!-- prettier-ignore -->
 === "pip"
     ```bash
     pip install complexipy
     ```
 
+<!-- prettier-ignore -->
 === "uv"
     ```bash
     uv add complexipy
     ```
 
+<!-- prettier-ignore -->
 === "poetry"
     ```bash
     poetry add complexipy
@@ -53,6 +56,15 @@ Mostrar solo las funciones que superen el umbral:
 complexipy . --failed
 ```
 
+Mostrar solo las N funciones más complejas entre todos los archivos analizados:
+
+```bash
+complexipy . --top 10
+```
+
+Cuando se usa `--top`, los resultados se reordenan globalmente por complejidad
+descendente antes de truncarse.
+
 Suprimir toda la salida (útil para pipelines de CI):
 
 ```bash
@@ -84,7 +96,11 @@ complexipy . --exclude tests --exclude migrations --exclude build
 complexipy . --exclude src/legacy/old_code.py
 ```
 
-!!! note "Cómo funciona la exclusión" - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta) - Las entradas inexistentes se ignoran silenciosamente - Las rutas son relativas a cada ruta raíz proporcionada
+<!-- prettier-ignore -->
+!!! note "Cómo funciona la exclusión"
+    - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta)
+    - Las entradas inexistentes se ignoran silenciosamente
+    - Las rutas son relativas a cada ruta raíz proporcionada
 
 ### Formatos de Salida
 
@@ -121,17 +137,40 @@ complexipy . --diff main
 complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
 ```
 
-El diff se añade después de la salida normal del análisis y no afecta el código de salida. Esto requiere `git` y una ruta dentro de un repositorio.
+El diff se añade después de la salida normal del análisis y no afecta el código
+de salida. Esto requiere `git` y una ruta dentro de un repositorio.
 
-### Complejidad de Script
+### Salida en Texto Plano
 
-Reporta el flujo de control a nivel módulo como una entrada sintética `<module>`:
+Usa la salida en texto plano cuando necesites una línea legible por máquina por
+función:
 
 ```bash
-complexipy scripts/bootstrap.py --check-script
-complexipy . --check-script --failed
+complexipy . --plain
+complexipy . --plain --top 5
+complexipy . --plain --failed -mx 10
 ```
 
+Cada línea se emite con este formato:
+
+```text
+<path> <function> <complexity>
+```
+
+`--plain` es solo para CLI y no se puede combinar con `--quiet`.
+
+### Complejidad de Script a Nivel de Módulo
+
+Usa `--check-script` para incluir el código a nivel de módulo en los resultados
+como `<module>`:
+
+```bash
+complexipy path/to/script.py --check-script
+complexipy path/to/script.py --check-script -mx 5
+```
+
+Esto es útil para scripts con flujo de control complejo en el nivel superior,
+fuera de las funciones.
 **Estructura de Salida JSON:**
 
 ```json
@@ -177,8 +216,9 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
 
 ### Configuraciones de Ejemplo
 
+<!-- prettier-ignore -->
 === "complexipy.toml"
-`toml
+    ```toml
     paths = ["src", "tests"]
     max-complexity-allowed = 10
     exclude = ["migrations", "build"]
@@ -192,24 +232,29 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     output-format = ["json", "gitlab"]
     output = "reports/"
     check-script = false
-    `
+    ```
 
+<!-- prettier-ignore -->
 === "pyproject.toml"
-`toml
+    ```toml
     [tool.complexipy]
     paths = ["src", "tests"]
     max-complexity-allowed = 10
     exclude = ["migrations", "build"]
     failed = true
     sort = "desc"
-    `
+    check-script = true
+    ```
 
+<!-- prettier-ignore -->
 === ".complexipy.toml"
-`toml
+    ```toml
     # Archivo de configuración oculto para ajustes específicos del equipo
     max-complexity-allowed = 15
     exclude = ["venv", ".venv", "node_modules"]
-    `
+    ```
+
+`check-script` está soportado en TOML. `--top` y `--plain` son flags solo de CLI.
 
 ## API de Python
 
@@ -453,6 +498,7 @@ def complex_function():
     pass
 ```
 
+<!-- prettier-ignore -->
 !!! note "Sintaxis Obsoleta"
     La sintaxis `# noqa: complexipy` está obsoleta y será eliminada en una versión futura.
     Por favor, migra a `# complexipy: ignore` en su lugar.
@@ -461,6 +507,7 @@ def complex_function():
     que flake8 no reconoce, lo que eliminaría silenciosamente tus supresiones de complexipy.
     La nueva sintaxis evita este conflicto por completo.
 
+<!-- prettier-ignore -->
 !!! warning "Usar con Moderación"
     Los ignorados en línea deben ser temporales. Documenta por qué la complejidad es necesaria y rastrea la deuda técnica.
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -84,10 +84,7 @@ complexipy . --exclude tests --exclude migrations --exclude build
 complexipy . --exclude src/legacy/old_code.py
 ```
 
-!!! note "Cómo funciona la exclusión"
-    - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta)
-    - Las entradas inexistentes se ignoran silenciosamente
-    - Las rutas son relativas a cada ruta raíz proporcionada
+!!! note "Cómo funciona la exclusión" - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta) - Las entradas inexistentes se ignoran silenciosamente - Las rutas son relativas a cada ruta raíz proporcionada
 
 ### Formatos de Salida
 
@@ -136,23 +133,24 @@ complexipy . --check-script --failed
 ```
 
 **Estructura de Salida JSON:**
+
 ```json
 {
-  "files": [
-    {
-      "path": "src/main.py",
-      "complexity": 42,
-      "functions": [
+    "files": [
         {
-          "name": "process_data",
-          "complexity": 18,
-          "line_start": 10,
-          "line_end": 45
+            "path": "src/main.py",
+            "complexity": 42,
+            "functions": [
+                {
+                    "name": "process_data",
+                    "complexity": 18,
+                    "line_start": 10,
+                    "line_end": 45
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "total_complexity": 42
+    ],
+    "total_complexity": 42
 }
 ```
 
@@ -180,7 +178,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
 ### Configuraciones de Ejemplo
 
 === "complexipy.toml"
-    ```toml
+`toml
     paths = ["src", "tests"]
     max-complexity-allowed = 10
     exclude = ["migrations", "build"]
@@ -194,24 +192,24 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     output-format = ["json", "gitlab"]
     output = "reports/"
     check-script = false
-    ```
+    `
 
 === "pyproject.toml"
-    ```toml
+`toml
     [tool.complexipy]
     paths = ["src", "tests"]
     max-complexity-allowed = 10
     exclude = ["migrations", "build"]
     failed = true
     sort = "desc"
-    ```
+    `
 
 === ".complexipy.toml"
-    ```toml
+`toml
     # Archivo de configuración oculto para ajustes específicos del equipo
     max-complexity-allowed = 15
     exclude = ["venv", ".venv", "node_modules"]
-    ```
+    `
 
 ## API de Python
 
@@ -389,16 +387,16 @@ name: Complexity Check
 on: [push, pull_request]
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install complexipy
-        run: pip install complexipy
+            - name: Install complexipy
+              run: pip install complexipy
 
-      - name: Check complexity
-        run: complexipy . --max-complexity-allowed 15
+            - name: Check complexity
+              run: complexipy . --max-complexity-allowed 15
 ```
 
 El archivo de snapshot (`complexipy-snapshot.json`) debería ser commiteado al control de versiones.
@@ -412,6 +410,7 @@ complexipy . --snapshot-ignore
 ```
 
 Úsalo al:
+
 - Refactorizar múltiples archivos a la vez
 - Regenerar la línea base
 - Probar diferentes umbrales
@@ -420,15 +419,15 @@ complexipy . --snapshot-ignore
 
 ```json
 {
-  "version": "1.0",
-  "threshold": 15,
-  "functions": {
-    "src/legacy.py::old_function": {
-      "complexity": 23,
-      "line_start": 10,
-      "line_end": 50
+    "version": "1.0",
+    "threshold": 15,
+    "functions": {
+        "src/legacy.py::old_function": {
+            "complexity": 23,
+            "line_start": 10,
+            "line_end": 50
+        }
     }
-  }
 }
 ```
 
@@ -474,9 +473,9 @@ Usa la acción oficial:
 ```yaml
 - uses: rohaquinlop/complexipy-action@v2
   with:
-    paths: src tests
-    max_complexity_allowed: 15
-    output_json: true
+      paths: src tests
+      max_complexity_allowed: 15
+      output_json: true
 ```
 
 O ejecuta directamente:
@@ -484,8 +483,8 @@ O ejecuta directamente:
 ```yaml
 - name: Check complexity
   run: |
-    pip install complexipy
-    complexipy . --max-complexity-allowed 15
+      pip install complexipy
+      complexipy . --max-complexity-allowed 15
 ```
 
 ### Hook de Pre-commit
@@ -494,31 +493,31 @@ Agrega a `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v4.2.0
-    hooks:
-      - id: complexipy
-        args: [--max-complexity-allowed=15]
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v4.2.0
+      hooks:
+          - id: complexipy
+            args: [--max-complexity-allowed=15]
 ```
 
 ### GitLab CI
 
 ```yaml
 .complexipy_code_quality:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
-  artifacts:
-    when: always
-    reports:
-      codequality: complexipy-code-quality.json
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
+    artifacts:
+        when: always
+        reports:
+            codequality: complexipy-code-quality.json
 
 complexity:
-  extends: .complexipy_code_quality
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    extends: .complexipy_code_quality
+    rules:
+        - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
 Usa `--ignore-complexity` cuando tu objetivo principal sea publicar el reporte aunque existan violaciones. GitLab seguirá mostrando los hallazgos en el widget del merge request y en la interfaz del pipeline.
@@ -527,20 +526,20 @@ Si además quieres que el job falle cuando se supere el umbral, separa el flujo 
 
 ```yaml
 complexity_check:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --max-complexity-allowed 15
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --max-complexity-allowed 15
 
 complexity_report:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
-  artifacts:
-    when: always
-    reports:
-      codequality: complexipy-code-quality.json
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
+    artifacts:
+        when: always
+        reports:
+            codequality: complexipy-code-quality.json
 ```
 
 ## Integración con VS Code

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,12 @@ complexipy . --output-format json --output-format csv
 # Save a GitLab report to a deterministic path
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
+# Compare complexity against a git reference
+complexipy . --diff HEAD~1
+
+# Include module-level script complexity as <module>
+complexipy . --check-script
+
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -79,7 +85,7 @@ complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 from complexipy import file_complexity, code_complexity
 
 # Analyze a file
-result = file_complexity("app.py")
+result = file_complexity("app.py", check_script=True)
 print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
@@ -94,7 +100,7 @@ def complex_function(data):
                 process(item)
 """
 
-result = code_complexity(snippet)
+result = code_complexity(snippet, check_script=True)
 print(f"Complexity: {result.complexity}")
 ```
 
@@ -159,6 +165,7 @@ sort = "asc"
 exclude = []
 output-format = ["json", "gitlab"]
 output = "reports/"
+check-script = false
 ```
 
 ```toml
@@ -176,6 +183,7 @@ sort = "asc"
 exclude = []
 output-format = ["json"]
 output = "complexipy-results.json"
+check-script = false
 ```
 
 Legacy TOML keys such as `output-json = true` and CLI flags such as
@@ -192,12 +200,14 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 | `--snapshot-ignore` | Skip comparing against the snapshot even if it exists | `false` |
 | `--failed` | Show only functions above the complexity threshold | `false` |
 | `--color <auto\|yes\|no>` | Use color | `auto` |
-| `--sort <asc\|desc\|name>` | Sort results | `asc` |
+| `--sort <asc\|desc\|file_name>` | Sort results | `asc` |
 | `--quiet` | Suppress output | `false` |
 | `--ignore-complexity` | Don't exit with error on threshold breach | `false` |
 | `--version` | Show installed complexipy version and exit | - |
 | `--output-format <format>` | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`) | — |
 | `--output <path>` | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats | — |
+| `--diff <ref>` | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`) | — |
+| `--check-script` | Report module-level (script) complexity as a synthetic `<module>` entry | `false` |
 | `--output-json` | Deprecated alias for `--output-format json` | `false` |
 | `--output-csv` | Deprecated alias for `--output-format csv` | `false` |
 | `--output-gitlab` | Deprecated alias for `--output-format gitlab` | `false` |
@@ -235,6 +245,30 @@ The snapshot file only stores functions whose complexity exceeds the configured 
 
 Use `--snapshot-ignore` if you need to temporarily bypass the snapshot gate (for example during a refactor or while regenerating the baseline).
 
+### Complexity Diff
+
+Compare complexity against any git reference to see whether a branch or commit made things better or worse:
+
+```bash
+# Compare the working tree against the previous commit
+complexipy . --diff HEAD~1
+
+# Compare against a named branch
+complexipy . --diff main
+```
+
+The diff is appended after the normal analysis output and does not affect the exit code. Requires `git` to be available and the analysed paths to be inside a git repository.
+
+### Script Complexity
+
+Use `--check-script` when you also want to score module-level control flow, not just functions:
+
+```bash
+complexipy scripts/bootstrap.py --check-script
+```
+
+The same capability is available in the Python API via `check_script=True` on both `file_complexity()` and `code_complexity()`.
+
 ### Inline Ignores
 
 You can explicitly ignore a known complex function inline using `# complexipy: ignore`:
@@ -254,8 +288,8 @@ Place `# complexipy: ignore` on the function definition line (or the line immedi
 
 ```python
 # Core functions
-file_complexity(path: str) -> FileComplexity
-code_complexity(source: str) -> CodeComplexity
+file_complexity(path: str, check_script: bool = False) -> FileComplexity
+code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 
 # Return types
 FileComplexity:

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,10 +81,6 @@ complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Compare complexity against a git reference
 complexipy . --diff HEAD~1
-
-# Include module-level script complexity as <module>
-complexipy . --check-script
-
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
 ```
@@ -176,7 +172,6 @@ exclude = []
 check-script = false
 output-format = ["json", "gitlab"]
 output = "reports/"
-check-script = false
 ```
 
 ```toml
@@ -195,7 +190,6 @@ exclude = []
 check-script = false
 output-format = ["json"]
 output = "complexipy-results.json"
-check-script = false
 ```
 
 Legacy TOML keys such as `output-json = true` and CLI flags such as
@@ -206,28 +200,28 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 ### CLI Options
 
-| Flag                            | Description                                                                                                                                                      | Default |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
-| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
-| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
-| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
-| `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
-| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
+| Flag                       | Description                                                                                                                                                      | Default |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--max-complexity-allowed` | Complexity threshold                                                                                                                                             | `15`    |
+| `--snapshot-create`        | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
+| `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
+| `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
 | `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                 | `asc`   |
-| `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
-| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                        | `false` |
-| `--version`                     | Show installed complexipy version and exit                                                                                                                       | -       |
-| `--top <n>`                     | Show only the `n` most complex functions, globally sorted by complexity descending                                                                               | —       |
-| `--plain`                       | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                    | `false` |
-| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                 | —       |
-| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
-| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
-| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
-| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
-| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
-| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
-| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
+| `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
+| `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
+| `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
+| `--top <n>`                | Show only the `n` most complex functions, globally sorted by complexity descending                                                                               | —       |
+| `--plain`                  | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                    | `false` |
+| `--output-format <format>` | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                 | —       |
+| `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
+| `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`           | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
+| `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
+| `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
+| `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
+| `--output-sarif`           | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
 
 Example:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@
 Unlike traditional metrics like cyclomatic complexity, cognitive complexity accounts for nesting depth and control flow patterns that affect human comprehension. Inspired by [G. Ann Campbell's research](https://www.sonarsource.com/resources/cognitive-complexity/) at SonarSource, complexipy provides a fast, accurate implementation for Python.
 
 **Key benefits:**
+
 - **Human-focused** - Penalizes nesting, flow breaks, and human-unfriendly logic
 - **Actionable insights** - Identifies genuinely hard-to-maintain code
 - **Different from cyclomatic** - Measures readability while cyclomatic measures structural, testing, and branch density
@@ -112,9 +113,9 @@ print(f"Complexity: {result.complexity}")
 ```yaml
 - uses: rohaquinlop/complexipy-action@v2
   with:
-    paths: .
-    max_complexity_allowed: 10
-    output_format: json
+      paths: .
+      max_complexity_allowed: 10
+      output_format: json
 ```
 
 </details>
@@ -124,10 +125,10 @@ print(f"Complexity: {result.complexity}")
 
 ```yaml
 repos:
-- repo: https://github.com/rohaquinlop/complexipy-pre-commit
-  rev: v4.2.0
-  hooks:
-    - id: complexipy
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v4.2.0
+      hooks:
+          - id: complexipy
 ```
 
 </details>
@@ -192,26 +193,26 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 ### CLI Options
 
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--exclude` | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |  |
-| `--max-complexity-allowed` | Complexity threshold | `15` |
-| `--snapshot-create` | Save the current violations above the threshold into `complexipy-snapshot.json` | `false` |
-| `--snapshot-ignore` | Skip comparing against the snapshot even if it exists | `false` |
-| `--failed` | Show only functions above the complexity threshold | `false` |
-| `--color <auto\|yes\|no>` | Use color | `auto` |
-| `--sort <asc\|desc\|file_name>` | Sort results | `asc` |
-| `--quiet` | Suppress output | `false` |
-| `--ignore-complexity` | Don't exit with error on threshold breach | `false` |
-| `--version` | Show installed complexipy version and exit | - |
-| `--output-format <format>` | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`) | — |
-| `--output <path>` | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats | — |
-| `--diff <ref>` | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`) | — |
-| `--check-script` | Report module-level (script) complexity as a synthetic `<module>` entry | `false` |
-| `--output-json` | Deprecated alias for `--output-format json` | `false` |
-| `--output-csv` | Deprecated alias for `--output-format csv` | `false` |
-| `--output-gitlab` | Deprecated alias for `--output-format gitlab` | `false` |
-| `--output-sarif` | Deprecated alias for `--output-format sarif` | `false` |
+| Flag                            | Description                                                                                                                                                      | Default |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
+| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
+| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
+| `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                     | `asc`   |
+| `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
+| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                        | `false` |
+| `--version`                     | Show installed complexipy version and exit                                                                                                                       | -       |
+| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                 | —       |
+| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
+| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
+| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
+| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
+| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
+| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
 
 Example:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,14 +67,20 @@ complexipy . --max-complexity-allowed 10
 # Save results to JSON/CSV
 complexipy . --output-format json --output-format csv
 
+# Show the top 5 most complex functions
+complexipy . --top 5
+
+# Emit plain text for scripting/AI agents
+complexipy . --plain
+
+# Include module-level script complexity as <module>
+complexipy . --check-script
+
 # Save a GitLab report to a deterministic path
 complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Compare complexity against a git reference
 complexipy . --diff HEAD~1
-
-# Include module-level script complexity as <module>
-complexipy . --check-script
 
 # Analyze current directory while excluding specific files
 complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
@@ -164,9 +170,9 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
+check-script = false
 output-format = ["json", "gitlab"]
 output = "reports/"
-check-script = false
 ```
 
 ```toml
@@ -182,37 +188,41 @@ failed = false
 color = "auto"
 sort = "asc"
 exclude = []
+check-script = false
 output-format = ["json"]
 output = "complexipy-results.json"
-check-script = false
 ```
 
 Legacy TOML keys such as `output-json = true` and CLI flags such as
 `--output-json` still work for now, but they are deprecated in favor of
 `output-format` and `--output-format`.
 
+`check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
+
 ### CLI Options
 
-| Flag                            | Description                                                                                                                                                      | Default |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
-| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
-| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
-| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
-| `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
-| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
-| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                     | `asc`   |
-| `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
-| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                        | `false` |
-| `--version`                     | Show installed complexipy version and exit                                                                                                                       | -       |
-| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                 | —       |
-| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
-| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
-| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
-| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
-| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
-| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
-| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
+| Flag                       | Description                                                                                                                                                      | Default |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--max-complexity-allowed` | Complexity threshold                                                                                                                                             | `15`    |
+| `--snapshot-create`        | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
+| `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
+| `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                 | `asc`   |
+| `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
+| `--ignore-complexity`      | Don't exit with error on threshold breach                                                                                                                        | `false` |
+| `--version`                | Show installed complexipy version and exit                                                                                                                       | -       |
+| `--top <n>`                | Show only the `n` most complex functions, globally sorted by complexity descending                                                                               | —       |
+| `--plain`                  | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                    | `false` |
+| `--output-format <format>` | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                 | —       |
+| `--output <path>`          | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                             | —       |
+| `--diff <ref>`             | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                           | —       |
+| `--check-script`           | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                          | `false` |
+| `--output-json`            | Deprecated alias for `--output-format json`                                                                                                                      | `false` |
+| `--output-csv`             | Deprecated alias for `--output-format csv`                                                                                                                       | `false` |
+| `--output-gitlab`          | Deprecated alias for `--output-format gitlab`                                                                                                                    | `false` |
+| `--output-sarif`           | Deprecated alias for `--output-format sarif`                                                                                                                     | `false` |
 
 Example:
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -66,7 +66,7 @@ Sort by complexity score:
 ```bash
 complexipy . --sort asc   # Ascending (default)
 complexipy . --sort desc  # Descending
-complexipy . --sort name  # Alphabetically by function name
+complexipy . --sort file_name  # Alphabetically by file name
 ```
 
 ### Excluding Files and Directories
@@ -118,6 +118,27 @@ complexipy . --output-format sarif
 
 Legacy flags such as `--output-json` and TOML keys such as `output-json = true`
 still work as deprecated aliases for one release cycle.
+
+### Complexity Diff
+
+Compare current results against any git reference:
+
+```bash
+complexipy . --diff HEAD~1
+complexipy . --diff main
+complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
+```
+
+The diff is appended after the regular analysis output and does not affect the exit code. This requires `git` and a repository-backed path.
+
+### Script Complexity
+
+Report module-level control flow as a synthetic `<module>` entry:
+
+```bash
+complexipy scripts/bootstrap.py --check-script
+complexipy . --check-script --failed
+```
 
 **JSON Output Structure:**
 ```json
@@ -177,6 +198,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     sort = "asc"
     output-format = ["json", "gitlab"]
     output = "reports/"
+    check-script = false
     ```
 
 === "pyproject.toml"
@@ -204,7 +226,7 @@ complexipy loads configuration in this order (highest to lowest priority):
 from complexipy import file_complexity
 
 # Analyze a file
-result = file_complexity("src/main.py")
+result = file_complexity("src/main.py", check_script=True)
 
 print(f"Total complexity: {result.complexity}")
 print(f"File path: {result.path}")
@@ -232,7 +254,7 @@ def calculate_discount(price, customer):
     return price
 """
 
-result = code_complexity(code)
+result = code_complexity(code, check_script=True)
 print(f"Complexity: {result.complexity}")
 
 for func in result.functions:

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -84,10 +84,7 @@ complexipy . --exclude tests --exclude migrations --exclude build
 complexipy . --exclude src/legacy/old_code.py
 ```
 
-!!! note "How exclusion works"
-    - Entries resolve to existing directories (prefix match) or files (exact match)
-    - Non-existent entries are silently ignored
-    - Paths are relative to each provided root path
+!!! note "How exclusion works" - Entries resolve to existing directories (prefix match) or files (exact match) - Non-existent entries are silently ignored - Paths are relative to each provided root path
 
 ### Output Formats
 
@@ -141,23 +138,24 @@ complexipy . --check-script --failed
 ```
 
 **JSON Output Structure:**
+
 ```json
 {
-  "files": [
-    {
-      "path": "src/main.py",
-      "complexity": 42,
-      "functions": [
+    "files": [
         {
-          "name": "process_data",
-          "complexity": 18,
-          "line_start": 10,
-          "line_end": 45
+            "path": "src/main.py",
+            "complexity": 42,
+            "functions": [
+                {
+                    "name": "process_data",
+                    "complexity": 18,
+                    "line_start": 10,
+                    "line_end": 45
+                }
+            ]
         }
-      ]
-    }
-  ],
-  "total_complexity": 42
+    ],
+    "total_complexity": 42
 }
 ```
 
@@ -394,16 +392,16 @@ name: Complexity Check
 on: [push, pull_request]
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install complexipy
-        run: pip install complexipy
+            - name: Install complexipy
+              run: pip install complexipy
 
-      - name: Check complexity
-        run: complexipy . --max-complexity-allowed 15
+            - name: Check complexity
+              run: complexipy . --max-complexity-allowed 15
 ```
 
 The snapshot file (`complexipy-snapshot.json`) should be committed to version control.
@@ -417,6 +415,7 @@ complexipy . --snapshot-ignore
 ```
 
 Use this when:
+
 - Refactoring multiple files at once
 - Regenerating the baseline
 - Testing different thresholds
@@ -425,15 +424,15 @@ Use this when:
 
 ```json
 {
-  "version": "1.0",
-  "threshold": 15,
-  "functions": {
-    "src/legacy.py::old_function": {
-      "complexity": 23,
-      "line_start": 10,
-      "line_end": 50
+    "version": "1.0",
+    "threshold": 15,
+    "functions": {
+        "src/legacy.py::old_function": {
+            "complexity": 23,
+            "line_start": 10,
+            "line_end": 50
+        }
     }
-  }
 }
 ```
 
@@ -479,9 +478,9 @@ Use the official action:
 ```yaml
 - uses: rohaquinlop/complexipy-action@v2
   with:
-    paths: src tests
-    max_complexity_allowed: 15
-    output_json: true
+      paths: src tests
+      max_complexity_allowed: 15
+      output_json: true
 ```
 
 Or run directly:
@@ -489,8 +488,8 @@ Or run directly:
 ```yaml
 - name: Check complexity
   run: |
-    pip install complexipy
-    complexipy . --max-complexity-allowed 15
+      pip install complexipy
+      complexipy . --max-complexity-allowed 15
 ```
 
 ### Pre-commit Hook
@@ -499,31 +498,31 @@ Add to `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
-  - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-    rev: v4.2.0
-    hooks:
-      - id: complexipy
-        args: [--max-complexity-allowed=15]
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v4.2.0
+      hooks:
+          - id: complexipy
+            args: [--max-complexity-allowed=15]
 ```
 
 ### GitLab CI
 
 ```yaml
 .complexipy_code_quality:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
-  artifacts:
-    when: always
-    reports:
-      codequality: complexipy-code-quality.json
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
+    artifacts:
+        when: always
+        reports:
+            codequality: complexipy-code-quality.json
 
 complexity:
-  extends: .complexipy_code_quality
-  rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    extends: .complexipy_code_quality
+    rules:
+        - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```
 
 Use `--ignore-complexity` when your main goal is to upload the report even if violations exist. GitLab will still display the findings in the merge request widget and pipeline UI.
@@ -532,20 +531,20 @@ If you also want the job to fail when the threshold is exceeded, split the workf
 
 ```yaml
 complexity_check:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --max-complexity-allowed 15
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --max-complexity-allowed 15
 
 complexity_report:
-  image: python:3.11
-  script:
-    - pip install complexipy
-    - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
-  artifacts:
-    when: always
-    reports:
-      codequality: complexipy-code-quality.json
+    image: python:3.11
+    script:
+        - pip install complexipy
+        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity --max-complexity-allowed 15
+    artifacts:
+        when: always
+        reports:
+            codequality: complexipy-code-quality.json
 ```
 
 ## VS Code Integration

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -96,7 +96,11 @@ complexipy . --exclude tests --exclude migrations --exclude build
 complexipy . --exclude src/legacy/old_code.py
 ```
 
-!!! note "How exclusion works" - Entries resolve to existing directories (prefix match) or files (exact match) - Non-existent entries are silently ignored - Paths are relative to each provided root path
+<!-- prettier-ignore -->
+!!! note "How exclusion works"
+    - Entries resolve to existing directories (prefix match) or files (exact match)
+    - Non-existent entries are silently ignored
+    - Paths are relative to each provided root path
 
 ### Output Formats
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -4,16 +4,19 @@ This guide covers everything you need to know to effectively use complexipy in y
 
 ## Installation
 
+<!-- prettier-ignore -->
 === "pip"
     ```bash
     pip install complexipy
     ```
 
+<!-- prettier-ignore -->
 === "uv"
     ```bash
     uv add complexipy
     ```
 
+<!-- prettier-ignore -->
 === "poetry"
     ```bash
     poetry add complexipy
@@ -53,6 +56,15 @@ Show only functions that exceed the threshold:
 complexipy . --failed
 ```
 
+Show only the top N most complex functions across the analyzed files:
+
+```bash
+complexipy . --top 10
+```
+
+When `--top` is set, results are globally re-sorted by complexity descending
+before truncation.
+
 Suppress all output (useful for CI pipelines):
 
 ```bash
@@ -84,7 +96,11 @@ complexipy . --exclude tests --exclude migrations --exclude build
 complexipy . --exclude src/legacy/old_code.py
 ```
 
-!!! note "How exclusion works" - Entries resolve to existing directories (prefix match) or files (exact match) - Non-existent entries are silently ignored - Paths are relative to each provided root path
+<!-- prettier-ignore -->
+!!! note "How exclusion works"
+    - Entries resolve to existing directories (prefix match) or files (exact match)
+    - Non-existent entries are silently ignored
+    - Paths are relative to each provided root path
 
 ### Output Formats
 
@@ -128,15 +144,36 @@ complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
 
 The diff is appended after the regular analysis output and does not affect the exit code. This requires `git` and a repository-backed path.
 
-### Script Complexity
+### Plain Output
 
-Report module-level control flow as a synthetic `<module>` entry:
+Use plain output when you need one machine-friendly line per function:
 
 ```bash
-complexipy scripts/bootstrap.py --check-script
-complexipy . --check-script --failed
+complexipy . --plain
+complexipy . --plain --top 5
+complexipy . --plain --failed -mx 10
 ```
 
+Each line is emitted as:
+
+```text
+<path> <function> <complexity>
+```
+
+`--plain` is CLI-only and cannot be combined with `--quiet`.
+
+### Module-Level Script Complexity
+
+Use `--check-script` to include module-level code in the results as
+`<module>`:
+
+```bash
+complexipy path/to/script.py --check-script
+complexipy path/to/script.py --check-script -mx 5
+```
+
+This is useful for scripts with complex top-level control flow outside
+functions.
 **JSON Output Structure:**
 
 ```json
@@ -182,6 +219,7 @@ complexipy loads configuration in this order (highest to lowest priority):
 
 ### Example Configurations
 
+<!-- prettier-ignore -->
 === "complexipy.toml"
     ```toml
     paths = ["src", "tests"]
@@ -199,6 +237,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     check-script = false
     ```
 
+<!-- prettier-ignore -->
 === "pyproject.toml"
     ```toml
     [tool.complexipy]
@@ -207,14 +246,18 @@ complexipy loads configuration in this order (highest to lowest priority):
     exclude = ["migrations", "build"]
     failed = true
     sort = "desc"
+    check-script = true
     ```
 
+<!-- prettier-ignore -->
 === ".complexipy.toml"
     ```toml
     # Hidden config file for team-specific settings
     max-complexity-allowed = 15
     exclude = ["venv", ".venv", "node_modules"]
     ```
+
+`check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
 
 ## Python API
 
@@ -458,6 +501,7 @@ def complex_function():
     pass
 ```
 
+<!-- prettier-ignore -->
 !!! note "Deprecated Syntax"
     The `# noqa: complexipy` syntax is deprecated and will be removed in a future version.
     Please migrate to `# complexipy: ignore` instead.
@@ -466,6 +510,7 @@ def complex_function():
     comments that aren't recognized by flake8, which would silently remove your complexipy
     suppressions. The new syntax avoids this conflict entirely.
 
+<!-- prettier-ignore -->
 !!! warning "Use Sparingly"
     Inline ignores should be temporary. Document why the complexity is necessary and track technical debt.
 

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -172,6 +172,25 @@ class TestTopOutput:
         assert "complex_fn" in result.output
         assert "simple" not in result.output
 
+    def test_top_with_failed_filters_both(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--top", "1", "--plain", "--failed", "-mx", "0", str(source_file)],
+        )
+
+        assert result.exit_code == 1
+        lines = [
+            line for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert len(lines) == 1
+        assert "complex_fn" in lines[0]
+
     def test_top_zero_errors(self, tmp_path: Path):
         import complexipy.main as main_module
 

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -99,6 +99,80 @@ class TestOutputCli:
         assert (output_dir / "complexipy-results.csv").exists()
 
 
+_MULTI_SNIPPET = """\
+def simple(x):
+    return x
+
+def medium(x):
+    if x:
+        if x > 1:
+            return x
+    return 0
+
+def complex_fn(x):
+    if x:
+        for i in range(x):
+            if i > 0:
+                if i % 2:
+                    return i
+    return 0
+"""
+
+
+class TestTopOutput:
+    def test_top_limits_to_n_functions(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--top", "2", "--plain", str(source_file)],
+        )
+
+        assert result.exit_code == 0
+        lines = [
+            line for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert len(lines) == 2
+
+    def test_top_sorts_descending(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--top", "3", "--plain", str(source_file)],
+        )
+
+        lines = [
+            line for line in result.output.strip().splitlines() if line.strip()
+        ]
+        complexities = [int(line.split()[-1]) for line in lines]
+        assert complexities == sorted(complexities, reverse=True)
+
+    def test_top_works_with_rich_output(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--top", "1", str(source_file)],
+        )
+
+        assert result.exit_code == 0
+        assert "complex_fn" in result.output
+        assert "simple" not in result.output
+
+
 class TestPlainOutput:
     def test_plain_outputs_one_line_per_function(self, tmp_path: Path):
         import complexipy.main as main_module

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -16,7 +16,9 @@ def simple(value):
 
 
 class TestOutputCli:
-    def test_output_format_writes_explicit_file(self, tmp_path: Path, monkeypatch):
+    def test_output_format_writes_explicit_file(
+        self, tmp_path: Path, monkeypatch
+    ):
         import complexipy.main as main_module
 
         runner = CliRunner()
@@ -38,9 +40,12 @@ class TestOutputCli:
 
         assert result.exit_code == 0, result.output
         assert output_file.exists()
-        assert json.loads(output_file.read_text(encoding="utf-8"))[0][
-            "function_name"
-        ] == "simple"
+        assert (
+            json.loads(output_file.read_text(encoding="utf-8"))[0][
+                "function_name"
+            ]
+            == "simple"
+        )
 
     def test_multiple_output_formats_require_directory(self, tmp_path: Path):
         import complexipy.main as main_module
@@ -92,6 +97,99 @@ class TestOutputCli:
         assert result.exit_code == 0, result.output
         assert (output_dir / "complexipy-results.json").exists()
         assert (output_dir / "complexipy-results.csv").exists()
+
+
+class TestPlainOutput:
+    def test_plain_outputs_one_line_per_function(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--plain", str(source_file)],
+        )
+
+        assert result.exit_code == 0
+        lines = [
+            line for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert len(lines) == 1
+        parts = lines[0].split()
+        assert parts[0] == "sample.py"
+        assert parts[1] == "simple"
+        assert parts[2] == "1"
+
+    def test_plain_with_failed_shows_only_failures(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--plain", "--failed", "-mx", "0", str(source_file)],
+        )
+
+        assert result.exit_code == 1
+        lines = [
+            line for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert len(lines) == 1
+        assert "simple" in lines[0]
+
+    def test_plain_with_failed_no_failures_is_silent(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--plain", "--failed", str(source_file)],
+        )
+
+        assert result.exit_code == 0
+        lines = [
+            line for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert len(lines) == 0
+
+    def test_plain_and_quiet_errors(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--plain", "--quiet", str(source_file)],
+        )
+
+        assert result.exit_code == 2
+
+    def test_plain_no_rich_decorations(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--plain", str(source_file)],
+        )
+
+        assert "──" not in result.output
+        assert "complexipy" not in result.output.lower().replace(
+            "sample.py", ""
+        )
+        assert "Analysis completed" not in result.output
 
 
 class TestOutputToml:

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -172,6 +172,20 @@ class TestTopOutput:
         assert "complex_fn" in result.output
         assert "simple" not in result.output
 
+    def test_top_zero_errors(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--top", "0", str(source_file)],
+        )
+
+        assert result.exit_code == 2
+
 
 class TestPlainOutput:
     def test_plain_outputs_one_line_per_function(self, tmp_path: Path):

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -191,6 +191,62 @@ class TestTopOutput:
         assert len(lines) == 1
         assert "complex_fn" in lines[0]
 
+    def test_top_multi_file_preserves_global_descending_order(
+        self, tmp_path: Path
+    ):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        file_a = tmp_path / "a.py"
+        file_b = tmp_path / "b.py"
+        # a.py has the most complex and the least complex function;
+        # b.py has a middle-complexity function. Global order must interleave.
+        file_a.write_text(
+            """\
+def a_high(x):
+    if x:
+        for i in range(x):
+            if i > 0:
+                if i % 2:
+                    if i % 3:
+                        return i
+    return 0
+
+def a_low(x):
+    return x
+""",
+            encoding="utf-8",
+        )
+        file_b.write_text(
+            """\
+def b_mid(x):
+    if x:
+        if x > 1:
+            return x
+    return 0
+""",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            main_module.app,
+            ["--top", "3", "--plain", str(tmp_path)],
+        )
+
+        assert result.exit_code == 0, result.output
+        lines = [
+            line for line in result.output.strip().splitlines() if line.strip()
+        ]
+        assert len(lines) == 3
+        complexities = [int(line.split()[-1]) for line in lines]
+        assert complexities == sorted(complexities, reverse=True)
+        # Ensure the middle entry is from b.py — proves the output is not
+        # regrouped by file (which would cluster both a.py rows together).
+        names = [line.split()[1] for line in lines]
+        assert names[0] == "a_high"
+        assert names[1] == "b_mid"
+        assert names[2] == "a_low"
+
     def test_top_zero_errors(self, tmp_path: Path):
         import complexipy.main as main_module
 


### PR DESCRIPTION
## Summary

- Adds `--plain` CLI flag that outputs one line per function: `<path> <function> <complexity>` (space-separated)
- Adds `--top N` flag to show only the N most complex functions (sorted descending)
- Both flags compose with `--failed` and each other
- `--plain` + `--quiet` raises an error (mutually exclusive)
- `--plain` is CLI-only (not supported in TOML — session-level display preference)
- Extracts `handle_display()` to keep `main()` under complexity threshold

Closes #121

## Examples

```bash
# Plain output for AI agents
$ complexipy . --plain
test_if.py if_function 3

# Top 5 most complex functions
$ complexipy . --top 5 --plain
main.py resolve_output_formats 13
main.py handle_snapshot 11
main.py main 10
utils/output.py build_output_rows 8
utils/output.py output_file_entries 5

# Only failures, plain
$ complexipy . --plain --failed -mx 10
main.py resolve_output_formats 13
```

## Test plan

- [x] `--plain` outputs correct format (path, function, complexity)
- [x] `--plain --failed` shows only failing functions
- [x] `--plain --failed` with no failures produces no output
- [x] `--plain --quiet` raises BadParameter (exit code 2)
- [x] `--plain` suppresses rich decorations (rules, emojis, headers)
- [x] `--top N` limits to N functions
- [x] `--top N` sorts descending by complexity
- [x] `--top N` works with rich output
- [x] Self-check: `complexipy complexipy --failed` passes
- [x] All existing tests pass