### PR TITLE
fix(exclude): normalize Windows paths for wax glob compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,8 @@ jobs:
             python-version: "3.13"
           - runner: macos-latest
             python-version: "3.13"
+    env:
+      PYTHONIOENCODING: utf-8
     steps:
       - uses: actions/checkout@v4
       - name: Install uv

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,8 @@ jobs:
           - runner: ubuntu-latest
             python-version: "3.13"
           - runner: windows-latest
+            python-version: "3.8"
+          - runner: windows-latest
             python-version: "3.13"
           - runner: macos-latest
             python-version: "3.13"
@@ -58,13 +60,28 @@ jobs:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: uv.lock
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - name: pytest
         shell: bash
         run: |
           uv sync --all-extras --frozen
           uv run -p ${{ matrix.python-version }} maturin develop
           uv run -p ${{ matrix.python-version }} pytest
-      - name: complexipy execution
+      - name: complexipy CLI validation
         shell: bash
         run: |-
           uv run -p ${{ matrix.python-version }} complexipy complexipy --failed
+      - name: complexipy exclude pattern validation
+        shell: bash
+        run: |-
+          uv run -p ${{ matrix.python-version }} complexipy tests/src --exclude "exclude_dir/**" --ignore-complexity
+          uv run -p ${{ matrix.python-version }} complexipy tests/src --exclude "**/test_exclude*.py" --ignore-complexity

--- a/src/helpers/exclude.rs
+++ b/src/helpers/exclude.rs
@@ -16,14 +16,9 @@ pub fn get_paths_to_process(
         .collect();
 
     let gitignore_walk = Walk::new(&normalized_root);
-    // Normalize all paths to use forward slashes for consistent comparison
-    // On Windows, ignore::Walk may return paths with backslashes
     let non_ignored: Vec<String> = gitignore_walk
         .filter_map(|result| match result {
-            Ok(entry) => entry
-                .path()
-                .to_str()
-                .map(|s| s.replace('\\', "/")),
+            Ok(entry) => entry.path().to_str().map(|s| s.replace('\\', "/")),
             Err(_) => None,
         })
         .collect();

--- a/src/helpers/exclude.rs
+++ b/src/helpers/exclude.rs
@@ -2,26 +2,47 @@ use ignore::Walk;
 use wax::walk::{Entry, FileIterator};
 use wax::{Glob, any};
 
-pub fn get_paths_to_process(root_path: &str, to_exclude_paths: Vec<String>) -> Vec<String> {
+pub fn get_paths_to_process(
+    root_path: &str,
+    to_exclude_paths: Vec<String>,
+) -> Result<Vec<String>, String> {
     let mut files_paths: Vec<String> = Vec::new();
     let glob = Glob::new("**/*.py").unwrap();
-    let gitignore_walk = Walk::new(root_path);
+
+    let normalized_root = root_path.replace('\\', "/");
+    let normalized_excludes: Vec<String> = to_exclude_paths
+        .iter()
+        .map(|s| s.replace('\\', "/"))
+        .collect();
+
+    let gitignore_walk = Walk::new(&normalized_root);
+    // Normalize all paths to use forward slashes for consistent comparison
+    // On Windows, ignore::Walk may return paths with backslashes
     let non_ignored: Vec<String> = gitignore_walk
         .filter_map(|result| match result {
-            Ok(entry) => entry.path().to_str().map(String::from),
+            Ok(entry) => entry
+                .path()
+                .to_str()
+                .map(|s| s.replace('\\', "/")),
             Err(_) => None,
         })
         .collect();
 
-    let exclude_refs: Vec<&str> = to_exclude_paths.iter().map(|s| s.as_str()).collect();
-    for entry in glob
-        .walk(root_path)
+    let exclude_refs: Vec<&str> = normalized_excludes.iter().map(|s| s.as_str()).collect();
+
+    let non_excluded_entries = glob
+        .walk(&normalized_root)
         .not(any(exclude_refs))
-        .unwrap()
+        .map_err(|e| format!("Failed to apply exclude patterns: {}", e))?;
+
+    for entry in non_excluded_entries
         .filter_map(|entry| entry.ok())
         .filter(|entry| {
-            let path = entry.path().to_str().expect("Failed to extract");
-            non_ignored.contains(&path.to_string())
+            entry
+                .path()
+                .to_str()
+                .map(|s| non_ignored.contains(&s.replace('\\', "/")))
+                .unwrap_or(false)
         })
     {
         let entry_path = entry.path();
@@ -30,8 +51,8 @@ pub fn get_paths_to_process(root_path: &str, to_exclude_paths: Vec<String>) -> V
             Err(_) => entry_path.to_path_buf(),
         };
         let file_abs_str = file_abs.to_string_lossy().replace('\\', "/");
-        files_paths.push(file_abs_str.to_string());
+        files_paths.push(file_abs_str);
     }
 
-    files_paths
+    Ok(files_paths)
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -165,7 +165,10 @@ fn evaluate_dir(path: &str, opts: &ProcessOptions) -> ComplexitiesAndFailedPaths
         .unwrap_or(path::Path::new("."))
         .to_string_lossy()
         .replace('\\', "/");
-    let files_paths_to_process = get_paths_to_process(path, opts.exclude.clone());
+    let files_paths_to_process = match get_paths_to_process(path, opts.exclude.clone()) {
+        Ok(paths) => paths,
+        Err(e) => return (vec![], vec![format!("{}: {}", path, e)]),
+    };
 
     if opts.quiet {
         let results: Vec<_> = files_paths_to_process
@@ -309,7 +312,13 @@ pub fn collect_all_ignored_locations(
                 Err(_) => failed_paths.push(path_str.to_string()),
             }
         } else if path_obj.is_dir() {
-            let files = get_paths_to_process(path_str, exclude.clone());
+            let files = match get_paths_to_process(path_str, exclude.clone()) {
+                Ok(paths) => paths,
+                Err(e) => {
+                    failed_paths.push(format!("{}: {}", path_str, e));
+                    continue;
+                }
+            };
             let base_dir = path_obj
                 .canonicalize()
                 .unwrap_or_else(|_| path_obj.to_path_buf())
@@ -369,7 +378,8 @@ fn collect_ignored_locations_from_url(
     }
 
     let repo_path = dir.path().join(&repo_name).to_string_lossy().to_string();
-    let files = get_paths_to_process(&repo_path, exclude.to_vec());
+    let files =
+        get_paths_to_process(&repo_path, exclude.to_vec()).map_err(PyValueError::new_err)?;
     let base_dir = path::Path::new(&repo_path)
         .canonicalize()
         .unwrap_or_else(|_| path::Path::new(&repo_path).to_path_buf())


### PR DESCRIPTION
## What

Fix `--exclude` panicking on Windows since version 5.5.0 by normalizing backslashes to forward slashes before passing paths to the wax glob library.

Closes: #193 

## Why

On Windows, file paths use backslashes (`\`) as separators, but the wax glob library interprets backslashes as escape characters in glob syntax. This caused a `ParseError` when using `--exclude` patterns on Windows, as the library tried to parse Windows paths like `app\src\app\test` as glob expressions.

## Changes

- Normalize `root_path`, exclude patterns, and all discovered paths to use forward slashes in `src/helpers/exclude.rs`
- Change `get_paths_to_process` return type from `Vec<String>` to `Result<Vec<String>, String>` for proper error handling
- Update all 3 callers in `src/runner.rs` to handle errors gracefully with path context
- Replace `unwrap()` with `map_err()` to provide clear error messages instead of panicking
- Normalize `non_ignored` paths from `ignore::Walk` for consistent cross-platform comparison

### CI improvements

- Add Python 3.8 on Windows to CI matrix for minimum version coverage
- Add Cargo caching to reduce build times
- Add exclude pattern validation tests that run on all platforms
