### PR TITLE
feat(core): add --no-ignore and --report-ignored CLI flags for suppression management

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -190,8 +190,10 @@ jobs:
                   cache-dependency-glob: uv.lock
             - name: Install dev dependencies
               run: uv sync --group dev --no-install-project --frozen
-            - name: Run ruff
+            - name: Run ruff check
               run: uv run ruff check .
+            - name: Run ruff format
+              run: uv run ruff format --check .
             - name: Run ty
               run: uv run ty check .
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: https://github.com/rohaquinlop/complexipy-pre-commit
-  rev: v4.2.0
-  hooks:
-    - id: complexipy
+    - repo: https://github.com/rohaquinlop/complexipy-pre-commit
+      rev: v5.5.0
+      hooks:
+          - id: complexipy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
     - repo: https://github.com/rohaquinlop/complexipy-pre-commit
-      rev: v5.5.0
+      rev: v5.1.0
       hooks:
           - id: complexipy

--- a/complexipy/__init__.py
+++ b/complexipy/__init__.py
@@ -4,6 +4,7 @@ from complexipy._complexipy import (
     CodeComplexity,
     FileComplexity,
     FunctionComplexity,
+    IgnoredLocation,
     LineComplexity,
     RefactorPlan,
 )
@@ -16,6 +17,7 @@ __all__ = [
     "CodeComplexity",
     "FileComplexity",
     "FunctionComplexity",
+    "IgnoredLocation",
     "LineComplexity",
     "RefactorPlan",
     "code_complexity",

--- a/complexipy/_complexipy.pyi
+++ b/complexipy/_complexipy.pyi
@@ -289,11 +289,40 @@ class CodeComplexity:
         self, functions: List[FunctionComplexity], complexity: int
     ) -> None: ...
 
+class IgnoredLocation:
+    """
+    Represents a single '# complexipy: ignore' or '# noqa: complexipy'
+    comment found in a source file.
+
+    This class is used by --report-ignored to surface suppressed
+    complexity locations for audit and technical debt tracking.
+
+    Example:
+        >>> loc = IgnoredLocation(
+        ...     path="src/utils/parser.py",
+        ...     line=42,
+        ...     comment="# complexipy: ignore"
+        ... )
+        >>> print(f"{loc.path}:{loc.line}  {loc.comment}")
+    """
+
+    path: str
+    """Relative path to the file containing the ignore comment."""
+
+    line: int
+    """Line number (1-indexed) where the ignore comment was found."""
+
+    comment: str
+    """The canonical ignore marker (e.g. '# complexipy: ignore' or '# noqa: complexipy')."""
+
+    def __init__(self, path: str, line: int, comment: str) -> None: ...
+
 def main(
     paths: List[str],
     quiet: bool,
     exclude: List[str],
     check_script: bool = False,
+    no_ignore: bool = False,
     invocation_path: str = ".",
 ) -> Tuple[List[FileComplexity], List[str]]:
     """
@@ -336,7 +365,9 @@ def main(
     """
     ...
 
-def code_complexity(code: str, check_script: bool = False) -> CodeComplexity:
+def code_complexity(
+    code: str, check_script: bool = False, no_ignore: bool = False
+) -> CodeComplexity:
     """
     Analyze cognitive complexity of Python code provided as a string.
 
@@ -388,7 +419,10 @@ def code_complexity(code: str, check_script: bool = False) -> CodeComplexity:
     ...
 
 def file_complexity(
-    file_path: str, base_path: str, check_script: bool = False
+    file_path: str,
+    base_path: str,
+    check_script: bool = False,
+    no_ignore: bool = False,
 ) -> FileComplexity:
     """
     Analyze cognitive complexity of a single Python source file.
@@ -550,3 +584,42 @@ def create_snapshot_file(
     files_complexities: List[FileComplexity],
 ) -> None: ...
 def load_snapshot_file(snapshot_file_path: str) -> List[FileComplexity]: ...
+def collect_all_ignored_locations(
+    paths: List[str],
+    exclude: List[str],
+    invocation_path: str = ".",
+) -> Tuple[List[IgnoredLocation], List[str]]:
+    """
+    Scan all processed Python files for ignore comments.
+
+    This function discovers all '# complexipy: ignore' and '# noqa: complexipy'
+    comments across the same set of files that the main analysis would process
+    (respecting --exclude and .gitignore). It returns the file path, line
+    number, and comment text for each ignore marker found.
+
+    Recognized forms:
+      - '# complexipy: ignore'
+      - '# noqa: complexipy'
+    (Bare '# noqa' is NOT recognized.)
+
+    This is the backend for the --report-ignored CLI flag.
+
+    Args:
+        paths: List of file paths, directory paths, or Git repository URLs.
+        exclude: List of file/directory paths or globs to exclude from scanning.
+        invocation_path: Working directory for resolving relative paths.
+
+    Returns:
+        A tuple of (ignored_locations, failed_paths) where:
+        - ignored_locations: List of IgnoredLocation objects, sorted by (path, line).
+        - failed_paths: List of paths that could not be processed.
+
+    Example:
+        >>> locations, failed = collect_all_ignored_locations(
+        ...     paths=["/project/src"],
+        ...     exclude=["tests/"],
+        ... )
+        >>> for loc in locations:
+        ...     print(f"{loc.path}:{loc.line}  {loc.comment}")
+    """
+    ...

--- a/complexipy/api.py
+++ b/complexipy/api.py
@@ -7,6 +7,7 @@ from complexipy._complexipy import CodeComplexity, FileComplexity
 def code_complexity(
     code: str,
     check_script: bool = False,
+    no_ignore: bool = False,
 ) -> CodeComplexity:
     """
     Analyze cognitive complexity of Python code provided as a string.
@@ -21,6 +22,8 @@ def code_complexity(
               syntactically correct Python code.
         check_script: If True, also report cognitive complexity of
                       module-level (script) code as a '<module>' entry.
+        no_ignore: If True, disregard all '# complexipy: ignore' and
+                   '# noqa: complexipy' comments, analyzing every function.
 
     Returns:
         CodeComplexity object containing the analysis results, including
@@ -40,11 +43,13 @@ def code_complexity(
         >>> result = code_complexity(code)
         >>> print(f"Total complexity: {result.complexity}")
     """
-    return _complexipy.code_complexity(code, check_script)
+    return _complexipy.code_complexity(code, check_script, no_ignore)
 
 
 def file_complexity(
-    file_path: str, check_script: bool = False
+    file_path: str,
+    check_script: bool = False,
+    no_ignore: bool = False,
 ) -> FileComplexity:
     """
     Analyze cognitive complexity of a single Python source file.
@@ -59,6 +64,8 @@ def file_complexity(
                    absolute. The file must exist and be readable.
         check_script: If True, also report cognitive complexity of
                       module-level (script) code as a '<module>' entry.
+        no_ignore: If True, disregard all '# complexipy: ignore' and
+                   '# noqa: complexipy' comments, analyzing every function.
 
     Returns:
         FileComplexity object containing complete analysis results for the
@@ -83,4 +90,5 @@ def file_complexity(
         path.resolve().as_posix(),
         base_path.resolve().as_posix(),
         check_script,
+        no_ignore,
     )

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -708,9 +708,7 @@ def handle_report_ignored(
         console.print("No ignore comments found.")
 
     if OutputFormat.json in output_formats and ignored_locations:
-        ignored_output_paths = resolve_output_paths(
-            [OutputFormat.json], output
-        )
+        ignored_output_paths = resolve_output_paths([OutputFormat.json], output)
         ignored_json_path = os.path.join(
             os.path.dirname(ignored_output_paths[OutputFormat.json]),
             "complexipy-ignored.json",

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 from importlib.metadata import (
@@ -225,6 +226,18 @@ def main(
         "-cs",
         help="Report cognitive complexity of module-level (script) code as '<module>'.",
     ),
+    no_ignore: Optional[bool] = typer.Option(
+        None,
+        "--no-ignore",
+        help="Disregard all '# complexipy: ignore' and '# noqa: complexipy' "
+        "comments, analyzing every function "
+        "(bare '# noqa' is not recognized).",
+    ),
+    report_ignored: Optional[bool] = typer.Option(
+        None,
+        "--report-ignored",
+        help="List every file:line where a '# complexipy: ignore' or '# noqa: complexipy' comment exists.",
+    ),
     version: bool = typer.Option(
         False,
         "--version",
@@ -256,6 +269,8 @@ def main(
         output,
         exclude,
         check_script,
+        no_ignore,
+        report_ignored,
     ) = get_arguments_value(
         TOML_CONFIG,
         paths,
@@ -275,26 +290,23 @@ def main(
         output_sarif,
         exclude,
         check_script,
+        no_ignore,
+        report_ignored,
     )
 
+    no_ignore = bool(no_ignore)
+    report_ignored = bool(report_ignored)
     ratchet = bool(get_argument_value(TOML_CONFIG, "ratchet", ratchet, False))
     validate_ratchet(ratchet, diff)
 
-    if plain is None:
-        plain = False
-    if suggest_refactors is None:
-        suggest_refactors = False
-
-    if plain and quiet:
-        raise typer.BadParameter("--plain and --quiet cannot be used together.")
-
-    if top is not None and top < 1:
-        raise typer.BadParameter("--top must be a positive integer.")
+    plain, suggest_refactors = validate_cli_arguments(
+        plain, suggest_refactors, top, quiet
+    )
 
     handle_console_settings(color, quiet, plain)
 
     result: Tuple[List[FileComplexity], List[str]] = _complexipy.main(
-        paths, quiet, exclude, check_script, INVOCATION_PATH
+        paths, quiet, exclude, check_script, no_ignore, INVOCATION_PATH
     )
     files_complexities, failed_paths = result
     emit_deprecated_output_warnings(
@@ -354,6 +366,10 @@ def main(
         plain,
         top,
         suggest_refactors,
+    )
+
+    handle_report_ignored(
+        report_ignored, paths, exclude, output_formats, output, no_ignore
     )
 
     snapshot_result = handle_snapshot(
@@ -662,10 +678,81 @@ def handle_diff_output(
     return None
 
 
+def handle_report_ignored(
+    report_ignored: bool,
+    paths: Optional[List[str]],
+    exclude: Optional[List[str]],
+    output_formats: List[OutputFormat],
+    output: Optional[str],
+    no_ignore: bool,
+) -> None:
+    """Print and optionally export ignored-location report."""
+    if not report_ignored:
+        return
+
+    global console
+    paths = paths or []
+    exclude = exclude or []
+    ignored_locations, _ = _complexipy.collect_all_ignored_locations(
+        paths, exclude, INVOCATION_PATH
+    )
+    if ignored_locations:
+        for loc in ignored_locations:
+            console.print(f"{loc.path}:{loc.line}  {loc.comment}")
+        console.print(
+            f"\nFound {len(ignored_locations)} suppressed location(s)."
+        )
+        if no_ignore:
+            console.print("(all markers ignored due to --no-ignore)")
+    else:
+        console.print("No ignore comments found.")
+
+    if OutputFormat.json in output_formats and ignored_locations:
+        ignored_output_paths = resolve_output_paths(
+            [OutputFormat.json], output
+        )
+        ignored_json_path = os.path.join(
+            os.path.dirname(ignored_output_paths[OutputFormat.json]),
+            "complexipy-ignored.json",
+        )
+        ignored_data = [
+            {"path": loc.path, "line": loc.line, "comment": loc.comment}
+            for loc in ignored_locations
+        ]
+        with open(ignored_json_path, "w") as f:
+            json.dump(ignored_data, f, indent=2)
+            f.write("\n")
+        console.print(f"Ignored locations saved at {ignored_json_path}")
+
+
 def validate_ratchet(ratchet: bool, diff: Optional[str]) -> None:
     if ratchet and not diff:
         console.print("[bold red]Error:[/bold red] --ratchet requires --diff")
         raise typer.Exit(code=2)
+
+
+def validate_cli_arguments(
+    plain: Optional[bool],
+    suggest_refactors: Optional[bool],
+    top: Optional[int],
+    quiet: bool,
+) -> Tuple[bool, bool]:
+    """Validate and normalize CLI arguments.
+
+    Returns (plain, suggest_refactors) with None resolved to False.
+    """
+    if plain is None:
+        plain = False
+    if suggest_refactors is None:
+        suggest_refactors = False
+
+    if plain and quiet:
+        raise typer.BadParameter("--plain and --quiet cannot be used together.")
+
+    if top is not None and top < 1:
+        raise typer.BadParameter("--top must be a positive integer.")
+
+    return plain, suggest_refactors
 
 
 def resolve_final_success(

--- a/complexipy/utils/toml.py
+++ b/complexipy/utils/toml.py
@@ -209,6 +209,8 @@ def get_arguments_value(
     output_sarif: bool | None,
     exclude: List[str] | None,
     check_script: bool | None,
+    no_ignore: bool | None,
+    report_ignored: bool | None,
 ) -> Tuple[
     List[str],
     int,
@@ -222,6 +224,8 @@ def get_arguments_value(
     List[str],
     str | None,
     List[str],
+    bool,
+    bool,
     bool,
 ]:
     paths = get_argument_value(toml_config, "paths", paths, [])
@@ -300,6 +304,16 @@ def get_arguments_value(
         bool,
         get_argument_value(toml_config, "check-script", check_script, False),
     )
+    no_ignore = cast(
+        bool,
+        get_argument_value(toml_config, "no-ignore", no_ignore, False),
+    )
+    report_ignored = cast(
+        bool,
+        get_argument_value(
+            toml_config, "report-ignored", report_ignored, False
+        ),
+    )
     return (
         paths,
         max_complexity_allowed,
@@ -314,4 +328,6 @@ def get_arguments_value(
         output,
         exclude,
         check_script,
+        no_ignore,
+        report_ignored,
     )

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -76,3 +76,15 @@ pub struct CodeComplexity {
     #[cfg(feature = "wasm")]
     pub version: String,
 }
+
+#[cfg_attr(feature = "python", pyclass(module = "complexipy", get_all))]
+#[cfg_attr(
+    any(feature = "python", feature = "wasm"),
+    derive(Serialize, Deserialize)
+)]
+#[derive(Clone)]
+pub struct IgnoredLocation {
+    pub path: String,
+    pub line: u64,
+    pub comment: String,
+}

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -16,8 +16,9 @@ use shared_deps::*;
 
 #[cfg(feature = "python")]
 mod python_deps {
+    pub use crate::classes::IgnoredLocation;
     pub use crate::helpers::exclude::get_paths_to_process;
-    pub use crate::utils::get_repo_name;
+    pub use crate::utils::{collect_ignored_locations, get_repo_name};
     pub use indicatif::ProgressBar;
     pub use indicatif::ProgressStyle;
     pub use pyo3::exceptions::PyValueError;
@@ -33,6 +34,14 @@ mod python_deps {
 }
 
 #[cfg(feature = "python")]
+struct ProcessOptions<'a> {
+    quiet: bool,
+    exclude: Vec<&'a str>,
+    check_script: bool,
+    no_ignore: bool,
+}
+
+#[cfg(feature = "python")]
 use python_deps::*;
 
 #[cfg(feature = "python")]
@@ -40,21 +49,19 @@ type ComplexitiesAndFailedPaths = (Vec<FileComplexity>, Vec<String>);
 
 #[cfg(feature = "python")]
 #[pyfunction]
-#[pyo3(signature = (paths, quiet, exclude, check_script=false, invocation_path="."))]
+#[pyo3(signature = (paths, quiet, exclude, check_script=false, no_ignore=false, invocation_path="."))]
 pub fn main(
     paths: Vec<&str>,
     quiet: bool,
     exclude: Vec<&str>,
     check_script: bool,
+    no_ignore: bool,
     invocation_path: &str,
 ) -> PyResult<ComplexitiesAndFailedPaths> {
+    let _ = invocation_path;
+
     let re = Regex::new(r"^(https:\/\/|http:\/\/|www\.|git@)(github|gitlab)\.com(\/[\w.-]+){2,}$")
         .map_err(|e| PyValueError::new_err(format!("Invalid repository pattern: {}", e)))?;
-
-    let cwd = path::Path::new(invocation_path)
-        .canonicalize()
-        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
-    let cwd_str = cwd.to_string_lossy().replace('\\', "/");
 
     let mut successful = Vec::new();
     let mut failed_paths = Vec::new();
@@ -70,15 +77,14 @@ pub fn main(
             continue;
         }
 
-        match process_path(
-            path,
-            is_dir,
-            is_url,
+        let opts = ProcessOptions {
             quiet,
-            exclude.clone(),
+            exclude: exclude.clone(),
             check_script,
-            &cwd_str,
-        ) {
+            no_ignore,
+        };
+
+        match process_path(path, is_dir, is_url, &opts) {
             Ok((mut complexities, mut f_paths)) => {
                 successful.append(&mut complexities);
                 failed_paths.append(&mut f_paths);
@@ -91,15 +97,11 @@ pub fn main(
 }
 
 #[cfg(feature = "python")]
-#[pyfunction]
-pub fn process_path(
+fn process_path(
     path: &str,
     is_dir: bool,
     is_url: bool,
-    quiet: bool,
-    exclude: Vec<&str>,
-    check_script: bool,
-    invocation_path: &str,
+    opts: &ProcessOptions,
 ) -> Result<ComplexitiesAndFailedPaths, PyErr> {
     let mut file_complexities = Vec::new();
     let mut failed_paths = Vec::new();
@@ -121,7 +123,7 @@ pub fn process_path(
             }
         });
 
-        let mut progress_bar = if quiet {
+        let mut progress_bar = if opts.quiet {
             None
         } else {
             let pb = ProgressBar::new_spinner();
@@ -153,19 +155,12 @@ pub fn process_path(
         }
 
         let repo_path = dir.path().join(&repo_name).to_string_lossy().to_string();
-        let (complexities, f_paths) = evaluate_dir(
-            &repo_path,
-            quiet,
-            exclude.clone(),
-            check_script,
-            invocation_path,
-        );
+        let (complexities, f_paths) = evaluate_dir(&repo_path, opts);
         dir.close()?;
         file_complexities = complexities;
         failed_paths = f_paths;
     } else if is_dir {
-        let (complexities, f_paths) =
-            evaluate_dir(path, quiet, exclude.clone(), check_script, invocation_path);
+        let (complexities, f_paths) = evaluate_dir(path, opts);
         file_complexities = complexities;
         failed_paths = f_paths;
     } else {
@@ -173,7 +168,8 @@ pub fn process_path(
             .parent()
             .and_then(|p| p.to_str())
             .unwrap_or(".");
-        if let Ok(complexity) = file_complexity(path, parent_dir, check_script) {
+        if let Ok(complexity) = file_complexity(path, parent_dir, opts.check_script, opts.no_ignore)
+        {
             file_complexities.push(complexity);
         } else {
             failed_paths.push(path.to_string());
@@ -188,13 +184,7 @@ pub fn process_path(
 }
 
 #[cfg(feature = "python")]
-fn evaluate_dir(
-    path: &str,
-    quiet: bool,
-    exclude: Vec<&str>,
-    check_script: bool,
-    _invocation_path: &str,
-) -> ComplexitiesAndFailedPaths {
+fn evaluate_dir(path: &str, opts: &ProcessOptions) -> ComplexitiesAndFailedPaths {
     let base_dir = path::Path::new(path)
         .canonicalize()
         .unwrap_or_else(|_| path::Path::new(path).to_path_buf())
@@ -202,17 +192,17 @@ fn evaluate_dir(
         .unwrap_or(path::Path::new("."))
         .to_string_lossy()
         .replace('\\', "/");
-    let files_paths_to_process = get_paths_to_process(path, exclude);
+    let files_paths_to_process = get_paths_to_process(path, opts.exclude.clone());
 
-    if quiet {
+    if opts.quiet {
         let results: Vec<_> = files_paths_to_process
             .iter()
-            .map(
-                |file_path| match file_complexity(file_path, &base_dir, check_script) {
+            .map(|file_path| {
+                match file_complexity(file_path, &base_dir, opts.check_script, opts.no_ignore) {
                     Ok(file_complexity) => (Some(file_complexity), None),
                     Err(_) => (None, Some(file_path.clone())),
-                },
-            )
+                }
+            })
             .collect();
         let mut complexities = Vec::new();
         let mut failed_paths = Vec::new();
@@ -237,7 +227,7 @@ fn evaluate_dir(
         .iter()
         .map(|file_path| {
             pb.inc(1);
-            match file_complexity(file_path, &base_dir, check_script) {
+            match file_complexity(file_path, &base_dir, opts.check_script, opts.no_ignore) {
                 Ok(file_complexity) => (Some(file_complexity), None),
                 Err(_) => (None, Some(file_path.clone())),
             }
@@ -259,11 +249,12 @@ fn evaluate_dir(
 
 #[cfg(feature = "python")]
 #[pyfunction]
-#[pyo3(signature = (file_path, base_path, check_script=false))]
+#[pyo3(signature = (file_path, base_path, check_script=false, no_ignore=false))]
 pub fn file_complexity(
     file_path: &str,
     base_path: &str,
     check_script: bool,
+    no_ignore: bool,
 ) -> PyResult<FileComplexity> {
     let path = path::Path::new(file_path);
     let file_name = path
@@ -276,7 +267,7 @@ pub fn file_complexity(
         .and_then(|p| p.to_str())
         .unwrap_or(file_path);
     let code = std::fs::read_to_string(file_path)?;
-    let code_complexity = match code_complexity(&code, check_script) {
+    let code_complexity = match code_complexity(&code, check_script, no_ignore) {
         Ok(v) => v,
         Err(e) => {
             return Err(PyValueError::new_err(format!(
@@ -295,8 +286,12 @@ pub fn file_complexity(
 
 #[cfg(feature = "python")]
 #[pyfunction]
-#[pyo3(signature = (code, check_script=false))]
-pub fn code_complexity(code: &str, check_script: bool) -> PyResult<CodeComplexity> {
+#[pyo3(signature = (code, check_script=false, no_ignore=false))]
+pub fn code_complexity(
+    code: &str,
+    check_script: bool,
+    no_ignore: bool,
+) -> PyResult<CodeComplexity> {
     let parsed = match parse_module(code) {
         Ok(parsed) => parsed,
         Err(e) => {
@@ -308,7 +303,7 @@ pub fn code_complexity(code: &str, check_script: bool) -> PyResult<CodeComplexit
     };
     let ast_body = parsed.into_suite();
     let (functions, complexity) =
-        function_level_cognitive_complexity_shared(&ast_body, code, check_script);
+        function_level_cognitive_complexity_shared(&ast_body, code, check_script, no_ignore);
     Ok(CodeComplexity {
         functions,
         complexity,
@@ -322,6 +317,7 @@ pub fn function_level_cognitive_complexity_shared(
     ast_body: &ast::Suite,
     code: &str,
     check_script: bool,
+    no_ignore: bool,
 ) -> (Vec<FunctionComplexity>, u64) {
     let mut functions: Vec<FunctionComplexity> = Vec::new();
     let mut complexity: u64 = 0;
@@ -333,7 +329,7 @@ pub fn function_level_cognitive_complexity_shared(
         match node {
             Stmt::FunctionDef(f) => {
                 let start_line = get_line_number(usize::from(f.range.start()), code);
-                if !has_noqa_complexipy(start_line, code) {
+                if no_ignore || !has_noqa_complexipy(start_line, code) {
                     let result = statement_cognitive_complexity_shared(node, 0, code);
                     functions.push(FunctionComplexity {
                         name: f.name.to_string(),
@@ -349,7 +345,7 @@ pub fn function_level_cognitive_complexity_shared(
                 for node in c.body.iter() {
                     if let Stmt::FunctionDef(f) = node {
                         let start_line = get_line_number(usize::from(f.range.start()), code);
-                        if !has_noqa_complexipy(start_line, code) {
+                        if no_ignore || !has_noqa_complexipy(start_line, code) {
                             let result = statement_cognitive_complexity_shared(node, 0, code);
                             functions.push(FunctionComplexity {
                                 name: format!("{}::{}", c.name, f.name),
@@ -829,4 +825,139 @@ fn statement_cognitive_complexity_shared(
     }
 
     result
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (file_path, base_path))]
+pub fn collect_file_ignored_locations(
+    file_path: &str,
+    base_path: &str,
+) -> PyResult<Vec<IgnoredLocation>> {
+    let path = path::Path::new(file_path);
+    let relative_path = path
+        .strip_prefix(base_path)
+        .ok()
+        .and_then(|p| p.to_str())
+        .unwrap_or(file_path);
+    let code = std::fs::read_to_string(file_path).map_err(|e| {
+        PyValueError::new_err(format!("Failed to read file '{}': {}", file_path, e))
+    })?;
+    let locations = collect_ignored_locations(&code);
+    Ok(locations
+        .into_iter()
+        .map(|(line, comment)| IgnoredLocation {
+            path: relative_path.to_string(),
+            line,
+            comment,
+        })
+        .collect())
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (paths, exclude, invocation_path="."))]
+pub fn collect_all_ignored_locations(
+    paths: Vec<&str>,
+    exclude: Vec<&str>,
+    invocation_path: &str,
+) -> PyResult<(Vec<IgnoredLocation>, Vec<String>)> {
+    let _invocation_dir = path::Path::new(invocation_path)
+        .canonicalize()
+        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
+
+    let mut all_locations = Vec::new();
+    let mut failed_paths = Vec::new();
+
+    let re = Regex::new(r"^(https:\/\/|http:\/\/|www\.|git@)(github|gitlab)\.com(\/[\w.-]+){2,}$")
+        .map_err(|e| PyValueError::new_err(format!("Invalid repository pattern: {}", e)))?;
+
+    for path_str in &paths {
+        let path_obj = path::Path::new(path_str);
+        let is_url = re.is_match(path_str);
+
+        if is_url {
+            match collect_ignored_locations_from_url(path_str, &exclude) {
+                Ok(locs) => all_locations.extend(locs),
+                Err(_) => failed_paths.push(path_str.to_string()),
+            }
+        } else if path_obj.is_dir() {
+            let files = get_paths_to_process(path_str, exclude.clone());
+            let base_dir = path_obj
+                .canonicalize()
+                .unwrap_or_else(|_| path_obj.to_path_buf())
+                .parent()
+                .unwrap_or(path::Path::new("."))
+                .to_string_lossy()
+                .replace('\\', "/");
+            for file_path in &files {
+                if let Ok(locs) = collect_file_ignored_locations(file_path, &base_dir) {
+                    all_locations.extend(locs)
+                }
+            }
+        } else if path_obj.is_file() {
+            let parent_dir = path_obj.parent().and_then(|p| p.to_str()).unwrap_or(".");
+            if let Ok(locs) = collect_file_ignored_locations(path_str, parent_dir) {
+                all_locations.extend(locs)
+            }
+        } else {
+            failed_paths.push(path_str.to_string());
+        }
+    }
+
+    all_locations.sort_by_key(|loc| (loc.path.clone(), loc.line));
+    Ok((all_locations, failed_paths))
+}
+
+fn collect_ignored_locations_from_url(
+    url: &str,
+    exclude: &[&str],
+) -> PyResult<Vec<IgnoredLocation>> {
+    let dir = tempdir()?;
+    let repo_name = get_repo_name(url)?;
+    env::set_current_dir(&dir)?;
+    let cloning_done = Arc::new(Mutex::new(false));
+    let cloning_done_clone = Arc::clone(&cloning_done);
+    let path_clone = url.to_owned();
+
+    thread::spawn(move || {
+        let _ = process::Command::new("git")
+            .args(["clone", &path_clone])
+            .output();
+        if let Ok(mut done) = cloning_done_clone.lock() {
+            *done = true;
+        }
+    });
+
+    loop {
+        match cloning_done.lock() {
+            Ok(done) if *done => break,
+            Ok(_) => {
+                thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Err(_) => {
+                return Err(PyValueError::new_err("Failed to track cloning progress"));
+            }
+        }
+    }
+
+    let repo_path = dir.path().join(&repo_name).to_string_lossy().to_string();
+    let files = get_paths_to_process(&repo_path, exclude.to_vec());
+    let base_dir = path::Path::new(&repo_path)
+        .canonicalize()
+        .unwrap_or_else(|_| path::Path::new(&repo_path).to_path_buf())
+        .parent()
+        .unwrap_or(path::Path::new("."))
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    let mut locations = Vec::new();
+    for file_path in &files {
+        if let Ok(locs) = collect_file_ignored_locations(file_path, &base_dir) {
+            locations.extend(locs);
+        }
+    }
+
+    dir.close()?;
+    Ok(locations)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,12 @@ mod utils;
 mod wasm;
 
 #[cfg(feature = "python")]
-use classes::{CodeComplexity, FileComplexity, FunctionComplexity, LineComplexity, RefactorPlan};
+use classes::{
+    CodeComplexity, FileComplexity, FunctionComplexity, IgnoredLocation, LineComplexity,
+    RefactorPlan,
+};
 #[cfg(feature = "python")]
-use cognitive_complexity::{code_complexity, file_complexity, main};
+use cognitive_complexity::{code_complexity, collect_all_ignored_locations, file_complexity, main};
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 #[cfg(feature = "python")]
@@ -25,6 +28,7 @@ fn _complexipy(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(main, m)?)?;
     m.add_function(wrap_pyfunction!(file_complexity, m)?)?;
     m.add_function(wrap_pyfunction!(code_complexity, m)?)?;
+    m.add_function(wrap_pyfunction!(collect_all_ignored_locations, m)?)?;
     m.add_function(wrap_pyfunction!(output_csv, m)?)?;
     m.add_function(wrap_pyfunction!(output_json, m)?)?;
     m.add_function(wrap_pyfunction!(create_snapshot_file, m)?)?;
@@ -32,6 +36,7 @@ fn _complexipy(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<CodeComplexity>()?;
     m.add_class::<FileComplexity>()?;
     m.add_class::<FunctionComplexity>()?;
+    m.add_class::<IgnoredLocation>()?;
     m.add_class::<LineComplexity>()?;
     m.add_class::<RefactorPlan>()?;
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -298,10 +298,10 @@ fn count_different_childs_type(expr: ast::Expr, prev_pr: ast::Expr) -> u64 {
     match expr {
         ast::Expr::BoolOp(..) => match prev_pr {
             ast::Expr::BoolOp(p) => {
-                if let Some(b) = expr.clone().bool_op_expr() {
-                    if b.op != p.op {
-                        complexity += 1;
-                    }
+                if let Some(b) = expr.clone().bool_op_expr()
+                    && b.op != p.op
+                {
+                    complexity += 1;
                 }
 
                 for value in p.values {
@@ -337,41 +337,79 @@ pub fn get_line_number(byte_index: usize, code: &str) -> u64 {
     (newline_count + 1) as u64
 }
 
+/// Extract a canonical ignore comment marker from a line.
+///
+/// Returns `Some("# complexipy: ignore")` or `Some("# noqa: complexipy")`
+/// when the line contains the corresponding pattern (case-insensitive).
+/// Returns `None` if neither marker is found.
+fn is_word_boundary(s: &str, pos: usize) -> bool {
+    pos >= s.len() || (!s.as_bytes()[pos].is_ascii_alphanumeric() && s.as_bytes()[pos] != b'_')
+}
+
+/// Extract a canonical ignore comment marker from a line.
+///
+/// Returns `Some("# complexipy: ignore")` or `Some("# noqa: complexipy")`
+/// when the line contains the corresponding pattern (case-insensitive).
+/// Returns `None` if neither marker is found.
 #[cfg(any(feature = "python", feature = "wasm"))]
-pub fn has_noqa_complexipy(line_number: u64, code: &str) -> bool {
+pub fn extract_comment_marker(line: &str) -> Option<String> {
+    for (idx, ch) in line.char_indices() {
+        if ch == '#' {
+            let after_hash = &line[idx + 1..];
+            let trimmed = after_hash.trim_start();
+            if trimmed.len() >= "complexipy: ignore".len()
+                && trimmed[.."complexipy: ignore".len()].eq_ignore_ascii_case("complexipy: ignore")
+                && is_word_boundary(trimmed, "complexipy: ignore".len())
+            {
+                return Some("# complexipy: ignore".to_string());
+            }
+            if trimmed.len() >= "noqa: complexipy".len()
+                && trimmed[.."noqa: complexipy".len()].eq_ignore_ascii_case("noqa: complexipy")
+                && is_word_boundary(trimmed, "noqa: complexipy".len())
+            {
+                return Some("# noqa: complexipy".to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Find a noqa/ignore comment near a `def` or decorator line.
+///
+/// Returns `Some(comment_text)` when a marker is found that would
+/// trigger suppression, `None` otherwise.
+#[cfg(any(feature = "python", feature = "wasm"))]
+pub fn find_noqa_comment(line_number: u64, code: &str) -> Option<String> {
     if line_number == 0 {
-        return false;
+        return None;
     }
 
     let lines: Vec<&str> = code.lines().collect();
     let idx = (line_number as usize).saturating_sub(1);
 
-    let contains_marker = |s: &str| -> bool {
-        let lower = s.to_lowercase();
-        lower.contains("complexipy: ignore") || lower.contains("noqa: complexipy")
-    };
-
-    let signature_has_marker = |def_idx: usize| -> bool {
+    let signature_has_marker = |def_idx: usize| -> Option<String> {
         let max_scan = (def_idx + 20).min(lines.len());
         for line in lines.iter().skip(def_idx).take(max_scan - def_idx) {
-            if contains_marker(line) {
-                return true;
+            if let Some(marker) = extract_comment_marker(line) {
+                return Some(marker);
             }
-
             if line.contains(':') {
                 break;
             }
         }
-
-        false
+        None
     };
 
-    if idx < lines.len() && contains_marker(lines[idx]) {
-        return true;
+    if idx < lines.len()
+        && let Some(marker) = extract_comment_marker(lines[idx])
+    {
+        return Some(marker);
     }
 
-    if idx > 0 && contains_marker(lines[idx - 1]) {
-        return true;
+    if idx > 0
+        && let Some(marker) = extract_comment_marker(lines[idx - 1])
+    {
+        return Some(marker);
     }
 
     if idx < lines.len() && lines[idx].trim_start().starts_with("def ") {
@@ -383,11 +421,13 @@ pub fn has_noqa_complexipy(line_number: u64, code: &str) -> bool {
         for i in (idx + 1)..max_scan {
             let line = lines[i].trim();
             if line.starts_with("def ") {
-                if signature_has_marker(i) {
-                    return true;
+                if let Some(marker) = signature_has_marker(i) {
+                    return Some(marker);
                 }
-                if i > 0 && contains_marker(lines[i - 1]) {
-                    return true;
+                if i > 0
+                    && let Some(marker) = extract_comment_marker(lines[i - 1])
+                {
+                    return Some(marker);
                 }
                 break;
             }
@@ -397,5 +437,79 @@ pub fn has_noqa_complexipy(line_number: u64, code: &str) -> bool {
         }
     }
 
-    false
+    None
+}
+
+#[cfg(any(feature = "python", feature = "wasm"))]
+pub fn has_noqa_complexipy(line_number: u64, code: &str) -> bool {
+    find_noqa_comment(line_number, code).is_some()
+}
+
+/// Collect ignored locations from code, only reporting markers that
+/// actually suppress a function definition (i.e., are adjacent to `def`
+/// or `@decorator` lines).
+#[cfg(any(feature = "python", feature = "wasm"))]
+pub fn collect_ignored_locations(code: &str) -> Vec<(u64, String)> {
+    let mut results = Vec::new();
+    let lines: Vec<&str> = code.lines().collect();
+    #[allow(clippy::needless_range_loop)]
+    let mut idx = 0;
+    while idx < lines.len() {
+        let trimmed = lines[idx].trim_start();
+
+        if trimmed.starts_with("def ") {
+            let line_number = (idx + 1) as u64;
+            if let Some(comment) = find_noqa_comment(line_number, code) {
+                results.push((line_number, comment));
+            }
+            idx += 1;
+        } else if trimmed.starts_with('@') {
+            // Scan forward to find the def line, use its line number for
+            // both the comment lookup and the reported location.
+            let max_scan = (idx + 10).min(lines.len());
+            let mut def_line_number = None;
+            for (inner_idx, inner_line) in lines
+                .iter()
+                .enumerate()
+                .skip(idx + 1)
+                .take(max_scan - (idx + 1))
+            {
+                let inner = inner_line.trim();
+                if inner.starts_with("def ") {
+                    def_line_number = Some((inner_idx + 1) as u64);
+                    break;
+                }
+                if !inner.is_empty() && !inner.starts_with('@') {
+                    break;
+                }
+            }
+            let mut reported = false;
+            if let Some(dln) = def_line_number
+                && let Some(comment) = find_noqa_comment(dln, code)
+            {
+                results.push((dln, comment));
+                reported = true;
+            }
+            // Skip remaining decorators in the chain so they don't
+            // re-scan and produce duplicate entries.
+            while idx + 1 < lines.len() {
+                let next = lines[idx + 1].trim_start();
+                if next.starts_with('@') || next.is_empty() {
+                    idx += 1;
+                } else {
+                    break;
+                }
+            }
+            // Skip the def line too if we already reported from this chain
+            if reported && idx + 1 < lines.len() && lines[idx + 1].trim_start().starts_with("def ")
+            {
+                idx += 1;
+            }
+            idx += 1;
+        } else {
+            idx += 1;
+        }
+    }
+
+    results
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -28,7 +28,7 @@ fn get_code_complexity(code: &str) -> Result<CodeComplexity, String> {
     };
 
     let (functions, complexity) =
-        function_level_cognitive_complexity_shared(parsed.suite(), code, false);
+        function_level_cognitive_complexity_shared(parsed.suite(), code, false, false);
 
     Ok(CodeComplexity {
         complexity,

--- a/tests/main.py
+++ b/tests/main.py
@@ -223,6 +223,193 @@ def hello_world(s: str) -> str:
         total_complexity = sum([file.complexity for file in files])
         assert 0 == total_complexity
 
+    # ── --no-ignore tests ────────────────────────────────────────────
+
+    def test_no_ignore_analyzes_ignored_function(self):
+        """With --no-ignore, functions with '# complexipy: ignore' are analyzed."""
+        path = self.local_path / "src/test_complexipy_ignore.py"
+        files, _ = _complexipy.main(
+            [path.resolve().as_posix()], False, [], False, True
+        )
+        total_complexity = sum([file.complexity for file in files])
+        assert total_complexity > 0
+
+    def test_no_ignore_analyzes_noqa_function(self):
+        """With --no-ignore, functions with '# noqa: complexipy' are analyzed."""
+        path = self.local_path / "src/test_noqa_complex.py"
+        files, _ = _complexipy.main(
+            [path.resolve().as_posix()], False, [], False, True
+        )
+        total_complexity = sum([file.complexity for file in files])
+        assert total_complexity > 0
+
+    def test_no_ignore_analyzes_decorated_ignored(self):
+        """With --no-ignore, decorated ignored functions are analyzed."""
+        path = self.local_path / "src/test_complexipy_ignore_decorator.py"
+        files, _ = _complexipy.main(
+            [path.resolve().as_posix()], False, [], False, True
+        )
+        total_complexity = sum([file.complexity for file in files])
+        assert total_complexity > 0
+
+    def test_no_ignore_analyzes_decorated_noqa(self):
+        """With --no-ignore, decorated noqa functions are analyzed."""
+        path = self.local_path / "src/test_noqa_decorator.py"
+        files, _ = _complexipy.main(
+            [path.resolve().as_posix()], False, [], False, True
+        )
+        total_complexity = sum([file.complexity for file in files])
+        assert total_complexity > 0
+
+    def test_no_ignore_false_is_default(self):
+        """Without no_ignore, behavior is unchanged from before."""
+        path = self.local_path / "src/test_complexipy_ignore.py"
+        files_default, _ = _complexipy.main(
+            [path.resolve().as_posix()], False, [], False
+        )
+        files_explicit, _ = _complexipy.main(
+            [path.resolve().as_posix()], False, [], False, False
+        )
+        assert sum(f.complexity for f in files_default) == sum(f.complexity for f in files_explicit)
+
+    def test_no_ignore_code_complexity_api(self):
+        """Python API: code_complexity() with no_ignore analyzes ignored functions."""
+        code = (
+            "def ignored(a):  # complexipy: ignore\n"
+            "    if a:\n"
+            "        return a\n"
+            "    return 0\n"
+        )
+        result_without = code_complexity(code)
+        result_with = code_complexity(code, no_ignore=True)
+        assert result_without.complexity == 0
+        assert result_with.complexity > 0
+
+    def test_no_ignore_file_complexity_api(self, tmp_path):
+        """Python API: file_complexity() with no_ignore analyzes ignored functions."""
+        source = tmp_path / "ignored.py"
+        source.write_text(
+            "def ignored(a):  # complexipy: ignore\n"
+            "    if a:\n"
+            "        return a\n"
+            "    return 0\n",
+            encoding="utf-8",
+        )
+        result_without = file_complexity(str(source))
+        result_with = file_complexity(str(source), no_ignore=True)
+        assert result_without.complexity == 0
+        assert result_with.complexity > 0
+
+    # ── --report-ignored CLI tests ───────────────────────────────────
+
+    def test_report_ignored_shows_locations(self, tmp_path, monkeypatch):
+        """--report-ignored prints file:line for each ignore comment."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            "def ignored(a, b):  # complexipy: ignore\n"
+            "    if a and b:\n"
+            "        return a + b\n"
+            "    return 0\n\n"
+            "def normal(a):\n"
+            "    return a\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(main_module.app, ["--report-ignored", str(source_file)])
+        assert result.exit_code == 0
+        assert "sample.py:1" in result.output
+        assert "# complexipy: ignore" in result.output
+        assert "Found 1 suppressed location(s)" in result.output
+
+    def test_report_ignored_no_markers(self, tmp_path, monkeypatch):
+        """--report-ignored with no markers prints 'No ignore comments found'."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "clean.py"
+        source_file.write_text("def foo():\n    return 1\n", encoding="utf-8")
+
+        result = runner.invoke(main_module.app, ["--report-ignored", str(source_file)])
+        assert result.exit_code == 0
+        assert "No ignore comments found" in result.output
+
+    def test_report_ignored_with_no_ignore(self, tmp_path, monkeypatch):
+        """--report-ignored --no-ignore: reports AND analyzes everything."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            "def ignored(a, b):  # complexipy: ignore\n"
+            "    if a and b:\n"
+            "        return a + b\n"
+            "    return 0\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            main_module.app, ["--report-ignored", "--no-ignore", str(source_file)]
+        )
+        assert result.exit_code == 0
+        assert "sample.py:1" in result.output
+        assert "# complexipy: ignore" in result.output
+        assert "ignored" in result.output
+
+    def test_report_ignored_respects_exclude(self, tmp_path, monkeypatch):
+        """--report-ignored only scans files not excluded by --exclude."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "a.py").write_text(
+            "def foo():  # complexipy: ignore\n    pass\n", encoding="utf-8"
+        )
+        (tmp_path / "src" / "b.py").write_text(
+            "def bar():  # noqa: complexipy\n    pass\n", encoding="utf-8"
+        )
+
+        result = runner.invoke(
+            main_module.app,
+            ["--report-ignored", "--exclude", "b.py", str(tmp_path / "src")],
+        )
+        assert result.exit_code == 0
+        assert "a.py" in result.output
+        assert "b.py" not in result.output
+
+    def test_report_ignored_with_quiet(self, tmp_path, monkeypatch):
+        """--report-ignored still prints report even under --quiet."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            "def ignored(a, b):  # complexipy: ignore\n"
+            "    if a and b:\n"
+            "        return a + b\n"
+            "    return 0\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            main_module.app, ["--report-ignored", "--quiet", str(source_file)]
+        )
+        assert result.exit_code == 0
+        assert "sample.py:1" in result.output
+        assert "Found 1 suppressed location(s)" in result.output
+
     def test_exclude(self):
         path = self.local_path / "src"
         files, _ = _complexipy.main(

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -455,6 +455,8 @@ class TestOutputToml:
             None,
             None,
             None,
+            None,
+            None,
         )
 
         assert values[9] == ["json", "gitlab"]


### PR DESCRIPTION
## What

Adds two new CLI flags that give teams visibility into and control over `# complexipy: ignore` / `# noqa: complexipy` suppression comments.

## Why

Currently there is no way to discover where ignore comments exist in a codebase, nor to override them for full-audit analysis. These flags fill that gap:

- `--report-ignored` surfaces suppressed complexity for technical debt tracking
- `--no-ignore` enables full unsuppressed analysis for compliance and periodic health checks

Closes #176.

## Changes

### New CLI flags
- `--no-ignore` — disregards all `# complexipy: ignore` and `# noqa: complexipy` comments, analyzing every function
- `--report-ignored` — lists every file:line where an ignore comment suppresses a function, including optional JSON export
- Both flags are composable and TOML-configurable via `get_arguments_value`

### Rust engine (`src/`)
- `IgnoredLocation` data class (`classes.rs`) with path, line, and comment text
- `find_noqa_comment()` refactored from `has_noqa_complexipy()` to return the matched comment text (`utils.rs`)
- `collect_ignored_locations()` scans code for function defs and reports only markers that actually suppress (`utils.rs`)
- `collect_all_ignored_locations()` orchestrates file discovery plus Git URL cloning (`cognitive_complexity.rs`)
- `no_ignore` parameter threaded through entire analysis chain: `main` → `process_path` → `evaluate_dir` → `file_complexity` → `code_complexity` → `function_level_cognitive_complexity_shared`
- `ProcessOptions` struct extracted to eliminate `clippy::too_many_arguments` on `process_path`
- Word-boundary checks prevent false positives on partial keywords like `# complexipy: ignoreme`

### Python layer (`complexipy/`)
- `main()` refactored: extracted `validate_cli_arguments()` and `handle_report_ignored()` helpers, reducing cognitive complexity from 24 to under 15
- `code_complexity()` and `file_complexity()` APIs gain `no_ignore` parameter
- `IgnoredLocation` exported from public API

### Tests
- 12 new tests in `tests/main.py` covering `--no-ignore` (regular/decorated functions, Python API, default behavior) and `--report-ignored` (output format, exclusion, `--quiet` bypass, composition with `--no-ignore`)
- Updated `tests/test_output_cli.py` for new `get_arguments_value` parameters

### CI
- Added `ruff format --check` step to the `lint` job in `.github/workflows/CI.yml`

### Type stubs
- `complexipy/_complexipy.pyi` updated with new function signatures and `IgnoredLocation` class