### PR TITLE
feat(cli): show refactor plans in rich output

### DIFF
--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -212,6 +212,14 @@ def main(
             "Useful for AI agents and scripting. CLI-only flag (not supported in TOML)."
         ),
     ),
+    suggest_refactors: Optional[bool] = typer.Option(
+        None,
+        "--suggest-refactors",
+        help=(
+            "Show deterministic refactor plans for displayed functions in rich output. "
+            "Ignored when --plain is used."
+        ),
+    ),
     check_script: Optional[bool] = typer.Option(
         None,
         "--check-script",
@@ -275,6 +283,8 @@ def main(
 
     if plain is None:
         plain = False
+    if suggest_refactors is None:
+        suggest_refactors = False
 
     if plain and quiet:
         raise typer.BadParameter("--plain and --quiet cannot be used together.")
@@ -344,6 +354,7 @@ def main(
         quiet,
         plain,
         top,
+        suggest_refactors,
     )
 
     snapshot_result = handle_snapshot(
@@ -404,6 +415,7 @@ def handle_display(
     quiet: bool,
     plain: bool,
     top: Optional[int] = None,
+    suggest_refactors: bool = False,
 ) -> bool:
     if files_complexities:
         previous_functions = remember_previous_functions(
@@ -427,6 +439,7 @@ def handle_display(
         active_snapshot_map,
         plain,
         top,
+        suggest_refactors,
     )
     if not plain:
         if platform.system() == "Windows":

--- a/complexipy/utils/dataclasses.py
+++ b/complexipy/utils/dataclasses.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
+from complexipy._complexipy import RefactorPlan
+
 
 @dataclass
 class FunctionRow:
@@ -11,6 +13,7 @@ class FunctionRow:
     passed: bool
     path: str
     file_name: str
+    refactor_plans: List[RefactorPlan]
 
 
 @dataclass

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -32,6 +32,7 @@ def output_summary(
     snapshot_map: Optional[Dict[Tuple[str, str, str], int]] = None,
     plain: bool = False,
     top: Optional[int] = None,
+    suggest_refactors: bool = False,
 ) -> bool:
     (
         file_entries,
@@ -67,6 +68,7 @@ def output_summary(
             ignore_complexity,
             previous_functions,
             max_complexity,
+            suggest_refactors,
         )
     return has_success
 
@@ -112,6 +114,7 @@ def output_file_entries(
     ignore_complexity: bool,
     previous_functions: Optional[Dict[Tuple[str, str, str], int]],
     max_complexity: int,
+    suggest_refactors: bool = False,
 ) -> None:
     for entry in file_entries:
         console.print(f"[bold]{entry.path}[/bold]")
@@ -123,6 +126,8 @@ def output_file_entries(
             console.print(
                 f"    {function.name} {function.complexity}{delta_text} {status_text}"
             )
+            if suggest_refactors:
+                output_refactor_plans(console, function)
         console.print()
 
     if failing_functions:
@@ -137,6 +142,26 @@ def output_file_entries(
         console.print(
             "[bold green]All functions are within the allowed complexity.[/bold green]"
         )
+
+
+def output_refactor_plans(console: Console, function: dc.FunctionRow) -> None:
+    if not function.refactor_plans:
+        return
+
+    console.print("\n      Refactor plans:")
+    for index, plan in enumerate(function.refactor_plans, start=1):
+        console.print(
+            f"        {index}. {plan.title}, lines {plan.line_start}-{plan.line_end}"
+        )
+        console.print(
+            "           estimated: "
+            f"{plan.current_complexity} -> {plan.estimated_complexity_after} "
+            f"(-{plan.estimated_reduction})"
+        )
+        if plan.steps:
+            console.print("           steps:")
+            for step in plan.steps:
+                console.print(f"             - {step}")
 
 
 def format_status_text(passed: bool) -> str:
@@ -222,6 +247,7 @@ def build_output_rows(
                     passed=passed,
                     path=file.path,
                     file_name=file.file_name,
+                    refactor_plans=function.refactor_plans,
                 )
             )
 

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -99,6 +99,15 @@ class TestOutputCli:
         assert (output_dir / "complexipy-results.csv").exists()
 
 
+_REFACTOR_SNIPPET = """\
+def sample(a, b, c, d):
+    if a:
+        if b:
+            if c and d:
+                return 1
+    return 0
+"""
+
 _MULTI_SNIPPET = """\
 def simple(x):
     return x
@@ -260,6 +269,72 @@ def b_mid(x):
         )
 
         assert result.exit_code == 2
+
+
+class TestSuggestRefactorsOutput:
+    def test_suggest_refactors_prints_plan_fragments(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_REFACTOR_SNIPPET, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--suggest-refactors", str(source_file)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Refactor plans:" in result.output
+        assert "Flatten nested condition block with guard clauses" in result.output
+        assert "estimated: 7 -> 5 (-2)" in result.output
+        assert "invert the outer condition" in result.output
+
+    def test_failed_with_suggest_refactors_only_shows_displayed_failures(
+        self, tmp_path: Path
+    ):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            _REFACTOR_SNIPPET
+            + "\n\ndef simple(value):\n    return value\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            main_module.app,
+            ["--failed", "-mx", "0", "--suggest-refactors", str(source_file)],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "sample 7" in result.output
+        assert "Refactor plans:" in result.output
+        assert "simple" not in result.output
+
+    def test_plain_with_suggest_refactors_preserves_plain_output(
+        self, tmp_path: Path
+    ):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(_REFACTOR_SNIPPET, encoding="utf-8")
+
+        without_flag = runner.invoke(
+            main_module.app,
+            ["--plain", str(source_file)],
+        )
+        with_flag = runner.invoke(
+            main_module.app,
+            ["--plain", "--suggest-refactors", str(source_file)],
+        )
+
+        assert without_flag.exit_code == 0, without_flag.output
+        assert with_flag.exit_code == 0, with_flag.output
+        assert with_flag.output == without_flag.output
+        assert "Refactor plans:" not in with_flag.output
 
 
 class TestPlainOutput:


### PR DESCRIPTION
## What

Adds a `--suggest-refactors` CLI flag that displays deterministic refactor plans under functions in rich output.

## Why

The Rust planner already exposes refactor plans through the Python API; this makes those plans visible to CLI users without changing default, plain, or machine-readable output.

## Changes

- Adds `--suggest-refactors` as a CLI-only flag.
- Threads `refactor_plans` from `FunctionComplexity` into output rows.
- Renders refactor plan title, line range, estimated complexity reduction, and steps in rich output.
- Keeps output unchanged when `--suggest-refactors` is not used.
- Keeps `--plain --suggest-refactors` identical to normal `--plain`.
- Ensures `--failed --suggest-refactors` only shows plans for displayed failing functions.
- Adds CLI tests for rich display, failed filtering, and plain compatibility.

## Validation

- `uv run pytest -q`
- `uv run ruff check complexipy tests/test_output_cli.py`
- `uv run ty check complexipy tests/test_output_cli.py`