### PR TITLE
fix(utils): prevent UTF-8 panic in comment marker extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "complexipy"
-version = "5.5.0"
+version = "5.6.0"
 dependencies = [
  "console_error_panic_hook",
  "csv",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@
 use regex::Regex;
 #[cfg(any(feature = "python", feature = "wasm"))]
 use ruff_python_ast::{self as ast, Stmt};
+#[cfg(any(feature = "python", feature = "wasm"))]
+use std::sync::OnceLock;
 
 #[cfg(feature = "python")]
 mod python_deps {
@@ -346,8 +348,12 @@ pub fn get_line_number(byte_index: usize, code: &str) -> u64 {
 /// Returns `None` if neither marker is found.
 #[cfg(any(feature = "python", feature = "wasm"))]
 pub fn extract_comment_marker(line: &str) -> Option<String> {
-    let ignore_re = Regex::new(r"#\s*complexipy\s*:\s*ignore.*").unwrap();
-    let noqa_re = Regex::new(r"#\s*noqa\s*:\s*complexipy").unwrap();
+    static IGNORE_RE: OnceLock<Regex> = OnceLock::new();
+    static NOQA_RE: OnceLock<Regex> = OnceLock::new();
+
+    let ignore_re =
+        IGNORE_RE.get_or_init(|| Regex::new(r"(?i)#\s*complexipy\s*:\s*ignore.*").unwrap());
+    let noqa_re = NOQA_RE.get_or_init(|| Regex::new(r"(?i)#\s*noqa\s*:\s*complexipy.*").unwrap());
 
     if ignore_re.is_match(line) {
         return Some("# complexipy: ignore".to_string());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
 #[cfg(any(feature = "python", feature = "wasm"))]
+use regex::Regex;
+#[cfg(any(feature = "python", feature = "wasm"))]
 use ruff_python_ast::{self as ast, Stmt};
 
 #[cfg(feature = "python")]
@@ -342,35 +344,17 @@ pub fn get_line_number(byte_index: usize, code: &str) -> u64 {
 /// Returns `Some("# complexipy: ignore")` or `Some("# noqa: complexipy")`
 /// when the line contains the corresponding pattern (case-insensitive).
 /// Returns `None` if neither marker is found.
-fn is_word_boundary(s: &str, pos: usize) -> bool {
-    pos >= s.len() || (!s.as_bytes()[pos].is_ascii_alphanumeric() && s.as_bytes()[pos] != b'_')
-}
-
-/// Extract a canonical ignore comment marker from a line.
-///
-/// Returns `Some("# complexipy: ignore")` or `Some("# noqa: complexipy")`
-/// when the line contains the corresponding pattern (case-insensitive).
-/// Returns `None` if neither marker is found.
 #[cfg(any(feature = "python", feature = "wasm"))]
 pub fn extract_comment_marker(line: &str) -> Option<String> {
-    for (idx, ch) in line.char_indices() {
-        if ch == '#' {
-            let after_hash = &line[idx + 1..];
-            let trimmed = after_hash.trim_start();
-            if trimmed.len() >= "complexipy: ignore".len()
-                && trimmed[.."complexipy: ignore".len()].eq_ignore_ascii_case("complexipy: ignore")
-                && is_word_boundary(trimmed, "complexipy: ignore".len())
-            {
-                return Some("# complexipy: ignore".to_string());
-            }
-            if trimmed.len() >= "noqa: complexipy".len()
-                && trimmed[.."noqa: complexipy".len()].eq_ignore_ascii_case("noqa: complexipy")
-                && is_word_boundary(trimmed, "noqa: complexipy".len())
-            {
-                return Some("# noqa: complexipy".to_string());
-            }
-        }
+    let ignore_re = Regex::new(r"#\s*complexipy\s*:\s*ignore.*").unwrap();
+    let noqa_re = Regex::new(r"#\s*noqa\s*:\s*complexipy").unwrap();
+
+    if ignore_re.is_match(line) {
+        return Some("# complexipy: ignore".to_string());
+    } else if noqa_re.is_match(line) {
+        return Some("# noqa: complexipy".to_string());
     }
+
     None
 }
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -45,7 +45,7 @@ class TestFiles:
             [path.resolve().as_posix()], False, [], False
         )
         total_complexity = sum([file.complexity for file in files])
-        assert 58 == total_complexity
+        assert 63 == total_complexity
 
     def test(self):
         path = self.local_path / "src/test.py"
@@ -188,6 +188,25 @@ def hello_world(s: str) -> str:
 """
         result = code_complexity(snippet)
         assert 2 == result.complexity
+
+    def test_utf8_multi_byte_comment_no_panic(self):
+        """Multi-byte UTF-8 characters in comments must not cause panics.
+
+        The old byte-slicing implementation would panic when slicing at
+        positions that fell in the middle of multi-byte UTF-8 characters.
+        This test ensures the regex replacement handles all Unicode safely.
+        """
+        path = self.local_path / "src/test_utf8_comment.py"
+        files, failed = _complexipy.main(
+            [path.resolve().as_posix()], False, [], False
+        )
+        # All marker-commented functions should be ignored; only
+        # not_ignored_normal (no marker) should count.
+        total_complexity = sum([file.complexity for file in files])
+        assert 5 == total_complexity, (
+            f"Expected 5 (only not_ignored_normal), got {total_complexity}"
+        )
+        assert failed == [], f"Unexpected failures: {failed}"
 
     def test_noqa_complexipy_ignore(self):
         path = self.local_path / "src/test_noqa_complex.py"
@@ -421,7 +440,7 @@ def hello_world(s: str) -> str:
         total_complexity = sum([file.complexity for file in files])
         # Excluding only by basename that does not exist at the root
         # should not exclude nested files anymore.
-        assert 58 == total_complexity
+        assert 63 == total_complexity
 
     def test_exclude_full_path(self):
         path = self.local_path / "src"
@@ -432,7 +451,7 @@ def hello_world(s: str) -> str:
             False,
         )
         total_complexity = sum([file.complexity for file in files])
-        assert 55 == total_complexity
+        assert 60 == total_complexity
 
     def test_exclude_whole_directory(self):
         path = self.local_path / "src"
@@ -443,7 +462,7 @@ def hello_world(s: str) -> str:
             False,
         )
         total_complexity = sum([file.complexity for file in files])
-        assert 52 == total_complexity
+        assert 57 == total_complexity
 
     def test_exclude_glob_single_file(self):
         path = self.local_path / "src"
@@ -455,7 +474,7 @@ def hello_world(s: str) -> str:
         )
         total_complexity = sum([file.complexity for file in files])
         # **/test_exclude1.py should match exclude_dir/test_exclude1.py (complexity 3)
-        assert 55 == total_complexity
+        assert 60 == total_complexity
 
     def test_exclude_glob_directory(self):
         path = self.local_path / "src"
@@ -467,7 +486,7 @@ def hello_world(s: str) -> str:
         )
         total_complexity = sum([file.complexity for file in files])
         # **/exclude_dir/** should match all files under exclude_dir (complexity 6 total)
-        assert 52 == total_complexity
+        assert 57 == total_complexity
 
     def test_exclude_glob_wildcard(self):
         path = self.local_path / "src"
@@ -479,7 +498,7 @@ def hello_world(s: str) -> str:
         )
         total_complexity = sum([file.complexity for file in files])
         # **/test_exclude*.py matches both test_exclude1.py and test_exclude2.py (complexity 3+3=6)
-        assert 52 == total_complexity
+        assert 57 == total_complexity
 
     def test_snapshot_watermark_passes_and_updates_snapshot(
         self, tmp_path: Path

--- a/tests/src/test_utf8_comment.py
+++ b/tests/src/test_utf8_comment.py
@@ -1,0 +1,63 @@
+def multi_byte_before_marker(a):  # noqa: complexipy — multi-byte em-dash before marker
+    if a:
+        return a
+    elif a > 10:
+        return a * 2
+    else:
+        return 0
+
+
+def emoji_comment(a, b):  # complexipy: ignore 🔥 multi-byte emoji after marker
+    if a and b:
+        return a + b
+    elif a or b:
+        return a | b
+    else:
+        return 0
+
+
+def accent_before(b):  # noqa: complexipy café multi-byte accent after marker
+    if b:
+        return b
+    elif b < 5:
+        return b * 3
+    else:
+        return 0
+
+
+def mixed_comment_marker(a, b, c):  # complexipy: ignore — 🚀 mixed em-dash & emoji
+    if a and b:
+        return a + b
+    elif b and c:
+        return b * c
+    elif a or c:
+        return a | c
+    else:
+        return 0
+
+
+def uppercase_variants(x):  # NOQA: COMPLEXIPY — uppercase variant
+    if x:
+        return x
+    elif x > 10:
+        return x * 2
+    else:
+        return 0
+
+
+def mixed_case_ignore(y):  # Complexipy: Ignore — mixed case
+    if y:
+        return y * 2
+    elif y < 0:
+        return -y
+    else:
+        return 0
+
+
+def not_ignored_normal(a, b):
+    if a and b:
+        return a + b
+    elif a or b:
+        return a | b
+    else:
+        return 0


### PR DESCRIPTION
## What

Replace the manual byte-slicing logic in `extract_comment_marker` with regex-based matching to prevent a hard crash when a multi-byte UTF-8 character straddles byte offset 16 of a comment.

## Why

The old implementation sliced at a fixed byte index without checking char boundaries, causing a panic when a multi-byte character (e.g. em-dash `—`, accented letters, CJK, emoji) happened to land at the cut point. Because the panic unwinds through `evaluate_dir`, a single offending comment aborts analysis of the entire directory with no way to skip the file. See #186 for the full reproduction.

## Changes

- **`src/utils.rs`** — Replaced byte-iteration + positional slicing in `extract_comment_marker` with `Regex` matching, which properly handles UTF-8 strings. Removed the now-unused `is_word_boundary` helper.
- **`src/utils.rs`** — Added `OnceLock` for lazy regex compilation and restored case-insensitive matching with the `(?i)` flag.
- **`tests/src/test_utf8_comment.py`** — New regression test covering em-dashes, emoji, accented characters, uppercase/mixed-case comment markers.
- **`tests/main.py`** — Added `test_utf8_multi_byte_comment_no_panic` test case; updated expected complexity values across directory-level tests.
- **`Cargo.lock`** — Synced the lockfile version from `5.5.0` to `5.6.0` to match `Cargo.toml`.

Fixes #186