### PR TITLE
Add deterministic refactor plans to complexity results

### DIFF
--- a/complexipy/__init__.py
+++ b/complexipy/__init__.py
@@ -5,6 +5,7 @@ from complexipy._complexipy import (
     FileComplexity,
     FunctionComplexity,
     LineComplexity,
+    RefactorPlan,
 )
 from complexipy.api import (
     code_complexity,
@@ -16,6 +17,7 @@ __all__ = [
     "FileComplexity",
     "FunctionComplexity",
     "LineComplexity",
+    "RefactorPlan",
     "code_complexity",
     "file_complexity",
 ]

--- a/complexipy/_complexipy.pyi
+++ b/complexipy/_complexipy.pyi
@@ -42,6 +42,30 @@ class LineComplexity:
 
     def __init__(self, line: int, complexity: int) -> None: ...
 
+class RefactorPlan:
+    """Deterministic refactoring plan for reducing one function's complexity."""
+
+    kind: str
+    title: str
+    line_start: int
+    line_end: int
+    current_complexity: int
+    estimated_reduction: int
+    estimated_complexity_after: int
+    steps: List[str]
+
+    def __init__(
+        self,
+        kind: str,
+        title: str,
+        line_start: int,
+        line_end: int,
+        current_complexity: int,
+        estimated_reduction: int,
+        estimated_complexity_after: int,
+        steps: List[str],
+    ) -> None: ...
+
 class FunctionComplexity:
     """
     Represents the cognitive complexity analysis of a Python function.
@@ -118,6 +142,9 @@ class FunctionComplexity:
         ...     print(f"Line {line_info.line}: +{line_info.complexity}")
     """
 
+    refactor_plans: List[RefactorPlan]
+    """Ranked deterministic refactoring plans for this function."""
+
     def __init__(
         self,
         name: str,
@@ -125,6 +152,7 @@ class FunctionComplexity:
         line_start: int,
         line_end: int,
         line_complexities: List[LineComplexity],
+        refactor_plans: List[RefactorPlan],
     ) -> None: ...
 
 class FileComplexity:

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -21,6 +21,23 @@ pub struct LineComplexity {
     derive(Serialize, Deserialize)
 )]
 #[derive(Clone)]
+pub struct RefactorPlan {
+    pub kind: String,
+    pub title: String,
+    pub line_start: u64,
+    pub line_end: u64,
+    pub current_complexity: u64,
+    pub estimated_reduction: u64,
+    pub estimated_complexity_after: u64,
+    pub steps: Vec<String>,
+}
+
+#[cfg_attr(feature = "python", pyclass(module = "complexipy", get_all))]
+#[cfg_attr(
+    any(feature = "python", feature = "wasm"),
+    derive(Serialize, Deserialize)
+)]
+#[derive(Clone)]
 pub struct FunctionComplexity {
     pub name: String,
     pub complexity: u64,
@@ -30,6 +47,8 @@ pub struct FunctionComplexity {
     pub line_end: u64,
     #[cfg_attr(feature = "python", serde(skip))]
     pub line_complexities: Vec<LineComplexity>,
+    #[cfg_attr(feature = "python", serde(skip))]
+    pub refactor_plans: Vec<RefactorPlan>,
 }
 
 #[cfg_attr(

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -1,6 +1,9 @@
 #[cfg(any(feature = "python", feature = "wasm"))]
 mod shared_deps {
     pub use crate::classes::{FunctionComplexity, LineComplexity};
+    pub use crate::refactor_plans::{
+        ComplexityRegion, ComplexityResult, RegionKind, build_refactor_plans,
+    };
     pub use crate::utils::{count_bool_ops, get_line_number, has_noqa_complexipy, is_decorator};
     pub use ruff_python_ast::{self as ast, Stmt};
 }
@@ -67,9 +70,7 @@ pub fn main(
                 successful.append(&mut complexities);
                 failed_paths.append(&mut f_paths);
             }
-            Err(_) => {
-                failed_paths.push(path.to_string());
-            }
+            Err(_) => failed_paths.push(path.to_string()),
         }
     }
 
@@ -92,9 +93,7 @@ pub fn process_path(
     if is_url {
         let dir = tempdir()?;
         let repo_name = get_repo_name(path)?;
-
         env::set_current_dir(&dir)?;
-
         let cloning_done = Arc::new(Mutex::new(false));
         let cloning_done_clone = Arc::clone(&cloning_done);
         let path_clone = path.to_owned();
@@ -103,7 +102,6 @@ pub fn process_path(
             let _ = process::Command::new("git")
                 .args(["clone", &path_clone])
                 .output();
-
             if let Ok(mut done) = cloning_done_clone.lock() {
                 *done = true;
             }
@@ -144,7 +142,6 @@ pub fn process_path(
         let (complexities, f_paths) =
             evaluate_dir(&repo_path, quiet, exclude.clone(), check_script);
         dir.close()?;
-
         file_complexities = complexities;
         failed_paths = f_paths;
     } else if is_dir {
@@ -166,9 +163,7 @@ pub fn process_path(
     file_complexities
         .iter_mut()
         .for_each(|f| f.functions.sort_by_key(|f| (f.complexity, f.name.clone())));
-
     file_complexities.sort_by_key(|f| (f.path.clone(), f.file_name.clone(), f.complexity));
-
     Ok((file_complexities, failed_paths))
 }
 
@@ -180,7 +175,6 @@ fn evaluate_dir(
     check_script: bool,
 ) -> ComplexitiesAndFailedPaths {
     let mut files_paths: Vec<String> = Vec::new();
-
     let parent_dir = path::Path::new(path)
         .parent()
         .and_then(|p| p.to_str())
@@ -197,9 +191,9 @@ fn evaluate_dir(
         Err(_) => path::PathBuf::from(path),
     };
     let root_canon_str = root_canon.to_string_lossy().replace('\\', "/");
-
     let mut exclude_specs: Vec<ExcludeSpec> = Vec::new();
     let mut glob_matchers: Vec<GlobMatcher> = Vec::new();
+
     for raw in exclude.iter() {
         if raw.contains('*') || raw.contains('?') || raw.contains('[') {
             if let Ok(glob) = Glob::new(raw) {
@@ -214,7 +208,6 @@ fn evaluate_dir(
         } else {
             root_canon.join(p)
         };
-
         let (exists, is_dir, is_file, abs_str) = match candidate.canonicalize() {
             Ok(canon) => {
                 let is_dir = canon.is_dir();
@@ -233,28 +226,23 @@ fn evaluate_dir(
         }
     }
 
-    // Get all the python files in the directory
     for entry in Walk::new(path) {
         let entry = match entry {
             Ok(e) => e,
             Err(_) => continue,
         };
         let entry_path = entry.path();
-
         if entry_path.extension().and_then(|s| s.to_str()) != Some("py") {
             continue;
         }
-
         let file_abs = match entry_path.canonicalize() {
             Ok(p) => p,
             Err(_) => entry_path.to_path_buf(),
         };
         let file_abs_str = file_abs.to_string_lossy().replace('\\', "/");
-
         let relative_path = file_abs_str
             .strip_prefix(&format!("{}/", root_canon_str))
             .unwrap_or(&file_abs_str);
-
         let is_excluded = exclude_specs.iter().any(|spec| {
             if spec.is_dir {
                 file_abs_str.starts_with(&spec.abs)
@@ -264,7 +252,6 @@ fn evaluate_dir(
         }) || glob_matchers
             .iter()
             .any(|m| m.is_match(relative_path) || m.is_match(&file_abs_str));
-
         if !is_excluded && let Some(file_path_str) = entry_path.to_str() {
             files_paths.push(file_path_str.to_string());
         }
@@ -280,10 +267,8 @@ fn evaluate_dir(
                 },
             )
             .collect();
-
         let mut complexities = Vec::new();
         let mut failed_paths = Vec::new();
-
         for (success, error_path) in results {
             match (success, error_path) {
                 (Some(file_complexity), None) => complexities.push(file_complexity),
@@ -291,7 +276,6 @@ fn evaluate_dir(
                 _ => unreachable!(),
             }
         }
-
         return (complexities, failed_paths);
     }
 
@@ -315,7 +299,6 @@ fn evaluate_dir(
 
     let mut complexities = Vec::new();
     let mut failed_paths = Vec::new();
-
     for (success, error_path) in results {
         match (success, error_path) {
             (Some(file_complexity), None) => complexities.push(file_complexity),
@@ -323,9 +306,7 @@ fn evaluate_dir(
             _ => unreachable!(),
         }
     }
-
     pb.finish_and_clear();
-
     (complexities, failed_paths)
 }
 
@@ -347,9 +328,7 @@ pub fn file_complexity(
         .ok()
         .and_then(|p| p.to_str())
         .unwrap_or(file_path);
-
     let code = std::fs::read_to_string(file_path)?;
-
     let code_complexity = match code_complexity(&code, check_script) {
         Ok(v) => v,
         Err(e) => {
@@ -359,7 +338,6 @@ pub fn file_complexity(
             )));
         }
     };
-
     Ok(FileComplexity {
         path: relative_path.to_string(),
         file_name: file_name.to_string(),
@@ -381,17 +359,14 @@ pub fn code_complexity(code: &str, check_script: bool) -> PyResult<CodeComplexit
             )));
         }
     };
-
     let ast_body = parsed.into_suite();
-
-    // println!("{:#?}", ast_body);
-
     let (functions, complexity) =
         function_level_cognitive_complexity_shared(&ast_body, code, check_script);
-
     Ok(CodeComplexity {
         functions,
         complexity,
+        #[cfg(feature = "wasm")]
+        version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }
 
@@ -405,24 +380,22 @@ pub fn function_level_cognitive_complexity_shared(
     let mut complexity: u64 = 0;
     let mut module_complexity: u64 = 0;
     let mut module_line_complexities: Vec<LineComplexity> = Vec::new();
+    let mut module_regions: Vec<ComplexityRegion> = Vec::new();
 
     for node in ast_body.iter() {
         match node {
             Stmt::FunctionDef(f) => {
                 let start_line = get_line_number(usize::from(f.range.start()), code);
                 if !has_noqa_complexipy(start_line, code) {
-                    let (func_complexity, line_complexities) =
-                        statement_cognitive_complexity_shared(node, 0, code);
-
-                    let function = FunctionComplexity {
+                    let result = statement_cognitive_complexity_shared(node, 0, code);
+                    functions.push(FunctionComplexity {
                         name: f.name.to_string(),
-                        complexity: func_complexity,
+                        complexity: result.complexity,
                         line_start: start_line,
                         line_end: get_line_number(usize::from(f.range.end()), code),
-                        line_complexities,
-                    };
-
-                    functions.push(function);
+                        line_complexities: result.line_complexities,
+                        refactor_plans: build_refactor_plans(result.complexity, &result.regions),
+                    });
                 }
             }
             Stmt::ClassDef(c) => {
@@ -430,30 +403,30 @@ pub fn function_level_cognitive_complexity_shared(
                     if let Stmt::FunctionDef(f) = node {
                         let start_line = get_line_number(usize::from(f.range.start()), code);
                         if !has_noqa_complexipy(start_line, code) {
-                            let (func_complexity, line_complexities) =
-                                statement_cognitive_complexity_shared(node, 0, code);
-
-                            let function = FunctionComplexity {
+                            let result = statement_cognitive_complexity_shared(node, 0, code);
+                            functions.push(FunctionComplexity {
                                 name: format!("{}::{}", c.name, f.name),
-                                complexity: func_complexity,
+                                complexity: result.complexity,
                                 line_start: start_line,
                                 line_end: get_line_number(usize::from(f.range.end()), code),
-                                line_complexities,
-                            };
-
-                            functions.push(function);
+                                line_complexities: result.line_complexities,
+                                refactor_plans: build_refactor_plans(
+                                    result.complexity,
+                                    &result.regions,
+                                ),
+                            });
                         }
                     }
                 }
             }
             _ => {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, 0, code);
+                let result = statement_cognitive_complexity_shared(node, 0, code);
                 if check_script {
-                    module_complexity += stmt_complexity;
-                    module_line_complexities.extend(stmt_line_complexities);
+                    module_complexity += result.complexity;
+                    module_line_complexities.extend(result.line_complexities);
+                    module_regions.extend(result.regions);
                 } else {
-                    complexity += stmt_complexity;
+                    complexity += result.complexity;
                 }
             }
         }
@@ -461,30 +434,98 @@ pub fn function_level_cognitive_complexity_shared(
 
     if check_script {
         let total_lines = code.lines().count() as u64;
-        let module_func = FunctionComplexity {
+        functions.push(FunctionComplexity {
             name: "<module>".to_string(),
             complexity: module_complexity,
             line_start: 1,
             line_end: total_lines,
             line_complexities: module_line_complexities,
-        };
-        functions.push(module_func);
+            refactor_plans: build_refactor_plans(module_complexity, &module_regions),
+        });
     }
 
     for function in functions.iter() {
         complexity += function.complexity;
     }
-
     (functions, complexity)
 }
 
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn empty_result() -> ComplexityResult {
+    ComplexityResult {
+        complexity: 0,
+        line_complexities: Vec::new(),
+        regions: Vec::new(),
+    }
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn merge_child(
+    result: &mut ComplexityResult,
+    child: ComplexityResult,
+    region_children: &mut Vec<ComplexityRegion>,
+) {
+    result.complexity += child.complexity;
+    result.line_complexities.extend(child.line_complexities);
+    region_children.extend(child.regions.clone());
+    result.regions.extend(child.regions);
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn collect_suite(
+    suite: &ast::Suite,
+    nesting_level: u64,
+    code: &str,
+    region_children: &mut Vec<ComplexityRegion>,
+) -> ComplexityResult {
+    let mut result = empty_result();
+    for node in suite.iter() {
+        let child = statement_cognitive_complexity_shared(node, nesting_level, code);
+        merge_child(&mut result, child, region_children);
+    }
+    result
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn sum_region_child_totals(children: &[ComplexityRegion]) -> u64 {
+    children
+        .iter()
+        .filter(|child| child.kind != RegionKind::BooleanCondition)
+        .map(|child| child.total)
+        .sum()
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn push_bool_region(
+    regions: &mut Vec<ComplexityRegion>,
+    line_start: u64,
+    line_end: u64,
+    boolean: u64,
+) {
+    if boolean >= 2 {
+        regions.push(ComplexityRegion {
+            kind: RegionKind::BooleanCondition,
+            line_start,
+            line_end,
+            structural: 0,
+            nesting: 0,
+            boolean,
+            total: boolean,
+            elif_count: 0,
+            case_count: 0,
+            bool_op_count: boolean,
+            children: Vec::new(),
+        });
+    }
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
 fn statement_cognitive_complexity_shared(
     statement: &Stmt,
     nesting_level: u64,
     code: &str,
-) -> (u64, Vec<LineComplexity>) {
-    let mut complexity: u64 = 0;
-    let mut line_complexities: Vec<LineComplexity> = Vec::new();
+) -> ComplexityResult {
+    let mut result = empty_result();
 
     if is_decorator(statement.clone())
         && let Stmt::FunctionDef(f) = statement
@@ -495,37 +536,32 @@ fn statement_cognitive_complexity_shared(
     match statement {
         Stmt::FunctionDef(f) => {
             for node in f.body.iter() {
-                match node {
-                    Stmt::FunctionDef(..) => {
-                        let (stmt_complexity, stmt_line_complexities) =
-                            statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                        complexity += stmt_complexity;
-                        line_complexities.extend(stmt_line_complexities);
-                    }
-                    _ => {
-                        let (stmt_complexity, stmt_line_complexities) =
-                            statement_cognitive_complexity_shared(node, nesting_level, code);
-                        complexity += stmt_complexity;
-                        line_complexities.extend(stmt_line_complexities);
-                    }
-                }
+                let next_nesting = if matches!(node, Stmt::FunctionDef(..)) {
+                    nesting_level + 1
+                } else {
+                    nesting_level
+                };
+                let child = statement_cognitive_complexity_shared(node, next_nesting, code);
+                result.complexity += child.complexity;
+                result.line_complexities.extend(child.line_complexities);
+                result.regions.extend(child.regions);
             }
         }
         Stmt::ClassDef(c) => {
             for node in c.body.iter() {
                 if let Stmt::FunctionDef(..) = node {
-                    let (stmt_complexity, stmt_line_complexities) =
-                        statement_cognitive_complexity_shared(node, nesting_level, code);
-                    complexity += stmt_complexity;
-                    line_complexities.extend(stmt_line_complexities);
+                    let child = statement_cognitive_complexity_shared(node, nesting_level, code);
+                    result.complexity += child.complexity;
+                    result.line_complexities.extend(child.line_complexities);
+                    result.regions.extend(child.regions);
                 }
             }
         }
         Stmt::Assign(a) => {
             let bool_ops_complexity = count_bool_ops(*a.value.clone(), nesting_level);
-            complexity += bool_ops_complexity;
+            result.complexity += bool_ops_complexity;
             let line = get_line_number(usize::from(a.range.start()), code);
-            line_complexities.push(LineComplexity {
+            result.line_complexities.push(LineComplexity {
                 line,
                 complexity: bool_ops_complexity,
             });
@@ -533,9 +569,9 @@ fn statement_cognitive_complexity_shared(
         Stmt::AnnAssign(a) => {
             if let Some(value) = a.value.clone() {
                 let bool_ops_complexity = count_bool_ops(*value, nesting_level);
-                complexity += bool_ops_complexity;
+                result.complexity += bool_ops_complexity;
                 let line = get_line_number(usize::from(a.range.start()), code);
-                line_complexities.push(LineComplexity {
+                result.line_complexities.push(LineComplexity {
                     line,
                     complexity: bool_ops_complexity,
                 });
@@ -543,144 +579,239 @@ fn statement_cognitive_complexity_shared(
         }
         Stmt::AugAssign(a) => {
             let bool_ops_complexity = count_bool_ops(*a.value.clone(), nesting_level);
-            complexity += bool_ops_complexity;
+            result.complexity += bool_ops_complexity;
             let line = get_line_number(usize::from(a.range.start()), code);
-            line_complexities.push(LineComplexity {
+            result.line_complexities.push(LineComplexity {
                 line,
                 complexity: bool_ops_complexity,
             });
         }
         Stmt::For(f) => {
-            let stmt_complexity = 1 + nesting_level;
-            complexity += stmt_complexity;
-            let line = get_line_number(usize::from(f.range.start()), code);
-            line_complexities.push(LineComplexity {
-                line,
-                complexity: stmt_complexity,
+            let structural = 1;
+            let nesting = nesting_level;
+            let own = structural + nesting;
+            result.complexity += own;
+            let line_start = get_line_number(usize::from(f.range.start()), code);
+            let line_end = get_line_number(usize::from(f.range.end()), code);
+            result.line_complexities.push(LineComplexity {
+                line: line_start,
+                complexity: own,
             });
-            for node in f.body.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
-            for node in f.orelse.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
+            let mut children = Vec::new();
+            let child_result = collect_suite(&f.body, nesting_level + 1, code, &mut children);
+            result.complexity += child_result.complexity;
+            result
+                .line_complexities
+                .extend(child_result.line_complexities);
+            let else_result = collect_suite(&f.orelse, nesting_level + 1, code, &mut children);
+            result.complexity += else_result.complexity;
+            result
+                .line_complexities
+                .extend(else_result.line_complexities);
+            let mut region = ComplexityRegion {
+                kind: RegionKind::Loop,
+                line_start,
+                line_end,
+                structural,
+                nesting,
+                boolean: 0,
+                total: own,
+                elif_count: 0,
+                case_count: 0,
+                bool_op_count: 0,
+                children,
+            };
+            region.total += sum_region_child_totals(&region.children);
+            result.regions.push(region);
         }
         Stmt::While(w) => {
-            let stmt_complexity =
-                1 + nesting_level + count_bool_ops(*w.test.clone(), nesting_level);
-            complexity += stmt_complexity;
-            let line = get_line_number(usize::from(w.range.start()), code);
-            line_complexities.push(LineComplexity {
-                line,
-                complexity: stmt_complexity,
+            let structural = 1;
+            let nesting = nesting_level;
+            let boolean = count_bool_ops(*w.test.clone(), nesting_level);
+            let own = structural + nesting + boolean;
+            result.complexity += own;
+            let line_start = get_line_number(usize::from(w.range.start()), code);
+            let line_end = get_line_number(usize::from(w.range.end()), code);
+            result.line_complexities.push(LineComplexity {
+                line: line_start,
+                complexity: own,
             });
-            for node in w.body.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
-            for node in w.orelse.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
+            let mut children = Vec::new();
+            push_bool_region(&mut children, line_start, line_start, boolean);
+            let child_result = collect_suite(&w.body, nesting_level + 1, code, &mut children);
+            result.complexity += child_result.complexity;
+            result
+                .line_complexities
+                .extend(child_result.line_complexities);
+            let else_result = collect_suite(&w.orelse, nesting_level + 1, code, &mut children);
+            result.complexity += else_result.complexity;
+            result
+                .line_complexities
+                .extend(else_result.line_complexities);
+            let mut region = ComplexityRegion {
+                kind: RegionKind::Loop,
+                line_start,
+                line_end,
+                structural,
+                nesting,
+                boolean,
+                total: own,
+                elif_count: 0,
+                case_count: 0,
+                bool_op_count: boolean,
+                children,
+            };
+            region.total += sum_region_child_totals(&region.children);
+            result.regions.push(region);
         }
         Stmt::If(i) => {
-            let stmt_complexity =
-                1 + nesting_level + count_bool_ops(*i.test.clone(), nesting_level);
-            complexity += stmt_complexity;
-            let line = get_line_number(usize::from(i.range.start()), code);
-            line_complexities.push(LineComplexity {
-                line,
-                complexity: stmt_complexity,
+            let structural = 1;
+            let nesting = nesting_level;
+            let boolean = count_bool_ops(*i.test.clone(), nesting_level);
+            let own = structural + nesting + boolean;
+            result.complexity += own;
+            let line_start = get_line_number(usize::from(i.range.start()), code);
+            let line_end = get_line_number(usize::from(i.range.end()), code);
+            result.line_complexities.push(LineComplexity {
+                line: line_start,
+                complexity: own,
             });
-            for node in i.body.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
+            let mut children = Vec::new();
+            push_bool_region(&mut children, line_start, line_start, boolean);
+            let body_result = collect_suite(&i.body, nesting_level + 1, code, &mut children);
+            result.complexity += body_result.complexity;
+            result
+                .line_complexities
+                .extend(body_result.line_complexities);
+            let mut elif_count = 0;
             for clause in i.elif_else_clauses.clone() {
                 let mut clause_complexity = 1;
                 if let Some(test) = clause.test.clone() {
-                    clause_complexity += count_bool_ops(test, nesting_level);
+                    elif_count += 1;
+                    let clause_bool = count_bool_ops(test, nesting_level);
+                    clause_complexity += clause_bool;
+                    let line = get_line_number(usize::from(clause.range.start()), code);
+                    push_bool_region(&mut children, line, line, clause_bool);
                 }
-
-                complexity += clause_complexity;
-
+                result.complexity += clause_complexity;
                 let line = get_line_number(usize::from(clause.range.start()), code);
-                line_complexities.push(LineComplexity {
+                result.line_complexities.push(LineComplexity {
                     line,
                     complexity: clause_complexity,
                 });
-
-                for node in clause.body.iter() {
-                    let (stmt_complexity, stmt_line_complexities) =
-                        statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                    complexity += stmt_complexity;
-                    line_complexities.extend(stmt_line_complexities);
-                }
+                let clause_result =
+                    collect_suite(&clause.body, nesting_level + 1, code, &mut children);
+                result.complexity += clause_result.complexity;
+                result
+                    .line_complexities
+                    .extend(clause_result.line_complexities);
             }
+            let kind = if elif_count > 0 {
+                RegionKind::ElifChain
+            } else {
+                RegionKind::If
+            };
+            let mut region = ComplexityRegion {
+                kind,
+                line_start,
+                line_end,
+                structural,
+                nesting,
+                boolean,
+                total: own,
+                elif_count,
+                case_count: 0,
+                bool_op_count: boolean,
+                children,
+            };
+            region.total += sum_region_child_totals(&region.children);
+            result.regions.push(region);
         }
         Stmt::Try(t) => {
-            for node in t.body.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
+            let line_start = get_line_number(usize::from(t.range.start()), code);
+            let line_end = get_line_number(usize::from(t.range.end()), code);
+            let mut children = Vec::new();
+            let body_result = collect_suite(&t.body, nesting_level + 1, code, &mut children);
+            result.complexity += body_result.complexity;
+            result
+                .line_complexities
+                .extend(body_result.line_complexities);
+            let mut structural = 0;
             for handler in t.handlers.iter() {
-                complexity += 1;
+                structural += 1;
+                result.complexity += 1;
                 let handler = handler.clone().expect_except_handler();
                 let line = get_line_number(usize::from(handler.range.start()), code);
-                line_complexities.push(LineComplexity {
+                result.line_complexities.push(LineComplexity {
                     line,
                     complexity: 1,
                 });
-                for node in handler.clone().body.iter() {
-                    let (stmt_complexity, stmt_line_complexities) =
-                        statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                    complexity += stmt_complexity;
-                    line_complexities.extend(stmt_line_complexities);
-                }
+                let handler_result =
+                    collect_suite(&handler.body, nesting_level + 1, code, &mut children);
+                result.complexity += handler_result.complexity;
+                result
+                    .line_complexities
+                    .extend(handler_result.line_complexities);
             }
-            for node in t.orelse.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
-            for node in t.finalbody.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
+            let else_result = collect_suite(&t.orelse, nesting_level + 1, code, &mut children);
+            result.complexity += else_result.complexity;
+            result
+                .line_complexities
+                .extend(else_result.line_complexities);
+            let final_result = collect_suite(&t.finalbody, nesting_level + 1, code, &mut children);
+            result.complexity += final_result.complexity;
+            result
+                .line_complexities
+                .extend(final_result.line_complexities);
+            let mut region = ComplexityRegion {
+                kind: RegionKind::Try,
+                line_start,
+                line_end,
+                structural,
+                nesting: 0,
+                boolean: 0,
+                total: structural,
+                elif_count: 0,
+                case_count: 0,
+                bool_op_count: 0,
+                children,
+            };
+            region.total += sum_region_child_totals(&region.children);
+            result.regions.push(region);
         }
         Stmt::Match(m) => {
+            let line_start = get_line_number(usize::from(m.range.start()), code);
+            let line_end = get_line_number(usize::from(m.range.end()), code);
+            let mut children = Vec::new();
             for case in m.cases.iter() {
-                for node in case.body.iter() {
-                    let (stmt_complexity, stmt_line_complexities) =
-                        statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                    complexity += stmt_complexity;
-                    line_complexities.extend(stmt_line_complexities);
-                }
+                let case_result = collect_suite(&case.body, nesting_level + 1, code, &mut children);
+                result.complexity += case_result.complexity;
+                result
+                    .line_complexities
+                    .extend(case_result.line_complexities);
             }
+            let mut region = ComplexityRegion {
+                kind: RegionKind::Match,
+                line_start,
+                line_end,
+                structural: 0,
+                nesting: 0,
+                boolean: 0,
+                total: 0,
+                elif_count: 0,
+                case_count: m.cases.len() as u64,
+                bool_op_count: 0,
+                children,
+            };
+            region.total += sum_region_child_totals(&region.children);
+            result.regions.push(region);
         }
         Stmt::Return(r) => {
             if let Some(value) = r.value.clone() {
                 let bool_ops_complexity = count_bool_ops(*value, nesting_level);
-                complexity += bool_ops_complexity;
+                result.complexity += bool_ops_complexity;
                 let line = get_line_number(usize::from(r.range.start()), code);
-                line_complexities.push(LineComplexity {
+                result.line_complexities.push(LineComplexity {
                     line,
                     complexity: bool_ops_complexity,
                 });
@@ -694,9 +825,9 @@ fn statement_cognitive_complexity_shared(
             if let Some(cause) = r.cause.clone() {
                 raise_complexity += count_bool_ops(*cause, nesting_level);
             }
-            complexity += raise_complexity;
+            result.complexity += raise_complexity;
             let line = get_line_number(usize::from(r.range.start()), code);
-            line_complexities.push(LineComplexity {
+            result.line_complexities.push(LineComplexity {
                 line,
                 complexity: raise_complexity,
             });
@@ -706,9 +837,9 @@ fn statement_cognitive_complexity_shared(
             if let Some(msg) = a.msg.clone() {
                 assert_complexity += count_bool_ops(*msg, nesting_level);
             }
-            complexity += assert_complexity;
+            result.complexity += assert_complexity;
             let line = get_line_number(usize::from(a.range.start()), code);
-            line_complexities.push(LineComplexity {
+            result.line_complexities.push(LineComplexity {
                 line,
                 complexity: assert_complexity,
             });
@@ -718,21 +849,37 @@ fn statement_cognitive_complexity_shared(
             for item in w.items.iter() {
                 with_complexity += count_bool_ops(item.context_expr.clone(), nesting_level);
             }
-            complexity += with_complexity;
-            let line = get_line_number(usize::from(w.range.start()), code);
-            line_complexities.push(LineComplexity {
-                line,
+            result.complexity += with_complexity;
+            let line_start = get_line_number(usize::from(w.range.start()), code);
+            let line_end = get_line_number(usize::from(w.range.end()), code);
+            result.line_complexities.push(LineComplexity {
+                line: line_start,
                 complexity: with_complexity,
             });
-            for node in w.body.iter() {
-                let (stmt_complexity, stmt_line_complexities) =
-                    statement_cognitive_complexity_shared(node, nesting_level + 1, code);
-                complexity += stmt_complexity;
-                line_complexities.extend(stmt_line_complexities);
-            }
+            let mut children = Vec::new();
+            let body_result = collect_suite(&w.body, nesting_level + 1, code, &mut children);
+            result.complexity += body_result.complexity;
+            result
+                .line_complexities
+                .extend(body_result.line_complexities);
+            let mut region = ComplexityRegion {
+                kind: RegionKind::With,
+                line_start,
+                line_end,
+                structural: 0,
+                nesting: 0,
+                boolean: with_complexity,
+                total: with_complexity,
+                elif_count: 0,
+                case_count: 0,
+                bool_op_count: with_complexity,
+                children,
+            };
+            region.total += sum_region_child_totals(&region.children);
+            result.regions.push(region);
         }
         _ => {}
     }
 
-    (complexity, line_complexities)
+    result
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod classes;
 mod cognitive_complexity;
+mod refactor_plans;
 mod utils;
 
 // Add WASM support when wasm feature is enabled
@@ -7,7 +8,7 @@ mod utils;
 mod wasm;
 
 #[cfg(feature = "python")]
-use classes::{CodeComplexity, FileComplexity, FunctionComplexity, LineComplexity};
+use classes::{CodeComplexity, FileComplexity, FunctionComplexity, LineComplexity, RefactorPlan};
 #[cfg(feature = "python")]
 use cognitive_complexity::{code_complexity, file_complexity, main};
 #[cfg(feature = "python")]
@@ -31,5 +32,6 @@ fn _complexipy(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<FileComplexity>()?;
     m.add_class::<FunctionComplexity>()?;
     m.add_class::<LineComplexity>()?;
+    m.add_class::<RefactorPlan>()?;
     Ok(())
 }

--- a/src/refactor_plans.rs
+++ b/src/refactor_plans.rs
@@ -1,0 +1,231 @@
+pub use crate::classes::{LineComplexity, RefactorPlan};
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum RegionKind {
+    If,
+    ElifChain,
+    Loop,
+    Try,
+    Match,
+    BooleanCondition,
+    With,
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+#[derive(Clone)]
+pub struct ComplexityRegion {
+    pub kind: RegionKind,
+    pub line_start: u64,
+    pub line_end: u64,
+    pub structural: u64,
+    pub nesting: u64,
+    pub boolean: u64,
+    pub total: u64,
+    pub elif_count: u64,
+    pub case_count: u64,
+    pub bool_op_count: u64,
+    pub children: Vec<ComplexityRegion>,
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+pub struct ComplexityResult {
+    pub complexity: u64,
+    pub line_complexities: Vec<LineComplexity>,
+    pub regions: Vec<ComplexityRegion>,
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+pub fn build_refactor_plans(
+    function_complexity: u64,
+    regions: &[ComplexityRegion],
+) -> Vec<RefactorPlan> {
+    let mut plans = Vec::new();
+    collect_refactor_plans(function_complexity, regions, &mut plans);
+    plans.retain(|plan| plan.estimated_reduction >= 2);
+    plans.sort_by(|a, b| {
+        b.estimated_reduction
+            .cmp(&a.estimated_reduction)
+            .then_with(|| b.current_complexity.cmp(&a.current_complexity))
+            .then_with(|| a.line_start.cmp(&b.line_start))
+    });
+
+    let mut selected: Vec<RefactorPlan> = Vec::new();
+    for plan in plans {
+        if plan.kind == "extract_helper"
+            && selected.iter().any(|existing| {
+                existing.kind == "extract_helper"
+                    && existing.line_start <= plan.line_start
+                    && existing.line_end >= plan.line_end
+            })
+        {
+            continue;
+        }
+        if !selected.iter().any(|existing| {
+            existing.kind == plan.kind
+                && existing.line_start == plan.line_start
+                && existing.line_end == plan.line_end
+        }) {
+            selected.push(plan);
+        }
+        if selected.len() == 3 {
+            break;
+        }
+    }
+    selected
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn collect_refactor_plans(
+    function_complexity: u64,
+    regions: &[ComplexityRegion],
+    plans: &mut Vec<RefactorPlan>,
+) {
+    for region in regions {
+        plan_for_region(function_complexity, region, plans);
+        collect_refactor_plans(function_complexity, &region.children, plans);
+    }
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn plan_for_region(
+    function_complexity: u64,
+    region: &ComplexityRegion,
+    plans: &mut Vec<RefactorPlan>,
+) {
+    if region.kind == RegionKind::If && region.nesting >= 2 && region.total >= 4 {
+        push_plan(
+            plans,
+            "flatten_condition",
+            "Flatten nested condition block with guard clauses",
+            region,
+            region.nesting,
+            function_complexity,
+            &[
+                "invert the outer condition",
+                "return early when the condition fails",
+                "move the main success path one indentation level left",
+                "repeat for inner nested conditions where safe",
+            ],
+        );
+    }
+
+    if region.kind == RegionKind::Loop
+        && region.total >= 5
+        && region
+            .children
+            .iter()
+            .any(|child| child.kind == RegionKind::If && child.nesting >= 1)
+    {
+        let reduction =
+            sum_if_nesting(&region.children).min(region.total.saturating_sub(region.structural));
+        push_plan(
+            plans,
+            "loop_guards",
+            "Flatten loop body with continue guards",
+            region,
+            reduction,
+            function_complexity,
+            &[
+                "add negative condition checks at the top of the loop",
+                "use continue for skipped items",
+                "keep the main processing path unindented",
+            ],
+        );
+    }
+
+    if region.total >= 6 && region.line_end.saturating_sub(region.line_start) + 1 >= 5 {
+        push_plan(
+            plans,
+            "extract_helper",
+            "Extract complex block into helper function",
+            region,
+            region.total.saturating_sub(1),
+            function_complexity,
+            &[
+                "move the selected block into a private helper",
+                "pass required values as parameters",
+                "return the result/status needed by the caller",
+            ],
+        );
+    }
+
+    if (region.kind == RegionKind::ElifChain && region.elif_count >= 3)
+        || (region.kind == RegionKind::Match && region.case_count >= 4)
+    {
+        let reduction = region
+            .elif_count
+            .max(region.case_count)
+            .saturating_sub(1)
+            .max(2);
+        push_plan(
+            plans,
+            "split_dispatcher",
+            "Split conditional dispatcher into handlers",
+            region,
+            reduction,
+            function_complexity,
+            &[
+                "create one handler per case",
+                "replace the chain with a dispatch table or small delegating match",
+                "keep the orchestration function shallow",
+            ],
+        );
+    }
+
+    if region.kind == RegionKind::BooleanCondition && region.boolean >= 2 {
+        push_plan(
+            plans,
+            "extract_predicate",
+            "Extract complex condition into named predicate",
+            region,
+            region.bool_op_count,
+            function_complexity,
+            &[
+                "move the condition into a well-named helper function",
+                "use the helper in the branch condition",
+                "keep the caller focused on control flow",
+            ],
+        );
+    }
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn sum_if_nesting(regions: &[ComplexityRegion]) -> u64 {
+    regions
+        .iter()
+        .map(|region| {
+            let own = if region.kind == RegionKind::If {
+                region.nesting
+            } else {
+                0
+            };
+            own + sum_if_nesting(&region.children)
+        })
+        .sum()
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+fn push_plan(
+    plans: &mut Vec<RefactorPlan>,
+    kind: &str,
+    title: &str,
+    region: &ComplexityRegion,
+    estimated_reduction: u64,
+    function_complexity: u64,
+    steps: &[&str],
+) {
+    if estimated_reduction == 0 {
+        return;
+    }
+    plans.push(RefactorPlan {
+        kind: kind.to_string(),
+        title: title.to_string(),
+        line_start: region.line_start,
+        line_end: region.line_end,
+        current_complexity: function_complexity,
+        estimated_reduction,
+        estimated_complexity_after: function_complexity.saturating_sub(estimated_reduction),
+        steps: steps.iter().map(|step| (*step).to_string()).collect(),
+    });
+}

--- a/tests/test_refactor_plans.py
+++ b/tests/test_refactor_plans.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+
+import complexipy
+from complexipy import RefactorPlan, code_complexity
+
+
+def first_func(code: str):
+    return code_complexity(code).functions[0]
+
+
+def plan_kinds(func) -> set[str]:
+    return {plan.kind for plan in func.refactor_plans}
+
+
+def test_nested_if_creates_flatten_condition_plan() -> None:
+    func = first_func(
+        """
+def sample(a, b, c, d):
+    if a:
+        if b:
+            if c and d:
+                return 1
+    return 0
+"""
+    )
+
+    assert func.complexity == 7
+    plan = next(plan for plan in func.refactor_plans if plan.kind == "flatten_condition")
+    assert plan.title == "Flatten nested condition block with guard clauses"
+    assert plan.line_start == 5
+    assert plan.line_end == 6
+    assert plan.estimated_reduction == 2
+
+
+def test_loop_with_nested_if_creates_loop_guard_plan() -> None:
+    func = first_func(
+        """
+def sample(items):
+    total = 0
+    for item in items:
+        if item.active:
+            if item.ready:
+                total += item.value
+    return total
+"""
+    )
+
+    assert "loop_guards" in plan_kinds(func)
+
+
+def test_high_complexity_region_creates_extract_helper_plan() -> None:
+    func = first_func(
+        """
+def sample(a, b, c, d):
+    if a and b:
+        if c:
+            for value in d:
+                if value.ready:
+                    return value
+    return None
+"""
+    )
+
+    assert "extract_helper" in plan_kinds(func)
+
+
+def test_long_elif_chain_creates_dispatcher_plan() -> None:
+    func = first_func(
+        """
+def sample(kind):
+    if kind == "a":
+        return 1
+    elif kind == "b":
+        return 2
+    elif kind == "c":
+        return 3
+    elif kind == "d":
+        return 4
+    return 0
+"""
+    )
+
+    plan = next(plan for plan in func.refactor_plans if plan.kind == "split_dispatcher")
+    assert plan.line_start == 3
+    assert plan.line_end == 10
+
+
+def test_match_dispatcher_creates_dispatcher_plan() -> None:
+    func = first_func(
+        """
+def sample(kind):
+    match kind:
+        case "a":
+            return 1
+        case "b":
+            return 2
+        case "c":
+            return 3
+        case "d":
+            return 4
+    return 0
+"""
+    )
+
+    assert "split_dispatcher" in plan_kinds(func)
+
+
+def test_boolean_heavy_condition_creates_predicate_plan() -> None:
+    func = first_func(
+        """
+def sample(a, b, c, d):
+    if (a and b) or (c and d):
+        return 1
+    return 0
+"""
+    )
+
+    plan = next(plan for plan in func.refactor_plans if plan.kind == "extract_predicate")
+    assert plan.line_start == 3
+    assert plan.line_end == 3
+
+
+def test_simple_function_creates_no_refactor_plans() -> None:
+    func = first_func(
+        """
+def sample(a, b):
+    return a + b
+"""
+    )
+
+    assert func.complexity == 0
+    assert func.refactor_plans == []
+
+
+def test_refactor_plan_exported_and_available_on_python_api() -> None:
+    func = first_func(
+        """
+def sample(a, b, c, d):
+    if (a and b) or (c and d):
+        return 1
+    return 0
+"""
+    )
+
+    assert complexipy.RefactorPlan is RefactorPlan
+    assert isinstance(func.refactor_plans[0], RefactorPlan)
+    assert func.refactor_plans[0].estimated_complexity_after <= func.complexity
+
+
+def test_manual_cli_json_and_snapshot_output_remain_unchanged(tmp_path) -> None:
+    source = tmp_path / "sample.py"
+    source.write_text(
+        """
+def sample(a, b, c, d):
+    if (a and b) or (c and d):
+        return 1
+    return 0
+"""
+    )
+    file_result = complexipy.file_complexity(str(source))
+    func = file_result.functions[0]
+    output_path = tmp_path / "complexity.json"
+
+    complexipy._complexipy.output_json(str(output_path), [file_result], True, 0)
+
+    assert json.loads(output_path.read_text()) == [
+        {
+            "path": "sample.py",
+            "file_name": "sample.py",
+            "function_name": "sample",
+            "complexity": func.complexity,
+        }
+    ]
+
+    snapshot_path = tmp_path / "complexipy-snapshot.json"
+    complexipy._complexipy.create_snapshot_file(str(snapshot_path), 0, [file_result])
+    snapshot_data = json.loads(snapshot_path.read_text())
+    assert "refactor_plans" not in snapshot_data[0]["functions"][0]


### PR DESCRIPTION
## What

This PR adds deterministic Rust-generated refactor plans to function complexity results and exposes them through the Python API and WASM serialization.

## Why

Users need actionable, region-based guidance for reducing cognitive complexity without relying on AI, Python-side analysis, or automatic code rewriting.

## Changes

- Added `RefactorPlan` public model and `FunctionComplexity.refactor_plans`.
- Added `src/refactor_plans.rs` with internal region metadata, ranked plan generation, de-duplication, and top-3 limiting.
- Updated cognitive complexity traversal to collect regions while preserving existing complexity scoring.
- Added support for nested-condition, loop-guard, extract-helper, dispatcher, and predicate refactor plans.
- Exported `RefactorPlan` through Rust Python bindings, `complexipy.__all__`, and `_complexipy.pyi`.
- Kept manual CLI JSON and snapshot JSON unchanged by skipping `refactor_plans` in Python serde output.
- Added tests for plan generation, API exposure, exports/stubs, unchanged complexity scoring, and unchanged JSON/snapshot output.