### PR TITLE
Fix snapshot output stability

### DIFF
--- a/complexipy/_complexipy.pyi
+++ b/complexipy/_complexipy.pyi
@@ -262,7 +262,10 @@ class CodeComplexity:
     ) -> None: ...
 
 def main(
-    paths: List[str], quiet: bool, exclude: List[str], check_script: bool = False
+    paths: List[str],
+    quiet: bool,
+    exclude: List[str],
+    check_script: bool = False,
 ) -> Tuple[List[FileComplexity], List[str]]:
     """
     Analyze cognitive complexity of Python files and directories.
@@ -355,7 +358,9 @@ def code_complexity(code: str, check_script: bool = False) -> CodeComplexity:
     """
     ...
 
-def file_complexity(file_path: str, base_path: str, check_script: bool = False) -> FileComplexity:
+def file_complexity(
+    file_path: str, base_path: str, check_script: bool = False
+) -> FileComplexity:
     """
     Analyze cognitive complexity of a single Python source file.
 

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -23,56 +23,48 @@ from complexipy import (
 )
 from complexipy._complexipy import FileComplexity
 
-from .types import (
+from complexipy.types import (
     ColorTypes,
     OutputFormat,
     Sort,
 )
-from .utils.cache import remember_previous_functions
-from .utils.csv import store_csv
-from .utils.diff import DiffEntry, compute_diff, format_diff, has_regressions
-from .utils.gitlab import store_gitlab
-from .utils.json import store_json
-from .utils.output import (
+from complexipy.utils.cache import remember_previous_functions
+from complexipy.utils.csv import store_csv
+from complexipy.utils.diff import (
+    DiffEntry,
+    compute_diff,
+    format_diff,
+    has_regressions,
+)
+from complexipy.utils.gitlab import store_gitlab
+from complexipy.utils.json import store_json
+from complexipy.utils.output import (
     has_success_functions,
     output_summary,
     print_invalid_paths,
 )
-from .utils.sarif import store_sarif
-from .utils.snapshot import (
+from complexipy.utils.sarif import store_sarif
+from complexipy.utils.snapshot import (
     build_snapshot_map,
     handle_snapshot_file_creation,
     handle_snapshot_functions_load,
     handle_snapshot_watermark,
 )
-from .utils.toml import (
+from complexipy.utils.toml import (
     get_argument_value,
     get_arguments_value,
     get_complexipy_toml_config,
+)
+from complexipy.utils.constants import (
+    DEFAULT_OUTPUT_FILENAMES,
+    LEGACY_OUTPUT_CONFIG_KEYS,
+    LEGACY_OUTPUT_FLAGS,
 )
 
 app = typer.Typer(name="complexipy")
 console = Console(color_system="auto")
 INVOCATION_PATH = os.getcwd()
 TOML_CONFIG = get_complexipy_toml_config(INVOCATION_PATH)
-DEFAULT_OUTPUT_FILENAMES = {
-    OutputFormat.csv: "complexipy-results.csv",
-    OutputFormat.json: "complexipy-results.json",
-    OutputFormat.gitlab: "complexipy-results.gitlab.json",
-    OutputFormat.sarif: "complexipy-results.sarif",
-}
-LEGACY_OUTPUT_FLAGS = {
-    OutputFormat.csv: "--output-csv",
-    OutputFormat.json: "--output-json",
-    OutputFormat.gitlab: "--output-gitlab",
-    OutputFormat.sarif: "--output-sarif",
-}
-LEGACY_OUTPUT_CONFIG_KEYS = {
-    OutputFormat.csv: "output-csv",
-    OutputFormat.json: "output-json",
-    OutputFormat.gitlab: "output-gitlab",
-    OutputFormat.sarif: "output-sarif",
-}
 
 
 def _version_callback(value: bool):
@@ -281,8 +273,6 @@ def main(
     ratchet = bool(get_argument_value(TOML_CONFIG, "ratchet", ratchet, False))
     validate_ratchet(ratchet, diff)
 
-    # --plain is intentionally CLI-only (not resolved via TOML) because it is
-    # a session-level display preference, not a project-wide default.
     if plain is None:
         plain = False
 
@@ -364,9 +354,6 @@ def main(
         watermark_success,
     )
     if should_run_snapshot_watermark:
-        # When the snapshot watermark is active, it is the authoritative
-        # success check. Functions exceeding the threshold that are already
-        # in the snapshot (and haven't regressed) should not cause a failure.
         has_success = snapshot_result
     else:
         has_success = has_success and snapshot_result

--- a/complexipy/utils/constants.py
+++ b/complexipy/utils/constants.py
@@ -1,0 +1,20 @@
+from complexipy.types import OutputFormat
+
+DEFAULT_OUTPUT_FILENAMES = {
+    OutputFormat.csv: "complexipy-results.csv",
+    OutputFormat.json: "complexipy-results.json",
+    OutputFormat.gitlab: "complexipy-results.gitlab.json",
+    OutputFormat.sarif: "complexipy-results.sarif",
+}
+LEGACY_OUTPUT_FLAGS = {
+    OutputFormat.csv: "--output-csv",
+    OutputFormat.json: "--output-json",
+    OutputFormat.gitlab: "--output-gitlab",
+    OutputFormat.sarif: "--output-sarif",
+}
+LEGACY_OUTPUT_CONFIG_KEYS = {
+    OutputFormat.csv: "output-csv",
+    OutputFormat.json: "output-json",
+    OutputFormat.gitlab: "output-gitlab",
+    OutputFormat.sarif: "output-sarif",
+}

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -24,8 +24,11 @@ pub struct LineComplexity {
 pub struct FunctionComplexity {
     pub name: String,
     pub complexity: u64,
+    #[cfg_attr(feature = "python", serde(skip))]
     pub line_start: u64,
+    #[cfg_attr(feature = "python", serde(skip))]
     pub line_end: u64,
+    #[cfg_attr(feature = "python", serde(skip))]
     pub line_complexities: Vec<LineComplexity>,
 }
 
@@ -38,6 +41,7 @@ pub struct FileComplexity {
     pub path: String,
     pub file_name: String,
     pub functions: Vec<FunctionComplexity>,
+    #[cfg_attr(feature = "python", serde(skip))]
     pub complexity: u64,
 }
 


### PR DESCRIPTION
## What

This PR stabilizes snapshot output by excluding transient complexity details from serialized Python snapshots.

## Why

Snapshot files should store only the baseline data needed for watermark comparisons, so reruns do not create noisy or unstable snapshot payloads.

## Changes

- Skip per-line and aggregate complexity fields when serializing Python-feature snapshot data.
- Keep function-level complexity, path, file name, and function names available for snapshot comparison.
- Move CLI output constants into `complexipy.utils.constants`.
- Normalize imports in `complexipy.main` and refresh generated type-stub formatting.

Closes #167 