### PR TITLE
Expose refactor plans in JSON output and release-only docs deploys

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -463,3 +463,11 @@ jobs:
               with:
                   command: upload
                   args: --non-interactive --skip-existing dist/*
+
+    deploy-docs:
+        name: Deploy docs
+        needs: release
+        if: startsWith(github.ref, 'refs/tags/')
+        permissions:
+            contents: write
+        uses: ./.github/workflows/docs.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,7 @@
 name: Deploy docs
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ complexipy . --output-format json --output-format csv
 # Show the top 5 most complex functions
 complexipy . --top 5
 
+# Show deterministic refactor suggestions for failing functions
+complexipy . --failed --suggest-refactors
+
 # Emit plain text for scripting/AI agents
 complexipy . --plain
 
@@ -247,6 +250,7 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 | `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
 | `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
 | `--failed`                      | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--suggest-refactors`           | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain`                                                                        | `false` |
 | `--color <auto\|yes\|no>`       | Use color                                                                                                                                                        | `auto`  |
 | `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                     | `asc`   |
 | `--quiet`                       | Suppress output                                                                                                                                                  | `false` |
@@ -272,6 +276,24 @@ complexipy . --exclude tests
 # This will not exclude './complexipy/utils.py' if you pass '--exclude utils' at repo root,
 # because there is no './utils' directory or file at that level.
 ```
+
+### Refactor Suggestions
+
+Use `--suggest-refactors` to print a small, ranked set of deterministic refactor plans next to rich CLI results:
+
+```bash
+complexipy . --failed --suggest-refactors
+```
+
+Sample output:
+
+```text
+Refactor plans:
+  • Flatten nested condition block with guard clauses (lines 3-8, estimated: 7 -> 5 (-2))
+    - invert the outer condition and return early
+```
+
+Plans are based on the Rust AST analysis only; no AI is used and no code is rewritten automatically. Estimated reductions are approximate, ranked, and limited, so treat them as guidance rather than exact future scores. `--plain --suggest-refactors` keeps plain output unchanged.
 
 ### Snapshot Baselines
 
@@ -373,7 +395,18 @@ FunctionComplexity:
   ├─ complexity: int
   ├─ line_start: int
   ├─ line_end: int
-  └─ line_complexities: List[LineComplexity]
+  ├─ line_complexities: List[LineComplexity]
+  └─ refactor_plans: List[RefactorPlan]
+
+RefactorPlan:
+  ├─ kind: str
+  ├─ title: str
+  ├─ line_start: int
+  ├─ line_end: int
+  ├─ current_complexity: int
+  ├─ estimated_reduction: int
+  ├─ estimated_complexity_after: int
+  └─ steps: List[str]
 
 LineComplexity:
   ├─ line: int

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -71,6 +71,9 @@ complexipy . --output-format json --output-format csv
 # Muestra las 5 funciones más complejas
 complexipy . --top 5
 
+# Muestra sugerencias deterministas de refactorización para funciones fallidas
+complexipy . --failed --suggest-refactors
+
 # Emite texto plano para scripts o agentes de IA
 complexipy . --plain
 
@@ -208,6 +211,7 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 | `--snapshot-create`        | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
 | `--snapshot-ignore`        | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
 | `--failed`                 | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                             | `false`        |
+| `--suggest-refactors`      | Muestra planes deterministas de refactorización basados en el AST de Rust en la salida CLI enriquecida. Ignorado por `--plain`                                                                              | `false`        |
 | `--color <auto\|yes\|no>`  | Usa color                                                                                                                                                                                                   | `auto`         |
 | `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                   | `asc`          |
 | `--quiet`                  | Suprime la salida                                                                                                                                                                                           | `false`        |
@@ -233,6 +237,24 @@ complexipy . --exclude tests
 # Esto no excluirá './complexipy/utils.py' si pasas '--exclude utils' en la raíz del repositorio,
 # porque no hay ningún directorio o archivo './utils' en ese nivel.
 ```
+
+### Sugerencias de Refactorización
+
+Usa `--suggest-refactors` para imprimir un conjunto pequeño y ordenado de planes deterministas de refactorización junto a los resultados enriquecidos de la CLI:
+
+```bash
+complexipy . --failed --suggest-refactors
+```
+
+Salida de ejemplo:
+
+```text
+Refactor plans:
+  • Flatten nested condition block with guard clauses (lines 3-8, estimated: 7 -> 5 (-2))
+    - invert the outer condition and return early
+```
+
+Los planes se basan solo en el análisis AST de Rust; no se usa IA y no se reescribe código automáticamente. Las reducciones estimadas son aproximadas, ordenadas y limitadas, así que trátalas como orientación, no como puntuaciones futuras exactas. `--plain --suggest-refactors` mantiene la salida plana sin cambios.
 
 ### Snapshots Base
 
@@ -331,7 +353,18 @@ FunctionComplexity:
   ├─ complexity: int
   ├─ line_start: int
   ├─ line_end: int
-  └─ line_complexities: List[LineComplexity]
+  ├─ line_complexities: List[LineComplexity]
+  └─ refactor_plans: List[RefactorPlan]
+
+RefactorPlan:
+  ├─ kind: str
+  ├─ title: str
+  ├─ line_start: int
+  ├─ line_end: int
+  ├─ current_complexity: int
+  ├─ estimated_reduction: int
+  ├─ estimated_complexity_after: int
+  └─ steps: List[str]
 
 LineComplexity:
   ├─ line: int

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -62,6 +62,12 @@ Mostrar solo las N funciones más complejas entre todos los archivos analizados:
 complexipy . --top 10
 ```
 
+Mostrar sugerencias deterministas de refactorización para funciones fallidas:
+
+```bash
+complexipy . --failed --suggest-refactors
+```
+
 Cuando se usa `--top`, los resultados se reordenan globalmente por complejidad
 descendente antes de truncarse.
 
@@ -195,6 +201,25 @@ complexipy path/to/script.py --check-script -mx 5
 
 Esto es útil para scripts con flujo de control complejo en el nivel superior,
 fuera de las funciones.
+
+### Sugerencias de Refactorización
+
+Usa `--suggest-refactors` para imprimir un conjunto pequeño y ordenado de planes deterministas de refactorización junto a los resultados enriquecidos de la CLI:
+
+```bash
+complexipy . --failed --suggest-refactors
+```
+
+Salida de ejemplo:
+
+```text
+Refactor plans:
+  • Flatten nested condition block with guard clauses (lines 3-8, estimated: 7 -> 5 (-2))
+    - invert the outer condition and return early
+```
+
+Los planes se basan solo en el análisis AST de Rust; no se usa IA y no se reescribe código automáticamente. Las reducciones estimadas son aproximadas, ordenadas y limitadas, así que trátalas como orientación, no como puntuaciones futuras exactas. `--plain --suggest-refactors` mantiene la salida plana sin cambios.
+
 **Estructura de Salida JSON:**
 
 ```json
@@ -203,12 +228,26 @@ fuera de las funciones.
         "path": "src",
         "file_name": "main.py",
         "function_name": "process_data",
-        "complexity": 18
+        "complexity": 18,
+        "refactor_plans": [
+            {
+                "kind": "flatten_condition",
+                "title": "Flatten nested condition block with guard clauses",
+                "line_start": 12,
+                "line_end": 18,
+                "current_complexity": 18,
+                "estimated_reduction": 3,
+                "estimated_complexity_after": 15,
+                "steps": [
+                    "invert the outer condition and return early"
+                ]
+            }
+        ]
     }
 ]
 ```
 
-Las salidas JSON y CSV contienen una entrada por cada función emitida. Los rangos de líneas están disponibles mediante la API de Python (`line_start`, `line_end`), pero no se incluyen en las salidas JSON/CSV legibles por máquina de la CLI.
+La salida JSON contiene una entrada por cada función emitida e incluye `refactor_plans` (o `[]` cuando no existe ningún plan). La salida CSV no cambia y no incluye planes. Los rangos de líneas de funciones están disponibles mediante la API de Python (`line_start`, `line_end`), pero no se incluyen en las entradas de función JSON/CSV legibles por máquina de la CLI.
 
 ### Salida en Color
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,9 @@ complexipy . --output-format json --output-format csv
 # Show the top 5 most complex functions
 complexipy . --top 5
 
+# Show deterministic refactor suggestions for failing functions
+complexipy . --failed --suggest-refactors
+
 # Emit plain text for scripting/AI agents
 complexipy . --plain
 
@@ -208,6 +211,7 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 | `--snapshot-create`        | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
 | `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
 | `--failed`                 | Show only functions above the complexity threshold                                                                                                               | `false` |
+| `--suggest-refactors`      | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain`                                                                        | `false` |
 | `--color <auto\|yes\|no>`  | Use color                                                                                                                                                        | `auto`  |
 | `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                 | `asc`   |
 | `--quiet`                  | Suppress output                                                                                                                                                  | `false` |
@@ -233,6 +237,24 @@ complexipy . --exclude tests
 # This will not exclude './complexipy/utils.py' if you pass '--exclude utils' at repo root,
 # because there is no './utils' directory or file at that level.
 ```
+
+### Refactor Suggestions
+
+Use `--suggest-refactors` to print a small, ranked set of deterministic refactor plans next to rich CLI results:
+
+```bash
+complexipy . --failed --suggest-refactors
+```
+
+Sample output:
+
+```text
+Refactor plans:
+  • Flatten nested condition block with guard clauses (lines 3-8, estimated: 7 -> 5 (-2))
+    - invert the outer condition and return early
+```
+
+Plans are based on the Rust AST analysis only; no AI is used and no code is rewritten automatically. Estimated reductions are approximate, ranked, and limited, so treat them as guidance rather than exact future scores. `--plain --suggest-refactors` keeps plain output unchanged.
 
 ### Snapshot Baselines
 
@@ -331,7 +353,18 @@ FunctionComplexity:
   ├─ complexity: int
   ├─ line_start: int
   ├─ line_end: int
-  └─ line_complexities: List[LineComplexity]
+  ├─ line_complexities: List[LineComplexity]
+  └─ refactor_plans: List[RefactorPlan]
+
+RefactorPlan:
+  ├─ kind: str
+  ├─ title: str
+  ├─ line_start: int
+  ├─ line_end: int
+  ├─ current_complexity: int
+  ├─ estimated_reduction: int
+  ├─ estimated_complexity_after: int
+  └─ steps: List[str]
 
 LineComplexity:
   ├─ line: int

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -62,6 +62,12 @@ Show only the top N most complex functions across the analyzed files:
 complexipy . --top 10
 ```
 
+Show deterministic refactor suggestions for failing functions:
+
+```bash
+complexipy . --failed --suggest-refactors
+```
+
 When `--top` is set, results are globally re-sorted by complexity descending
 before truncation.
 
@@ -198,6 +204,25 @@ complexipy path/to/script.py --check-script -mx 5
 
 This is useful for scripts with complex top-level control flow outside
 functions.
+
+### Refactor Suggestions
+
+Use `--suggest-refactors` to print a small, ranked set of deterministic refactor plans next to rich CLI results:
+
+```bash
+complexipy . --failed --suggest-refactors
+```
+
+Sample output:
+
+```text
+Refactor plans:
+  • Flatten nested condition block with guard clauses (lines 3-8, estimated: 7 -> 5 (-2))
+    - invert the outer condition and return early
+```
+
+Plans are based on the Rust AST analysis only; no AI is used and no code is rewritten automatically. Estimated reductions are approximate, ranked, and limited, so treat them as guidance rather than exact future scores. `--plain --suggest-refactors` keeps plain output unchanged.
+
 **JSON Output Structure:**
 
 ```json
@@ -206,12 +231,26 @@ functions.
         "path": "src",
         "file_name": "main.py",
         "function_name": "process_data",
-        "complexity": 18
+        "complexity": 18,
+        "refactor_plans": [
+            {
+                "kind": "flatten_condition",
+                "title": "Flatten nested condition block with guard clauses",
+                "line_start": 12,
+                "line_end": 18,
+                "current_complexity": 18,
+                "estimated_reduction": 3,
+                "estimated_complexity_after": 15,
+                "steps": [
+                    "invert the outer condition and return early"
+                ]
+            }
+        ]
     }
 ]
 ```
 
-The JSON and CSV outputs contain one entry per emitted function. Line ranges are available through the Python API (`line_start`, `line_end`), but are not included in the machine-readable CLI JSON/CSV outputs.
+JSON output contains one entry per emitted function and includes `refactor_plans` (or `[]` when no plan exists). CSV output is unchanged and does not include plans. Function line ranges are available through the Python API (`line_start`, `line_end`), but are not included in the machine-readable CLI JSON/CSV function entries.
 
 ### Color Output
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -111,7 +111,8 @@ pub fn output_json(
                     "path": file.path,
                     "file_name": file.file_name,
                     "function_name": function.name,
-                    "complexity": function.complexity
+                    "complexity": function.complexity,
+                    "refactor_plans": function.refactor_plans
                 });
                 json_data.push(entry);
             }

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -38,7 +38,9 @@ class TestJsonOutput:
 
         assert content.endswith(b"\n")
         assert not content.endswith(b"\n\n")
-        assert json.loads(content.decode("utf-8"))[0]["function_name"] == "simple"
+        data = json.loads(content.decode("utf-8"))
+        assert data[0]["function_name"] == "simple"
+        assert data[0]["refactor_plans"] == []
 
     def test_cli_json_output_has_final_newline(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module

--- a/tests/test_refactor_plans.py
+++ b/tests/test_refactor_plans.py
@@ -149,7 +149,7 @@ def sample(a, b, c, d):
     assert func.refactor_plans[0].estimated_complexity_after <= func.complexity
 
 
-def test_manual_cli_json_and_snapshot_output_remain_unchanged(tmp_path) -> None:
+def test_manual_cli_json_includes_refactor_plans_and_snapshot_stays_unchanged(tmp_path) -> None:
     source = tmp_path / "sample.py"
     source.write_text(
         """
@@ -165,12 +165,25 @@ def sample(a, b, c, d):
 
     complexipy._complexipy.output_json(str(output_path), [file_result], True, 0)
 
-    assert json.loads(output_path.read_text()) == [
+    json_data = json.loads(output_path.read_text())
+    assert json_data == [
         {
             "path": "sample.py",
             "file_name": "sample.py",
             "function_name": "sample",
             "complexity": func.complexity,
+            "refactor_plans": [
+                {
+                    "kind": func.refactor_plans[0].kind,
+                    "title": func.refactor_plans[0].title,
+                    "line_start": func.refactor_plans[0].line_start,
+                    "line_end": func.refactor_plans[0].line_end,
+                    "current_complexity": func.refactor_plans[0].current_complexity,
+                    "estimated_reduction": func.refactor_plans[0].estimated_reduction,
+                    "estimated_complexity_after": func.refactor_plans[0].estimated_complexity_after,
+                    "steps": list(func.refactor_plans[0].steps),
+                }
+            ],
         }
     ]
 


### PR DESCRIPTION
## What

This PR documents refactor suggestions, adds refactor plans to JSON output, and changes docs deployment to run only during tagged releases.

## Why

Users need to discover `--suggest-refactors` and consume plans from machine-readable JSON without changing CSV, SARIF, snapshots, or plain output. Docs should only be published when a release is being made.

## Changes

- Add `refactor_plans` to JSON output with an empty array when no plans exist.
- Keep CSV, SARIF, snapshots, and existing required JSON fields unchanged.
- Update English and Spanish docs with `--suggest-refactors`, sample output, limitations, and API/JSON shape.
- Add tests for JSON plan serialization and empty plan arrays.
- Convert docs workflow to reusable `workflow_call` only.
- Trigger docs deployment from the release CI job after publishing tagged releases.