### PR TITLE
Fix recursive exclude matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "wasm-bindgen",
+ "wax",
  "web-sys",
 ]
 
@@ -154,6 +155,27 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -440,6 +462,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +545,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -581,6 +634,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1226,6 +1288,21 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wax"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8cbf8125142b9b30321ac8721f54c52fbcd6659f76cf863d5e2e38c07a3d7b"
+dependencies = [
+ "const_format",
+ "itertools",
+ "nom",
+ "pori",
+ "regex",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ js-sys = { version = "0.3", optional = true }
 serde-wasm-bindgen = { version = "0.4", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 web-sys = { version = "0.3", features = ["console"], optional = true }
+wax = "0.7.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ complexipy . --diff HEAD~1
 
 # Fail only on threshold-breaking regressions in a diff
 complexipy . --diff main --ratchet
-# Analyze current directory while excluding specific files
-complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
+# Analyze current directory while excluding files or directories with glob patterns
+complexipy . --exclude "tests/**" --exclude "path/to/exclude.py"
 ```
 
 ### Python API
@@ -245,7 +245,7 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 | Flag                            | Description                                                                                                                                                      | Default |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                     | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--exclude`                     | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files. |         |
 | `--max-complexity-allowed`      | Complexity threshold                                                                                                                                             | `15`    |
 | `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
 | `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
@@ -271,10 +271,10 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 Example:
 
 ```
-# Exclude only top-level 'tests' directory under the provided root
-complexipy . --exclude tests
-# This will not exclude './complexipy/utils.py' if you pass '--exclude utils' at repo root,
-# because there is no './utils' directory or file at that level.
+# Exclude a directory recursively under the provided root
+complexipy . --exclude "tests/**"
+# Exclude a specific file
+complexipy . --exclude "src/legacy/old_code.py"
 ```
 
 ### Refactor Suggestions

--- a/complexipy.toml
+++ b/complexipy.toml
@@ -4,6 +4,6 @@ quiet = false
 ignore-complexity = false
 failed = false
 sort = "asc"
-exclude = ["tests"]
+exclude = ["tests/**"]
 output-csv = false
 output-json = false

--- a/complexipy/_complexipy.pyi
+++ b/complexipy/_complexipy.pyi
@@ -294,6 +294,7 @@ def main(
     quiet: bool,
     exclude: List[str],
     check_script: bool = False,
+    invocation_path: str = ".",
 ) -> Tuple[List[FileComplexity], List[str]]:
     """
     Analyze cognitive complexity of Python files and directories.

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -22,13 +22,17 @@ from complexipy import (
     _complexipy,
 )
 from complexipy._complexipy import FileComplexity
-
 from complexipy.types import (
     ColorTypes,
     OutputFormat,
     Sort,
 )
 from complexipy.utils.cache import remember_previous_functions
+from complexipy.utils.constants import (
+    DEFAULT_OUTPUT_FILENAMES,
+    LEGACY_OUTPUT_CONFIG_KEYS,
+    LEGACY_OUTPUT_FLAGS,
+)
 from complexipy.utils.csv import store_csv
 from complexipy.utils.diff import (
     DiffEntry,
@@ -54,11 +58,6 @@ from complexipy.utils.toml import (
     get_argument_value,
     get_arguments_value,
     get_complexipy_toml_config,
-)
-from complexipy.utils.constants import (
-    DEFAULT_OUTPUT_FILENAMES,
-    LEGACY_OUTPUT_CONFIG_KEYS,
-    LEGACY_OUTPUT_FLAGS,
 )
 
 app = typer.Typer(name="complexipy")
@@ -295,7 +294,7 @@ def main(
     handle_console_settings(color, quiet, plain)
 
     result: Tuple[List[FileComplexity], List[str]] = _complexipy.main(
-        paths, quiet, exclude, check_script
+        paths, quiet, exclude, check_script, INVOCATION_PATH
     )
     files_complexities, failed_paths = result
     emit_deprecated_output_warnings(

--- a/complexipy/utils/cache.py
+++ b/complexipy/utils/cache.py
@@ -3,15 +3,33 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import time
 from pathlib import Path
 from typing import (
+    Dict,
     List,  # It's important to use this to make it compatible with python 3.8, don't remove it
     Optional,
+    cast,
 )
 
 from complexipy._complexipy import FileComplexity
 
 CACHE_DIR_NAME = ".complexipy_cache"
+CACHE_VALUES_DIR = "v/cache"
+FUNCTIONS_CACHE_KEY = "functions"
+MAX_CACHE_ENTRIES = 64
+CACHEDIR_TAG_CONTENT = """Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by complexipy.
+# For information about cache directory tags, see:
+#	https://bford.info/cachedir/spec.html
+"""
+README_CONTENT = """# complexipy cache directory #
+
+This directory contains data from complexipy's cache, which stores previous
+complexity results so future runs can compare per-function complexity changes.
+
+**Do not** commit this to version control.
+"""
 
 
 def remember_previous_functions(
@@ -21,29 +39,33 @@ def remember_previous_functions(
 ) -> Optional[dict[tuple[str, str, str], int]]:
     """Store per-function results for the target set and return previous map.
 
-    The cache is organized per target set (using a stable hash of the targets)
-    but stores function-level complexities so future runs can compare totals
-    even if the underlying functions change.
+    The cache is stored in a pytest-like key/value layout to keep the number of
+    files bounded. Different target sets are entries inside one cache value, and
+    old target-set entries are pruned automatically.
     """
     cache_key = _build_cache_key(invocation_path, targets)
     if cache_key is None:
         return None
 
     cache_dir = Path(invocation_path) / CACHE_DIR_NAME
+    cache_file = _cache_value_path(cache_dir, FUNCTIONS_CACHE_KEY)
     try:
-        cache_dir.mkdir(exist_ok=True)
-        _ensure_gitignore(cache_dir)
+        _ensure_cache_dir_and_supporting_files(cache_dir)
     except OSError:
         return None
 
-    cache_file = cache_dir / f"{cache_key}.json"
-    previous_map = _load_previous_map(cache_file)
+    cache_store = _load_cache_store(cache_file)
+    _migrate_legacy_cache_entry(cache_dir, cache_store, cache_key)
+    previous_map = _load_previous_map_from_store(cache_store, cache_key)
 
-    payload = {
+    cache_store.setdefault("entries", {})[cache_key] = {
         "targets": _normalize_targets(invocation_path, targets),
         "functions": _collect_functions(files_complexities),
+        "updated_at": time.time(),
     }
-    _persist_cache(cache_file, payload)
+    _prune_cache_store(cache_store)
+    if _persist_cache(cache_file, cache_store):
+        _remove_legacy_cache_files(cache_dir)
     return previous_map
 
 
@@ -103,13 +125,66 @@ def _collect_functions(files_complexities: List[FileComplexity]) -> List[dict]:
     return functions
 
 
-def _load_previous_map(
-    cache_file: Path,
-) -> Optional[dict[tuple[str, str, str], int]]:
+def _cache_value_path(cache_dir: Path, key: str) -> Path:
+    return cache_dir.joinpath(CACHE_VALUES_DIR, key)
+
+
+def _load_cache_store(cache_file: Path) -> dict:
     raw = _load_cache(cache_file)
     if raw is None:
+        return {"entries": {}}
+
+    entries = raw.get("entries")
+    if not isinstance(entries, dict):
+        return {"entries": {}}
+
+    return raw
+
+
+def _migrate_legacy_cache_entry(
+    cache_dir: Path,
+    cache_store: dict,
+    cache_key: str,
+) -> None:
+    entries = cache_store.get("entries")
+    if not isinstance(entries, dict) or cache_key in entries:
+        return
+
+    legacy_cache_file = cache_dir / f"{cache_key}.json"
+    legacy_payload = _load_cache(legacy_cache_file)
+    if legacy_payload is None:
+        return
+
+    try:
+        updated_at = legacy_cache_file.stat().st_mtime
+    except OSError:
+        updated_at = 0.0
+
+    entries[cache_key] = {
+        "targets": legacy_payload.get("targets", []),
+        "functions": legacy_payload.get("functions", []),
+        "updated_at": updated_at,
+    }
+
+
+def _load_previous_map_from_store(
+    cache_store: dict,
+    cache_key: str,
+) -> Optional[dict[tuple[str, str, str], int]]:
+    entries = cache_store.get("entries")
+    if not isinstance(entries, dict):
         return None
 
+    entry = entries.get(cache_key)
+    if not isinstance(entry, dict):
+        return None
+
+    return _load_previous_map(entry)
+
+
+def _load_previous_map(
+    raw: dict,
+) -> Optional[dict[tuple[str, str, str], int]]:
     functions = raw.get("functions", [])
     if not isinstance(functions, list):
         return None
@@ -159,22 +234,73 @@ def _build_function_key(
     return (path, file_name, function_name)
 
 
-def _persist_cache(cache_file: Path, payload: dict) -> None:
+def _prune_cache_store(cache_store: dict) -> None:
+    entries = cache_store.get("entries")
+    if not isinstance(entries, dict) or len(entries) <= MAX_CACHE_ENTRIES:
+        return
+
+    sorted_entries = sorted(
+        entries.items(),
+        key=lambda item: _entry_updated_at(item[1]),
+        reverse=True,
+    )
+    cache_store["entries"] = dict(sorted_entries[:MAX_CACHE_ENTRIES])
+
+
+def _entry_updated_at(entry: object) -> float:
+    if not isinstance(entry, dict):
+        return 0.0
+
+    entry_dict = cast(Dict[str, object], entry)
+    updated_at = entry_dict.get("updated_at")
+    if isinstance(updated_at, bool):
+        return 0.0
+
+    if isinstance(updated_at, (int, float, str)):
+        try:
+            return float(updated_at)
+        except ValueError:
+            return 0.0
+
+    return 0.0
+
+
+def _persist_cache(cache_file: Path, payload: dict) -> bool:
     try:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_text(
             json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
         )
     except OSError:
         # Failing to persist the cache should not break the main command.
-        pass
+        return False
+
+    return True
 
 
-def _ensure_gitignore(cache_dir: Path) -> None:
-    """Create a .gitignore file in the cache directory to prevent accidental commits."""
-    gitignore_file = cache_dir / ".gitignore"
-    if not gitignore_file.exists():
+def _remove_legacy_cache_files(cache_dir: Path) -> None:
+    for legacy_cache_file in cache_dir.glob("*.json"):
         try:
-            gitignore_file.write_text("*\n", encoding="utf-8")
+            legacy_cache_file.unlink()
         except OSError:
-            # Failing to create .gitignore should not break the main command.
+            # Failing to remove legacy cache files should not break the main command.
             pass
+
+
+def _ensure_cache_dir_and_supporting_files(cache_dir: Path) -> None:
+    """Create the cache directory and support files used by cache tools."""
+    cache_dir.mkdir(exist_ok=True)
+    _write_support_file(cache_dir / ".gitignore", "*\n")
+    _write_support_file(cache_dir / "CACHEDIR.TAG", CACHEDIR_TAG_CONTENT)
+    _write_support_file(cache_dir / "README.md", README_CONTENT)
+
+
+def _write_support_file(path: Path, content: str) -> None:
+    if path.exists():
+        return
+
+    try:
+        path.write_text(content, encoding="utf-8")
+    except OSError:
+        # Failing to create support files should not break the main command.
+        pass

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -85,8 +85,8 @@ complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Compara la complejidad contra una referencia de git
 complexipy . --diff HEAD~1
-# Analiza el directorio actual excluyendo ciertos archivos
-complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
+# Analiza el directorio actual excluyendo archivos o directorios con patrones glob
+complexipy . --exclude "tests/**" --exclude "path/to/exclude.py"
 ```
 
 ### API de Python
@@ -206,7 +206,7 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 
 | Opción                     | Descripción                                                                                                                                                                                                 | Predeterminado |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `--exclude`                | Excluye entradas relativas a cada ruta proporcionada. Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta). Las entradas inexistentes se ignoran. |                |
+| `--exclude`                | Excluye patrones glob relativos a cada ruta proporcionada. Usa patrones como `tests/**` para directorios o `src/legacy/file.py` para archivos específicos. |                |
 | `--max-complexity-allowed` | Umbral de complejidad                                                                                                                                                                                       | `15`           |
 | `--snapshot-create`        | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                         | `false`        |
 | `--snapshot-ignore`        | Omite la comparación con un snapshot aunque exista                                                                                                                                                          | `false`        |
@@ -232,10 +232,10 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 Ejemplo:
 
 ```
-# Excluye solo el directorio 'tests' de nivel superior bajo la raíz proporcionada
-complexipy . --exclude tests
-# Esto no excluirá './complexipy/utils.py' si pasas '--exclude utils' en la raíz del repositorio,
-# porque no hay ningún directorio o archivo './utils' en ese nivel.
+# Excluye un directorio recursivamente bajo la raíz proporcionada
+complexipy . --exclude "tests/**"
+# Excluye un archivo específico
+complexipy . --exclude "src/legacy/old_code.py"
 ```
 
 ### Sugerencias de Refactorización

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -92,21 +92,22 @@ complexipy . --sort file_name  # Alfabéticamente por nombre de archivo
 Excluir rutas específicas del análisis:
 
 ```bash
-# Excluir un directorio
-complexipy . --exclude tests
+# Excluir un directorio recursivamente
+complexipy . --exclude "tests/**"
 
-# Excluir múltiples rutas
-complexipy . --exclude tests --exclude migrations --exclude build
+# Excluir múltiples directorios recursivamente
+complexipy . --exclude "tests/**" --exclude "migrations/**" --exclude "build/**"
 
 # Excluir archivos específicos
-complexipy . --exclude src/legacy/old_code.py
+complexipy . --exclude "src/legacy/old_code.py"
 ```
 
 <!-- prettier-ignore -->
 !!! note "Cómo funciona la exclusión"
-    - Las entradas se resuelven a directorios existentes (coincidencia por prefijo) o archivos (coincidencia exacta)
-    - Las entradas inexistentes se ignoran silenciosamente
-    - Las rutas son relativas a cada ruta raíz proporcionada
+    - Las exclusiones son patrones glob evaluados de forma relativa a cada ruta raíz proporcionada
+    - Usa `directory/**` para excluir un directorio recursivamente
+    - Usa una ruta relativa exacta, como `src/legacy/old_code.py`, para excluir un archivo
+    - Las reglas de gitignore se siguen respetando durante el descubrimiento de archivos
 
 ### Formatos de Salida
 
@@ -277,7 +278,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     ```toml
     paths = ["src", "tests"]
     max-complexity-allowed = 10
-    exclude = ["migrations", "build"]
+    exclude = ["migrations/**", "build/**"]
     snapshot-create = false
     snapshot-ignore = false
     quiet = false
@@ -296,7 +297,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     [tool.complexipy]
     paths = ["src", "tests"]
     max-complexity-allowed = 10
-    exclude = ["migrations", "build"]
+    exclude = ["migrations/**", "build/**"]
     failed = true
     sort = "desc"
     check-script = true
@@ -307,7 +308,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     ```toml
     # Archivo de configuración oculto para ajustes específicos del equipo
     max-complexity-allowed = 15
-    exclude = ["venv", ".venv", "node_modules"]
+    exclude = ["venv/**", ".venv/**", "node_modules/**"]
     ```
 
 `check-script` está soportado en TOML. `--top` y `--plain` son flags solo de CLI.
@@ -726,7 +727,7 @@ python -m py_compile file.py
 Excluir directorios innecesarios:
 
 ```bash
-complexipy . --exclude venv --exclude .venv --exclude node_modules
+complexipy . --exclude "venv/**" --exclude ".venv/**" --exclude "node_modules/**"
 ```
 
 ### Resultados diferentes a los esperados

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,8 +85,8 @@ complexipy . --output-format gitlab --output complexipy-code-quality.json
 
 # Compare complexity against a git reference
 complexipy . --diff HEAD~1
-# Analyze current directory while excluding specific files
-complexipy . --exclude path/to/exclude.py --exclude path/to/other/exclude.py
+# Analyze current directory while excluding files or directories with glob patterns
+complexipy . --exclude "tests/**" --exclude "path/to/exclude.py"
 ```
 
 ### Python API
@@ -206,7 +206,7 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 | Flag                       | Description                                                                                                                                                      | Default |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                | Exclude entries relative to each provided path. Entries resolve to existing directories (prefix match) or files (exact match). Non-existent entries are ignored. |         |
+| `--exclude`                | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files. |         |
 | `--max-complexity-allowed` | Complexity threshold                                                                                                                                             | `15`    |
 | `--snapshot-create`        | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                  | `false` |
 | `--snapshot-ignore`        | Skip comparing against the snapshot even if it exists                                                                                                            | `false` |
@@ -232,10 +232,10 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 Example:
 
 ```
-# Exclude only top-level 'tests' directory under the provided root
-complexipy . --exclude tests
-# This will not exclude './complexipy/utils.py' if you pass '--exclude utils' at repo root,
-# because there is no './utils' directory or file at that level.
+# Exclude a directory recursively under the provided root
+complexipy . --exclude "tests/**"
+# Exclude a specific file
+complexipy . --exclude "src/legacy/old_code.py"
 ```
 
 ### Refactor Suggestions

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -92,21 +92,22 @@ complexipy . --sort file_name  # Alphabetically by file name
 Exclude specific paths from analysis:
 
 ```bash
-# Exclude a directory
-complexipy . --exclude tests
+# Exclude a directory recursively
+complexipy . --exclude "tests/**"
 
-# Exclude multiple paths
-complexipy . --exclude tests --exclude migrations --exclude build
+# Exclude multiple directories recursively
+complexipy . --exclude "tests/**" --exclude "migrations/**" --exclude "build/**"
 
 # Exclude specific files
-complexipy . --exclude src/legacy/old_code.py
+complexipy . --exclude "src/legacy/old_code.py"
 ```
 
 <!-- prettier-ignore -->
 !!! note "How exclusion works"
-    - Entries resolve to existing directories (prefix match) or files (exact match)
-    - Non-existent entries are silently ignored
-    - Paths are relative to each provided root path
+    - Exclusions are glob patterns evaluated relative to each provided root path
+    - Use `directory/**` to exclude a directory recursively
+    - Use an exact relative file path, such as `src/legacy/old_code.py`, to exclude one file
+    - Gitignore rules are still respected during file discovery
 
 ### Output Formats
 
@@ -280,7 +281,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     ```toml
     paths = ["src", "tests"]
     max-complexity-allowed = 10
-    exclude = ["migrations", "build"]
+    exclude = ["migrations/**", "build/**"]
     snapshot-create = false
     snapshot-ignore = false
     quiet = false
@@ -299,7 +300,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     [tool.complexipy]
     paths = ["src", "tests"]
     max-complexity-allowed = 10
-    exclude = ["migrations", "build"]
+    exclude = ["migrations/**", "build/**"]
     failed = true
     sort = "desc"
     check-script = true
@@ -310,7 +311,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     ```toml
     # Hidden config file for team-specific settings
     max-complexity-allowed = 15
-    exclude = ["venv", ".venv", "node_modules"]
+    exclude = ["venv/**", ".venv/**", "node_modules/**"]
     ```
 
 `check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
@@ -729,7 +730,7 @@ python -m py_compile file.py
 Exclude unnecessary directories:
 
 ```bash
-complexipy . --exclude venv --exclude .venv --exclude node_modules
+complexipy . --exclude "venv/**" --exclude ".venv/**" --exclude "node_modules/**"
 ```
 
 ### Different results than expected

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -16,9 +16,8 @@ use shared_deps::*;
 
 #[cfg(feature = "python")]
 mod python_deps {
+    pub use crate::helpers::exclude::get_paths_to_process;
     pub use crate::utils::get_repo_name;
-    pub use globset::{Glob, GlobMatcher};
-    pub use ignore::Walk;
     pub use indicatif::ProgressBar;
     pub use indicatif::ProgressStyle;
     pub use pyo3::exceptions::PyValueError;
@@ -41,15 +40,21 @@ type ComplexitiesAndFailedPaths = (Vec<FileComplexity>, Vec<String>);
 
 #[cfg(feature = "python")]
 #[pyfunction]
-#[pyo3(signature = (paths, quiet, exclude, check_script=false))]
+#[pyo3(signature = (paths, quiet, exclude, check_script=false, invocation_path="."))]
 pub fn main(
     paths: Vec<&str>,
     quiet: bool,
     exclude: Vec<&str>,
     check_script: bool,
+    invocation_path: &str,
 ) -> PyResult<ComplexitiesAndFailedPaths> {
     let re = Regex::new(r"^(https:\/\/|http:\/\/|www\.|git@)(github|gitlab)\.com(\/[\w.-]+){2,}$")
         .map_err(|e| PyValueError::new_err(format!("Invalid repository pattern: {}", e)))?;
+
+    let cwd = path::Path::new(invocation_path)
+        .canonicalize()
+        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
+    let cwd_str = cwd.to_string_lossy().replace('\\', "/");
 
     let mut successful = Vec::new();
     let mut failed_paths = Vec::new();
@@ -65,7 +70,15 @@ pub fn main(
             continue;
         }
 
-        match process_path(path, is_dir, is_url, quiet, exclude.clone(), check_script) {
+        match process_path(
+            path,
+            is_dir,
+            is_url,
+            quiet,
+            exclude.clone(),
+            check_script,
+            &cwd_str,
+        ) {
             Ok((mut complexities, mut f_paths)) => {
                 successful.append(&mut complexities);
                 failed_paths.append(&mut f_paths);
@@ -86,6 +99,7 @@ pub fn process_path(
     quiet: bool,
     exclude: Vec<&str>,
     check_script: bool,
+    invocation_path: &str,
 ) -> Result<ComplexitiesAndFailedPaths, PyErr> {
     let mut file_complexities = Vec::new();
     let mut failed_paths = Vec::new();
@@ -139,13 +153,19 @@ pub fn process_path(
         }
 
         let repo_path = dir.path().join(&repo_name).to_string_lossy().to_string();
-        let (complexities, f_paths) =
-            evaluate_dir(&repo_path, quiet, exclude.clone(), check_script);
+        let (complexities, f_paths) = evaluate_dir(
+            &repo_path,
+            quiet,
+            exclude.clone(),
+            check_script,
+            invocation_path,
+        );
         dir.close()?;
         file_complexities = complexities;
         failed_paths = f_paths;
     } else if is_dir {
-        let (complexities, f_paths) = evaluate_dir(path, quiet, exclude.clone(), check_script);
+        let (complexities, f_paths) =
+            evaluate_dir(path, quiet, exclude.clone(), check_script, invocation_path);
         file_complexities = complexities;
         failed_paths = f_paths;
     } else {
@@ -173,95 +193,22 @@ fn evaluate_dir(
     quiet: bool,
     exclude: Vec<&str>,
     check_script: bool,
+    _invocation_path: &str,
 ) -> ComplexitiesAndFailedPaths {
-    let mut files_paths: Vec<String> = Vec::new();
-    let parent_dir = path::Path::new(path)
+    let base_dir = path::Path::new(path)
+        .canonicalize()
+        .unwrap_or_else(|_| path::Path::new(path).to_path_buf())
         .parent()
-        .and_then(|p| p.to_str())
-        .unwrap_or(".");
-
-    #[derive(Clone)]
-    struct ExcludeSpec {
-        abs: String,
-        is_dir: bool,
-    }
-
-    let root_canon = match path::Path::new(path).canonicalize() {
-        Ok(p) => p,
-        Err(_) => path::PathBuf::from(path),
-    };
-    let root_canon_str = root_canon.to_string_lossy().replace('\\', "/");
-    let mut exclude_specs: Vec<ExcludeSpec> = Vec::new();
-    let mut glob_matchers: Vec<GlobMatcher> = Vec::new();
-
-    for raw in exclude.iter() {
-        if raw.contains('*') || raw.contains('?') || raw.contains('[') {
-            if let Ok(glob) = Glob::new(raw) {
-                glob_matchers.push(glob.compile_matcher());
-            }
-            continue;
-        }
-
-        let p = path::Path::new(raw);
-        let candidate = if p.is_absolute() {
-            p.to_path_buf()
-        } else {
-            root_canon.join(p)
-        };
-        let (exists, is_dir, is_file, abs_str) = match candidate.canonicalize() {
-            Ok(canon) => {
-                let is_dir = canon.is_dir();
-                let is_file = canon.is_file();
-                let s = canon.to_string_lossy().replace('\\', "/");
-                (true, is_dir, is_file, s)
-            }
-            Err(_) => (false, false, false, String::new()),
-        };
-
-        if exists && (is_dir || is_file) {
-            exclude_specs.push(ExcludeSpec {
-                abs: abs_str,
-                is_dir,
-            });
-        }
-    }
-
-    for entry in Walk::new(path) {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-        let entry_path = entry.path();
-        if entry_path.extension().and_then(|s| s.to_str()) != Some("py") {
-            continue;
-        }
-        let file_abs = match entry_path.canonicalize() {
-            Ok(p) => p,
-            Err(_) => entry_path.to_path_buf(),
-        };
-        let file_abs_str = file_abs.to_string_lossy().replace('\\', "/");
-        let relative_path = file_abs_str
-            .strip_prefix(&format!("{}/", root_canon_str))
-            .unwrap_or(&file_abs_str);
-        let is_excluded = exclude_specs.iter().any(|spec| {
-            if spec.is_dir {
-                file_abs_str.starts_with(&spec.abs)
-            } else {
-                file_abs_str == spec.abs
-            }
-        }) || glob_matchers
-            .iter()
-            .any(|m| m.is_match(relative_path) || m.is_match(&file_abs_str));
-        if !is_excluded && let Some(file_path_str) = entry_path.to_str() {
-            files_paths.push(file_path_str.to_string());
-        }
-    }
+        .unwrap_or(path::Path::new("."))
+        .to_string_lossy()
+        .replace('\\', "/");
+    let files_paths_to_process = get_paths_to_process(path, exclude);
 
     if quiet {
-        let results: Vec<_> = files_paths
+        let results: Vec<_> = files_paths_to_process
             .iter()
             .map(
-                |file_path| match file_complexity(file_path, parent_dir, check_script) {
+                |file_path| match file_complexity(file_path, &base_dir, check_script) {
                     Ok(file_complexity) => (Some(file_complexity), None),
                     Err(_) => (None, Some(file_path.clone())),
                 },
@@ -279,18 +226,18 @@ fn evaluate_dir(
         return (complexities, failed_paths);
     }
 
-    let pb = ProgressBar::new(files_paths.len() as u64);
+    let pb = ProgressBar::new(files_paths_to_process.len() as u64);
     let bar_style = indicatif::ProgressStyle::default_bar()
         .template("{spiner:.green} [{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}")
         .unwrap_or_else(|_| indicatif::ProgressStyle::default_bar())
         .progress_chars("##-");
     pb.set_style(bar_style);
 
-    let results: Vec<_> = files_paths
+    let results: Vec<_> = files_paths_to_process
         .iter()
         .map(|file_path| {
             pb.inc(1);
-            match file_complexity(file_path, parent_dir, check_script) {
+            match file_complexity(file_path, &base_dir, check_script) {
                 Ok(file_complexity) => (Some(file_complexity), None),
                 Err(_) => (None, Some(file_path.clone())),
             }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,1 @@
+pub mod exclude;

--- a/src/helpers/exclude.rs
+++ b/src/helpers/exclude.rs
@@ -1,0 +1,36 @@
+use ignore::Walk;
+use wax::walk::{Entry, FileIterator};
+use wax::{Glob, any};
+
+pub fn get_paths_to_process(root_path: &str, to_exclude_paths: Vec<&str>) -> Vec<String> {
+    let mut files_paths: Vec<String> = Vec::new();
+    let glob = Glob::new("**/*.py").unwrap();
+    let gitignore_walk = Walk::new(root_path);
+    let non_ignored: Vec<String> = gitignore_walk
+        .filter_map(|result| match result {
+            Ok(entry) => entry.path().to_str().map(String::from),
+            Err(_) => None,
+        })
+        .collect();
+
+    for entry in glob
+        .walk(root_path)
+        .not(any(to_exclude_paths))
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            let path = entry.path().to_str().expect("Failed to extract");
+            non_ignored.contains(&path.to_string())
+        })
+    {
+        let entry_path = entry.path();
+        let file_abs = match entry_path.canonicalize() {
+            Ok(p) => p,
+            Err(_) => entry_path.to_path_buf(),
+        };
+        let file_abs_str = file_abs.to_string_lossy().replace('\\', "/");
+        files_paths.push(file_abs_str.to_string());
+    }
+
+    files_paths
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod classes;
 mod cognitive_complexity;
+mod helpers;
 mod refactor_plans;
 mod utils;
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -252,7 +252,7 @@ def hello_world(s: str) -> str:
         files, _ = _complexipy.main(
             [path.resolve().as_posix()],
             False,
-            ["exclude_dir"],
+            ["exclude_dir/**"],
             False,
         )
         total_complexity = sum([file.complexity for file in files])

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,13 @@
+import json
 from pathlib import Path
 
 from complexipy import _complexipy
-from complexipy.utils.cache import CACHE_DIR_NAME, remember_previous_functions
+from complexipy.utils.cache import (
+    CACHE_DIR_NAME,
+    FUNCTIONS_CACHE_KEY,
+    MAX_CACHE_ENTRIES,
+    remember_previous_functions,
+)
 
 
 class TestCache:
@@ -28,14 +34,27 @@ class TestCache:
         assert cache_dir.exists()
         assert cache_dir.is_dir()
 
-        # Verify .gitignore was created
+        # Verify support files were created
         gitignore_file = cache_dir / ".gitignore"
         assert gitignore_file.exists()
         assert gitignore_file.is_file()
+        assert gitignore_file.read_text(encoding="utf-8") == "*\n"
 
-        # Verify .gitignore content
-        content = gitignore_file.read_text(encoding="utf-8")
-        assert content == "*\n"
+        cachedir_tag = cache_dir / "CACHEDIR.TAG"
+        assert cachedir_tag.exists()
+        assert cachedir_tag.is_file()
+        assert cachedir_tag.read_text(encoding="utf-8").startswith(
+            "Signature: 8a477f597d28d172789f06886806bc55"
+        )
+
+        readme = cache_dir / "README.md"
+        assert readme.exists()
+        assert readme.is_file()
+        assert "complexipy cache directory" in readme.read_text(encoding="utf-8")
+
+        cache_file = cache_dir / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        assert cache_file.exists()
+        assert cache_file.is_file()
 
     def test_gitignore_is_not_recreated_if_exists(self, tmp_path: Path):
         """Test that existing .gitignore is not overwritten."""
@@ -65,6 +84,104 @@ class TestCache:
         # Verify .gitignore still has custom content
         content = gitignore_file.read_text(encoding="utf-8")
         assert content == custom_content
+
+    def test_cache_reuses_single_functions_file_for_target_sets(self, tmp_path: Path):
+        """Test that target-set caches are entries in one value file."""
+        first_file = tmp_path / "first.py"
+        first_file.write_text("def first():\n    return 1\n", encoding="utf-8")
+        second_file = tmp_path / "second.py"
+        second_file.write_text("def second():\n    return 2\n", encoding="utf-8")
+
+        first_files, _ = _complexipy.main([str(first_file)], False, [])
+        second_files, _ = _complexipy.main([str(second_file)], False, [])
+
+        assert (
+            remember_previous_functions(
+                invocation_path=str(tmp_path),
+                targets=[str(first_file)],
+                files_complexities=first_files,
+            )
+            is None
+        )
+        first_previous = remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(first_file)],
+            files_complexities=first_files,
+        )
+        assert first_previous is not None
+        assert len(first_previous) == 1
+
+        remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(second_file)],
+            files_complexities=second_files,
+        )
+
+        cache_dir = tmp_path / CACHE_DIR_NAME
+        value_files = [path for path in cache_dir.rglob("*") if path.is_file()]
+        cache_values = [path for path in value_files if path.name == FUNCTIONS_CACHE_KEY]
+        legacy_json_files = list(cache_dir.glob("*.json"))
+
+        assert len(cache_values) == 1
+        assert legacy_json_files == []
+
+    def test_cache_migrates_and_removes_legacy_hash_file(self, tmp_path: Path):
+        """Test that existing per-target JSON files are migrated and cleaned up."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def example():\n    return 1\n", encoding="utf-8")
+        files, _ = _complexipy.main([str(test_file)], False, [])
+
+        remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(test_file)],
+            files_complexities=files,
+        )
+
+        cache_file = tmp_path / CACHE_DIR_NAME / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+        [cache_key] = cache_payload["entries"].keys()
+        cache_file.unlink()
+
+        legacy_file = tmp_path / CACHE_DIR_NAME / f"{cache_key}.json"
+        legacy_file.write_text(
+            json.dumps(next(iter(cache_payload["entries"].values()))),
+            encoding="utf-8",
+        )
+
+        previous = remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(test_file)],
+            files_complexities=files,
+        )
+
+        assert previous is not None
+        assert len(previous) == 1
+        assert not legacy_file.exists()
+        assert cache_file.exists()
+
+    def test_cache_prunes_old_target_set_entries(self, tmp_path: Path):
+        """Test that the single value file does not grow unbounded."""
+        files = []
+        for index in range(MAX_CACHE_ENTRIES + 1):
+            test_file = tmp_path / f"test_{index}.py"
+            test_file.write_text(
+                f"def example_{index}():\n    return {index}\n",
+                encoding="utf-8",
+            )
+            files.append(test_file)
+
+        for test_file in files:
+            complexities, _ = _complexipy.main([str(test_file)], False, [])
+            remember_previous_functions(
+                invocation_path=str(tmp_path),
+                targets=[str(test_file)],
+                files_complexities=complexities,
+            )
+
+        cache_file = tmp_path / CACHE_DIR_NAME / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+
+        assert len(cache_payload["entries"]) == MAX_CACHE_ENTRIES
 
     def test_cache_failure_does_not_break_functionality(self, tmp_path: Path):
         """Test that cache operations don't break when filesystem operations fail."""


### PR DESCRIPTION
## What

This PR fixes recursive exclude handling by moving Python file discovery to a glob-based walker that can exclude nested paths correctly.

## Why

Directory excludes such as `tests/**` need to apply recursively and consistently while still respecting gitignore rules during analysis.

## Changes

- Add `wax` for glob-based Python file discovery and recursive exclude matching
- Move path discovery and exclude filtering into `src/helpers/exclude.rs`
- Keep gitignore-aware filtering by intersecting glob results with `ignore::Walk`
- Update the default project exclude config from `tests` to `tests/**`
- Pass the invocation path into the Rust analyzer and update the Python stub signature
- Update exclude test coverage to use recursive exclude patterns
- Additionally, bound `.complexipy_cache` growth by storing target-set entries in `.complexipy_cache/v/cache/functions`, pruning old entries, and migrating/removing legacy per-target JSON cache files

Solves: #174 