### PR TITLE
Update stale CLI and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 # Return types
 FileComplexity:
   ├─ path: str
+  ├─ file_name: str
   ├─ complexity: int
   └─ functions: List[FunctionComplexity]
 
@@ -371,7 +372,16 @@ FunctionComplexity:
   ├─ name: str
   ├─ complexity: int
   ├─ line_start: int
-  └─ line_end: int
+  ├─ line_end: int
+  └─ line_complexities: List[LineComplexity]
+
+LineComplexity:
+  ├─ line: int
+  └─ complexity: int
+
+CodeComplexity:
+  ├─ complexity: int
+  └─ functions: List[FunctionComplexity]
 ```
 
 ---

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -322,6 +322,7 @@ code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 # Tipos de retorno
 FileComplexity:
   ├─ path: str
+  ├─ file_name: str
   ├─ complexity: int
   └─ functions: List[FunctionComplexity]
 
@@ -329,7 +330,16 @@ FunctionComplexity:
   ├─ name: str
   ├─ complexity: int
   ├─ line_start: int
-  └─ line_end: int
+  ├─ line_end: int
+  └─ line_complexities: List[LineComplexity]
+
+LineComplexity:
+  ├─ line: int
+  └─ complexity: int
+
+CodeComplexity:
+  ├─ complexity: int
+  └─ functions: List[FunctionComplexity]
 ```
 
 ---

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -65,7 +65,7 @@ complexipy . --top 10
 Cuando se usa `--top`, los resultados se reordenan globalmente por complejidad
 descendente antes de truncarse.
 
-Suprimir toda la salida (útil para pipelines de CI):
+Suprimir la salida del análisis (útil para pipelines de CI):
 
 ```bash
 complexipy . --quiet
@@ -104,7 +104,7 @@ complexipy . --exclude src/legacy/old_code.py
 
 ### Formatos de Salida
 
-Guarda los resultados en JSON o CSV:
+Guarda los resultados en JSON, CSV, GitLab Code Quality o SARIF:
 
 ```bash
 # Salida JSON (guardada en complexipy-results.json)
@@ -198,24 +198,17 @@ fuera de las funciones.
 **Estructura de Salida JSON:**
 
 ```json
-{
-    "files": [
-        {
-            "path": "src/main.py",
-            "complexity": 42,
-            "functions": [
-                {
-                    "name": "process_data",
-                    "complexity": 18,
-                    "line_start": 10,
-                    "line_end": 45
-                }
-            ]
-        }
-    ],
-    "total_complexity": 42
-}
+[
+    {
+        "path": "src",
+        "file_name": "main.py",
+        "function_name": "process_data",
+        "complexity": 18
+    }
+]
 ```
+
+Las salidas JSON y CSV contienen una entrada por cada función emitida. Los rangos de líneas están disponibles mediante la API de Python (`line_start`, `line_end`), pero no se incluyen en las salidas JSON/CSV legibles por máquina de la CLI.
 
 ### Salida en Color
 
@@ -487,18 +480,21 @@ complexipy . --snapshot-ignore
 ### Formato del Archivo de snapshot
 
 ```json
-{
-    "version": "1.0",
-    "threshold": 15,
-    "functions": {
-        "src/legacy.py::old_function": {
-            "complexity": 23,
-            "line_start": 10,
-            "line_end": 50
-        }
+[
+    {
+        "path": "src",
+        "file_name": "legacy.py",
+        "functions": [
+            {
+                "name": "old_function",
+                "complexity": 23
+            }
+        ]
     }
-}
+]
 ```
+
+Los snapshots se guardan como un arreglo JSON de archivos analizados. Cada entrada contiene solo las funciones por encima del umbral cuando se escribió el snapshot. El archivo se reescribe después de verificaciones de snapshot exitosas, así que las funciones que mejoran se eliminan automáticamente. Es posible que los snapshots creados por versiones anteriores de complexipy deban regenerarse con `--snapshot-create`.
 
 ## Ignorar en Línea
 
@@ -546,7 +542,7 @@ Usa la acción oficial:
   with:
       paths: src tests
       max_complexity_allowed: 15
-      output_json: true
+      output_format: json
 ```
 
 O ejecuta directamente:

--- a/docs/index.md
+++ b/docs/index.md
@@ -322,6 +322,7 @@ code_complexity(source: str, check_script: bool = False) -> CodeComplexity
 # Return types
 FileComplexity:
   ├─ path: str
+  ├─ file_name: str
   ├─ complexity: int
   └─ functions: List[FunctionComplexity]
 
@@ -329,7 +330,16 @@ FunctionComplexity:
   ├─ name: str
   ├─ complexity: int
   ├─ line_start: int
-  └─ line_end: int
+  ├─ line_end: int
+  └─ line_complexities: List[LineComplexity]
+
+LineComplexity:
+  ├─ line: int
+  └─ complexity: int
+
+CodeComplexity:
+  ├─ complexity: int
+  └─ functions: List[FunctionComplexity]
 ```
 
 ---

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -65,7 +65,7 @@ complexipy . --top 10
 When `--top` is set, results are globally re-sorted by complexity descending
 before truncation.
 
-Suppress all output (useful for CI pipelines):
+Suppress analysis output (useful for CI pipelines):
 
 ```bash
 complexipy . --quiet
@@ -201,24 +201,17 @@ functions.
 **JSON Output Structure:**
 
 ```json
-{
-    "files": [
-        {
-            "path": "src/main.py",
-            "complexity": 42,
-            "functions": [
-                {
-                    "name": "process_data",
-                    "complexity": 18,
-                    "line_start": 10,
-                    "line_end": 45
-                }
-            ]
-        }
-    ],
-    "total_complexity": 42
-}
+[
+    {
+        "path": "src",
+        "file_name": "main.py",
+        "function_name": "process_data",
+        "complexity": 18
+    }
+]
 ```
+
+The JSON and CSV outputs contain one entry per emitted function. Line ranges are available through the Python API (`line_start`, `line_end`), but are not included in the machine-readable CLI JSON/CSV outputs.
 
 ### Color Output
 
@@ -490,18 +483,21 @@ Use this when:
 ### Snapshot File Format
 
 ```json
-{
-    "version": "1.0",
-    "threshold": 15,
-    "functions": {
-        "src/legacy.py::old_function": {
-            "complexity": 23,
-            "line_start": 10,
-            "line_end": 50
-        }
+[
+    {
+        "path": "src",
+        "file_name": "legacy.py",
+        "functions": [
+            {
+                "name": "old_function",
+                "complexity": 23
+            }
+        ]
     }
-}
+]
 ```
+
+Snapshots are stored as a JSON array of analyzed files. Each entry contains only functions above the threshold at the time the snapshot was written. The file is rewritten after successful snapshot checks, so improved functions are removed automatically. Snapshots created by older complexipy versions may need to be regenerated with `--snapshot-create`.
 
 ## Inline Ignores
 
@@ -549,7 +545,7 @@ Use the official action:
   with:
       paths: src tests
       max_complexity_allowed: 15
-      output_json: true
+      output_format: json
 ```
 
 Or run directly:


### PR DESCRIPTION
## What

This PR updates documentation so CLI output examples, snapshot examples, GitHub Action usage, and API return types match current complexipy behavior.

## Why

Several docs examples still described older output shapes or incomplete API types, which could mislead users integrating complexipy in scripts, CI, or generated reports.

## Changes

- Update JSON output examples in English and Spanish usage guides to show the current flat array schema.
- Update snapshot file examples to show the current serialized `FileComplexity` array format.
- Clarify that CLI JSON/CSV outputs omit line ranges while the Python API exposes them.
- Fix Spanish output-format docs to include GitLab Code Quality and SARIF.
- Change GitHub Action examples from deprecated `output_json` to `output_format`.
- Expand API return type docs with `file_name`, `line_complexities`, `LineComplexity`, and `CodeComplexity`.
- Tighten `--quiet` wording to match current behavior.