### PR TITLE
Fix feature gating for WASM builds and include version metadata

### DIFF
--- a/src/classes.rs
+++ b/src/classes.rs
@@ -29,12 +29,11 @@ pub struct FunctionComplexity {
     pub line_complexities: Vec<LineComplexity>,
 }
 
-#[cfg_attr(feature = "python", pyclass(module = "complexipy", get_all))]
 #[cfg_attr(
-    any(feature = "python", feature = "wasm"),
-    derive(Serialize, Deserialize)
+    feature = "python",
+    pyclass(module = "complexipy", get_all),
+    derive(Serialize, Deserialize, Clone)
 )]
-#[derive(Clone)]
 pub struct FileComplexity {
     pub path: String,
     pub file_name: String,
@@ -51,4 +50,6 @@ pub struct FileComplexity {
 pub struct CodeComplexity {
     pub functions: Vec<FunctionComplexity>,
     pub complexity: u64,
+    #[cfg(feature = "wasm")]
+    pub version: String,
 }

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -1,9 +1,12 @@
 #[cfg(any(feature = "python", feature = "wasm"))]
 mod shared_deps {
-    pub use crate::classes::{CodeComplexity, FileComplexity, FunctionComplexity, LineComplexity};
+    pub use crate::classes::{FunctionComplexity, LineComplexity};
     pub use crate::utils::{count_bool_ops, get_line_number, has_noqa_complexipy, is_decorator};
     pub use ruff_python_ast::{self as ast, Stmt};
 }
+
+#[cfg(feature = "python")]
+use crate::classes::{CodeComplexity, FileComplexity};
 
 #[cfg(any(feature = "python", feature = "wasm"))]
 use shared_deps::*;
@@ -30,6 +33,7 @@ mod python_deps {
 #[cfg(feature = "python")]
 use python_deps::*;
 
+#[cfg(feature = "python")]
 type ComplexitiesAndFailedPaths = (Vec<FileComplexity>, Vec<String>);
 
 #[cfg(feature = "python")]
@@ -137,7 +141,8 @@ pub fn process_path(
         }
 
         let repo_path = dir.path().join(&repo_name).to_string_lossy().to_string();
-        let (complexities, f_paths) = evaluate_dir(&repo_path, quiet, exclude.clone(), check_script);
+        let (complexities, f_paths) =
+            evaluate_dir(&repo_path, quiet, exclude.clone(), check_script);
         dir.close()?;
 
         file_complexities = complexities;
@@ -168,7 +173,12 @@ pub fn process_path(
 }
 
 #[cfg(feature = "python")]
-fn evaluate_dir(path: &str, quiet: bool, exclude: Vec<&str>, check_script: bool) -> ComplexitiesAndFailedPaths {
+fn evaluate_dir(
+    path: &str,
+    quiet: bool,
+    exclude: Vec<&str>,
+    check_script: bool,
+) -> ComplexitiesAndFailedPaths {
     let mut files_paths: Vec<String> = Vec::new();
 
     let parent_dir = path::Path::new(path)
@@ -263,10 +273,12 @@ fn evaluate_dir(path: &str, quiet: bool, exclude: Vec<&str>, check_script: bool)
     if quiet {
         let results: Vec<_> = files_paths
             .iter()
-            .map(|file_path| match file_complexity(file_path, parent_dir, check_script) {
-                Ok(file_complexity) => (Some(file_complexity), None),
-                Err(_) => (None, Some(file_path.clone())),
-            })
+            .map(
+                |file_path| match file_complexity(file_path, parent_dir, check_script) {
+                    Ok(file_complexity) => (Some(file_complexity), None),
+                    Err(_) => (None, Some(file_path.clone())),
+                },
+            )
             .collect();
 
         let mut complexities = Vec::new();
@@ -320,7 +332,11 @@ fn evaluate_dir(path: &str, quiet: bool, exclude: Vec<&str>, check_script: bool)
 #[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(signature = (file_path, base_path, check_script=false))]
-pub fn file_complexity(file_path: &str, base_path: &str, check_script: bool) -> PyResult<FileComplexity> {
+pub fn file_complexity(
+    file_path: &str,
+    base_path: &str,
+    check_script: bool,
+) -> PyResult<FileComplexity> {
     let path = path::Path::new(file_path);
     let file_name = path
         .file_name()
@@ -370,7 +386,8 @@ pub fn code_complexity(code: &str, check_script: bool) -> PyResult<CodeComplexit
 
     // println!("{:#?}", ast_body);
 
-    let (functions, complexity) = function_level_cognitive_complexity_shared(&ast_body, code, check_script);
+    let (functions, complexity) =
+        function_level_cognitive_complexity_shared(&ast_body, code, check_script);
 
     Ok(CodeComplexity {
         functions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,16 +2,17 @@ mod classes;
 mod cognitive_complexity;
 mod utils;
 
-#[cfg(feature = "python")]
-use pyo3::prelude::*;
-
 // Add WASM support when wasm feature is enabled
 #[cfg(feature = "wasm")]
 mod wasm;
 
 #[cfg(feature = "python")]
 use classes::{CodeComplexity, FileComplexity, FunctionComplexity, LineComplexity};
+#[cfg(feature = "python")]
 use cognitive_complexity::{code_complexity, file_complexity, main};
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
 use utils::{create_snapshot_file, load_snapshot_file, output_csv, output_json};
 
 /// A Python module implemented in Rust.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -27,10 +27,12 @@ fn get_code_complexity(code: &str) -> Result<CodeComplexity, String> {
         Err(e) => return Err(format!("Parse error: {}", e)),
     };
 
-    let (functions, complexity) = function_level_cognitive_complexity_shared(parsed.suite(), code, false);
+    let (functions, complexity) =
+        function_level_cognitive_complexity_shared(parsed.suite(), code, false);
 
     Ok(CodeComplexity {
         complexity,
         functions,
+        version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }


### PR DESCRIPTION
## What

Fixes Python/WASM feature gating in the Rust crate so WASM builds compile with the right shared types and now return the package version in WASM complexity results.

## Why

Some structs and imports were still coupled to Python-specific attributes or symbols, which made the WASM feature configuration brittle. This also adds version metadata to the WASM response so consumers can identify the package version they are running.

## Changes

- Limit `FileComplexity` Python-specific `pyclass`/derive behavior to the `python` feature instead of applying shared configuration to `wasm`
- Gate Python-only imports, type aliases, and module exports behind `feature = "python"` in `src/cognitive_complexity.rs` and `src/lib.rs`
- Narrow shared dependencies between Python and WASM to the function and line complexity types that both targets actually use
- Add a WASM-only `version` field to `CodeComplexity`
- Populate the WASM `CodeComplexity` response with `env!("CARGO_PKG_VERSION")` in `src/wasm.rs`
- Keep touched functions formatted consistently after the gating changes
