### PR TITLE
refactor(cli): simplify diff API and improve output

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ complexipy . --output-format gitlab --output complexipy-code-quality.json
 complexipy . --diff HEAD~1
 
 # Fail only on threshold-breaking regressions in a diff
-complexipy . --diff main --ratchet
+complexipy . --diff main
 # Analyze current directory while excluding files or directories with glob patterns
 complexipy . --exclude "tests/**" --exclude "path/to/exclude.py"
 
@@ -253,32 +253,33 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 ### CLI Options
 
-| Flag                            | Description                                                                                                                                    | Default |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `--exclude`                     | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files. |         |
-| `--max-complexity-allowed`      | Complexity threshold                                                                                                                           | `15`    |
-| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                | `false` |
-| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                          | `false` |
-| `--failed`                      | Show only functions above the complexity threshold                                                                                             | `false` |
-| `--suggest-refactors`           | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain`                                                      | `false` |
-| `--color <auto\|yes\|no>`       | Use color                                                                                                                                      | `auto`  |
-| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                   | `asc`   |
-| `--quiet`                       | Suppress output                                                                                                                                | `false` |
-| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                      | `false` |
-| `--version`                     | Show installed complexipy version and exit                                                                                                     | -       |
-| `--top <n>`                     | Show only the `n` most complex functions, globally sorted by complexity descending                                                             | —       |
-| `--plain`                       | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                   | `false` |
-| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                        | —       |
-| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                           | —       |
-| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                         | —       |
-| `--ratchet`                     | With `--diff`, fail only when a change pushes a function above `--max-complexity-allowed` or makes an already-over function worse              | `false` |
-| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                        | `false` |
-| `--no-ignore`                   | Analyze every function, disregarding inline ignore comments (`# complexipy: ignore`, `# noqa: complexipy`)                                     | `false` |
-| `--report-ignored`              | List every file:line where an ignore comment suppresses a function. Prints even under `--quiet`                                                | `false` |
-| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                    | `false` |
-| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                     | `false` |
-| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                  | `false` |
-| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                   | `false` |
+| Flag                            | Description                                                                                                                                                               | Default |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                     | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files.                            |         |
+| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                                      | `15`    |
+| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                           | `false` |
+| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                                     | `false` |
+| `--failed`                      | Show only functions above the complexity threshold                                                                                                                        | `false` |
+| `--suggest-refactors`           | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain`                                                                                 | `false` |
+| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                                 | `auto`  |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                              | `asc`   |
+| `--quiet`                       | Suppress output                                                                                                                                                           | `false` |
+| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                                 | `false` |
+| `--version`                     | Show installed complexipy version and exit                                                                                                                                | -       |
+| `--top <n>`                     | Show only the `n` most complex functions, globally sorted by complexity descending                                                                                        | —       |
+| `--plain`                       | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                              | `false` |
+| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                   | —       |
+| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                                      | —       |
+| `--diff <ref>`                  | Show a complexity diff against a git reference and enforce the threshold. Fails on regressions above `--max-complexity-allowed` (see [Complexity Diff](#complexity-diff)) | —       |
+| `--diff-only <ref>`             | Show a complexity diff visually without affecting the exit code (see [Complexity Diff](#complexity-diff))                                                                 | —       |
+| `--ratchet`, `-R`               | **Deprecated.** Use `--diff` instead, which now enforces by default                                                                                                       | `false` |
+| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                                   | `false` |
+| `--no-ignore`                   | Analyze every function, disregarding inline ignore comments (`# complexipy: ignore`, `# noqa: complexipy`)                                                                | `false` |
+| `--report-ignored`              | List every file:line where an ignore comment suppresses a function. Prints even under `--quiet`                                                                           | `false` |
+| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                               | `false` |
+| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                                | `false` |
+| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                             | `false` |
+| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                              | `false` |
 
 Example:
 
@@ -332,7 +333,7 @@ Use `--snapshot-ignore` if you need to temporarily bypass the snapshot gate (for
 
 ### Complexity Diff
 
-Compare complexity against any git reference to see at a glance whether a branch or commit made things better or worse:
+Compare complexity against any git reference to see whether a branch or commit made things better or worse:
 
 ```bash
 # Compare the working tree against the previous commit
@@ -340,29 +341,22 @@ complexipy . --diff HEAD~1
 
 # Compare against a named branch
 complexipy . --diff main
-
-# Fail only on threshold-breaking regressions
-complexipy . --diff main --ratchet
-
-# Combine with other flags
-complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
 ```
 
-`--ratchet` requires `--diff`. It exits with code `1` only when a new or modified function breaches `--max-complexity-allowed`; regressions that stay within the threshold are allowed.
+By default `--diff` **enforces** the complexity threshold: the run exits with code `1` only when a change breaches the contract relative to `--max-complexity-allowed`:
 
-Sample output:
+- A new function is introduced above the threshold, or
+- an existing function's complexity increases **and** ends above the threshold (already-over functions getting worse also fail).
 
+Functions that regress but stay at or below the threshold (e.g. `3 → 4` with `-mx 15`) are **not** flagged — the threshold is still the main contract, and `--diff` only catches regressions that actually break it.
+
+To see the diff visually without affecting the exit code, use `--diff-only` instead:
+
+```bash
+complexipy . --diff-only HEAD~1
 ```
-Complexity diff  (vs HEAD~1)
-────────────────────────────────────────────────────────────────────────
-  REGRESSED   src/api.py::handle_request                        12 → 19  (+7)
-  IMPROVED    src/utils.py::flatten_tree                        22 → 14  (-8)
-  NEW         src/auth.py::validate_token                       17        (new)
-────────────────────────────────────────────────────────────────────────
-Net: 1 regressed, 1 improved, 1 new
-```
 
-The diff is appended after the normal analysis output and does not affect the exit code. Requires `git` to be available and the analysed paths to be inside a git repository.
+Requires `git` to be available and the analysed paths to be inside a git repository.
 
 ### Script Complexity
 

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -299,27 +299,13 @@ def main(
     no_ignore = bool(no_ignore)
     report_ignored = bool(report_ignored)
     ratchet = bool(get_argument_value(TOML_CONFIG, "ratchet", ratchet, False))
-    if ratchet and diff:
-        console.print(
-            "[yellow]Deprecated:[/yellow] --ratchet is deprecated. "
-            "--diff now enforces by default. Remove --ratchet."
-        )
-    elif ratchet and not diff:
-        console.print("[bold red]Error:[/bold red] --ratchet requires --diff")
-        raise typer.Exit(code=2)
-
-    if diff_only and diff:
-        console.print(
-            "[yellow]Warning:[/yellow] --diff and --diff-only both set. "
-            "Using --diff-only (visual only, no enforcement)."
-        )
-        diff = None
 
     plain, suggest_refactors = validate_cli_arguments(
         plain, suggest_refactors, top, quiet
     )
 
     handle_console_settings(color, quiet, plain)
+    diff, diff_only = resolve_diff_flags(diff, diff_only, ratchet)
 
     result: Tuple[List[FileComplexity], List[str]] = _complexipy.main(
         paths, quiet, exclude, check_script, no_ignore, INVOCATION_PATH
@@ -412,6 +398,12 @@ def main(
         max_complexity_allowed,
     )
 
+    if not quiet and not plain:
+        if platform.system() == "Windows":
+            console.rule("Analysis completed!")
+        else:
+            console.rule(":tada: Analysis completed! :tada:")
+
     if not has_success:
         raise typer.Exit(code=1)
 
@@ -475,11 +467,6 @@ def handle_display(
         top,
         suggest_refactors,
     )
-    if not plain:
-        if platform.system() == "Windows":
-            console.rule("Analysis completed!")
-        else:
-            console.rule(":tada: Analysis completed! :tada:")
     return has_success
 
 
@@ -689,11 +676,13 @@ def handle_diff_output(
     quiet: bool,
 ) -> Optional[List[DiffEntry]]:
     global console
-    if diff and files_complexities:
-        entries = compute_diff(files_complexities, diff, INVOCATION_PATH)
-        if not quiet:
-            console.print(format_diff(entries, diff))
-        return entries
+    if diff:
+        if files_complexities:
+            entries = compute_diff(files_complexities, diff, INVOCATION_PATH)
+            if not quiet:
+                format_diff(console, entries, diff)
+            return entries
+        return []
     return None
 
 
@@ -740,6 +729,33 @@ def handle_report_ignored(
             json.dump(ignored_data, f, indent=2)
             f.write("\n")
         console.print(f"Ignored locations saved at {ignored_json_path}")
+
+
+def resolve_diff_flags(
+    diff: Optional[str],
+    diff_only: Optional[str],
+    ratchet: bool,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Validate and resolve --diff, --diff-only, and deprecated --ratchet flags."""
+    global console
+
+    if ratchet and diff:
+        console.print(
+            "[yellow]Deprecated:[/yellow] --ratchet is deprecated. "
+            "--diff now enforces by default. Remove --ratchet."
+        )
+    elif ratchet and not diff:
+        console.print("[bold red]Error:[/bold red] --ratchet requires --diff")
+        raise typer.Exit(code=2)
+
+    if diff_only and diff:
+        console.print(
+            "[yellow]Warning:[/yellow] --diff and --diff-only both set. "
+            "Using --diff-only (visual only, no enforcement)."
+        )
+        diff = None
+
+    return diff, diff_only
 
 
 def validate_cli_arguments(

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -174,22 +174,24 @@ def main(
         "--diff",
         "-d",
         help=(
-            "Show a complexity diff against a git reference (e.g. HEAD~1, main, "
-            "a commit SHA).  Requires git to be available and the paths to be "
-            "inside a git repository."
+            "Show a complexity diff against a git reference and fail if any "
+            "function regresses above --max-complexity-allowed. "
+            "Use --diff-only for visual-only output without enforcement."
+        ),
+    ),
+    diff_only: Optional[str] = typer.Option(
+        None,
+        "--diff-only",
+        help=(
+            "Show a complexity diff against a git reference without affecting "
+            "the exit code. Visual-only, no enforcement."
         ),
     ),
     ratchet: Optional[bool] = typer.Option(
         None,
         "--ratchet",
         "-R",
-        help=(
-            "Only fail when a change breaches --max-complexity-allowed. "
-            "Requires --diff. Exit 1 if a new function exceeds the threshold "
-            "or an existing function regresses above it (already-over "
-            "functions that get worse also fail). Regressions that stay "
-            "within the threshold are allowed."
-        ),
+        help="Deprecated. --diff now enforces by default.",
     ),
     output_sarif: Optional[bool] = typer.Option(
         None,
@@ -297,7 +299,21 @@ def main(
     no_ignore = bool(no_ignore)
     report_ignored = bool(report_ignored)
     ratchet = bool(get_argument_value(TOML_CONFIG, "ratchet", ratchet, False))
-    validate_ratchet(ratchet, diff)
+    if ratchet and diff:
+        console.print(
+            "[yellow]Deprecated:[/yellow] --ratchet is deprecated. "
+            "--diff now enforces by default. Remove --ratchet."
+        )
+    elif ratchet and not diff:
+        console.print("[bold red]Error:[/bold red] --ratchet requires --diff")
+        raise typer.Exit(code=2)
+
+    if diff_only and diff:
+        console.print(
+            "[yellow]Warning:[/yellow] --diff and --diff-only both set. "
+            "Using --diff-only (visual only, no enforcement)."
+        )
+        diff = None
 
     plain, suggest_refactors = validate_cli_arguments(
         plain, suggest_refactors, top, quiet
@@ -385,12 +401,13 @@ def main(
         has_success = has_success and snapshot_result
 
     valid_paths = print_invalid_paths(console, quiet, failed_paths)
-    diff_entries = handle_diff_output(diff, files_complexities, quiet)
+    diff_ref = diff or diff_only
+    diff_entries = handle_diff_output(diff_ref, files_complexities, quiet)
     has_success = resolve_final_success(
         has_success,
         valid_paths,
         snapshot_result,
-        ratchet,
+        bool(diff),
         diff_entries,
         max_complexity_allowed,
     )
@@ -725,12 +742,6 @@ def handle_report_ignored(
         console.print(f"Ignored locations saved at {ignored_json_path}")
 
 
-def validate_ratchet(ratchet: bool, diff: Optional[str]) -> None:
-    if ratchet and not diff:
-        console.print("[bold red]Error:[/bold red] --ratchet requires --diff")
-        raise typer.Exit(code=2)
-
-
 def validate_cli_arguments(
     plain: Optional[bool],
     suggest_refactors: Optional[bool],
@@ -759,11 +770,11 @@ def resolve_final_success(
     has_success: bool,
     valid_paths: bool,
     snapshot_result: bool,
-    ratchet: bool,
+    enforce: bool,
     diff_entries: Optional[List[DiffEntry]],
     max_complexity_allowed: int,
 ) -> bool:
-    if ratchet and diff_entries is not None:
+    if enforce and diff_entries is not None:
         ratchet_ok = not has_regressions(diff_entries, max_complexity_allowed)
         return ratchet_ok and valid_paths and snapshot_result
     return has_success and valid_paths

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -440,7 +440,9 @@ def handle_display(
         previous_functions = None
 
     if quiet:
-        return has_success_functions(files_complexities, max_complexity_allowed)
+        return has_success_functions(
+            files_complexities, max_complexity_allowed, active_snapshot_map
+        )
 
     effective_sort = Sort.desc if top is not None else sort
     has_success = output_summary(

--- a/complexipy/types.py
+++ b/complexipy/types.py
@@ -9,9 +9,9 @@ else:
 
 
 class ColorTypes(str, Enum):
-    auto = "auto"  # Decide whether to color automatically, based on output tty
-    yes = "yes"  # Use color
-    no = "no"  # Do not use color
+    auto = "auto"
+    yes = "yes"
+    no = "no"
 
 
 class Sort(str, Enum):

--- a/complexipy/utils/diff.py
+++ b/complexipy/utils/diff.py
@@ -10,7 +10,6 @@ from rich.console import Console
 from complexipy import code_complexity as _code_complexity
 from complexipy._complexipy import FileComplexity
 
-# Status labels with fixed width for aligned output.
 _STATUS_REGRESSED = "REGRESSED"
 _STATUS_IMPROVED = "IMPROVED"
 _STATUS_UNCHANGED = "UNCHANGED"
@@ -22,8 +21,8 @@ _STATUS_REMOVED = "REMOVED"
 class DiffEntry:
     file_path: str
     func_name: str
-    old_complexity: Optional[int]  # None when the function is new
-    new_complexity: Optional[int]  # None when the function was removed
+    old_complexity: Optional[int]
+    new_complexity: Optional[int]
 
     @property
     def status(self) -> str:
@@ -145,7 +144,6 @@ def compute_diff(
         current_map = _build_func_map(file)
 
         if old_content is None:
-            # File did not exist at the reference – every function is new.
             for name, new_c in sorted(current_map.items()):
                 entries.append(DiffEntry(file.path, name, None, new_c))
             continue

--- a/complexipy/utils/diff.py
+++ b/complexipy/utils/diff.py
@@ -82,6 +82,34 @@ def _build_func_map(file: FileComplexity) -> Dict[str, int]:
     return {f.name: f.complexity for f in file.functions}
 
 
+def _resolve_git_path(
+    file_path: str, git_ref: str, invocation_path: str
+) -> str:
+    """Resolve a runner-relative file path to a git-root-relative path.
+
+    The Rust runner computes ``file.path`` relative to the *parent* of the
+    target directory (its ``base_dir``).  When the invocation path equals
+    the git root (e.g. ``complexipy .``), this produces paths like
+    ``complexipy/complexipy/main.py`` instead of the git-correct
+    ``complexipy/main.py``.
+
+    We fix this by trying the path as-is first, then progressively stripping
+    leading components until ``git show`` can locate the file.
+    """
+    normalized = file_path.replace(os.sep, "/").replace("\\", "/")
+    parts = normalized.split("/")
+
+    for i in range(len(parts)):
+        candidate = "/".join(parts[i:])
+        if (
+            _file_content_at_ref(git_ref, candidate, invocation_path)
+            is not None
+        ):
+            return candidate
+
+    return normalized
+
+
 def compute_diff(
     current_files: List[FileComplexity],
     git_ref: str,
@@ -101,20 +129,13 @@ def compute_diff(
     either changed or is new/removed.  Unchanged functions are included so
     callers can choose how to filter.
     """
-    root = _git_root(invocation_path) or invocation_path
     entries: List[DiffEntry] = []
 
     for file in current_files:
-        # Build the path relative to the git root so ``git show`` can find it.
-        abs_file = os.path.normpath(os.path.join(invocation_path, file.path))
-        try:
-            path_from_root = os.path.relpath(abs_file, root)
-        except ValueError:
-            # relpath fails across drives on Windows – fall back to file.path
-            path_from_root = file.path
-
-        # git show requires forward slashes in the path even on Windows.
-        path_from_root = path_from_root.replace(os.sep, "/")
+        # file.path is relative to the parent of invocation_path (the Rust
+        # runner's base_dir).  Resolve it to a git-root-relative path so
+        # ``git show`` can find the file at the reference.
+        path_from_root = _resolve_git_path(file.path, git_ref, invocation_path)
 
         old_content = _file_content_at_ref(
             git_ref, path_from_root, invocation_path
@@ -146,18 +167,25 @@ def compute_diff(
 
 
 def _format_entry(e: DiffEntry) -> str:
-    label = e.status.ljust(10)
     location = f"{e.file_path}::{e.func_name}"
 
     if e.status == _STATUS_NEW:
-        return f"  {label}  {location:<55}  {e.new_complexity}  (new)"
+        label = f"[bold yellow]{_STATUS_NEW}[/bold yellow]"
+        return f"  {label:<30}  {location:<55}  {e.new_complexity}  (new)"
     if e.status == _STATUS_REMOVED:
-        return f"  {label}  {location:<55}  {e.old_complexity}  (removed)"
+        label = f"[dim]{_STATUS_REMOVED}[/dim]"
+        return f"  {label:<30}  {location:<55}  {e.old_complexity}  (removed)"
+    if e.status == _STATUS_REGRESSED:
+        label = f"[bold red]{_STATUS_REGRESSED}[/bold red]"
+    elif e.status == _STATUS_IMPROVED:
+        label = f"[bold green]{_STATUS_IMPROVED}[/bold green]"
+    else:
+        label = e.status
 
     delta = e.delta
     sign = "+" if delta and delta > 0 else ""
     score = f"{e.old_complexity} → {e.new_complexity}  ({sign}{delta})"
-    return f"  {label}  {location:<55}  {score}  "
+    return f"  {label:<30}  {location:<55}  {score}  "
 
 
 def _build_diff_summary(changed: List[DiffEntry]) -> str:
@@ -172,12 +200,16 @@ def _build_diff_summary(changed: List[DiffEntry]) -> str:
             counts[e.status] += 1
 
     labels = [
-        (_STATUS_REGRESSED, "regressed"),
-        (_STATUS_IMPROVED, "improved"),
-        (_STATUS_NEW, "new"),
-        (_STATUS_REMOVED, "removed"),
+        (_STATUS_REGRESSED, "regressed", "red"),
+        (_STATUS_IMPROVED, "improved", "green"),
+        (_STATUS_NEW, "new", "yellow"),
+        (_STATUS_REMOVED, "removed", "dim"),
     ]
-    parts = [f"{counts[s]} {label}" for s, label in labels if counts[s]]
+    parts = [
+        f"[{style}]{counts[s]} {label}[/{style}]"
+        for s, label, style in labels
+        if counts[s]
+    ]
     return ", ".join(parts) if parts else "no changes"
 
 

--- a/complexipy/utils/diff.py
+++ b/complexipy/utils/diff.py
@@ -5,6 +5,8 @@ import subprocess
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
+from rich.console import Console
+
 from complexipy import code_complexity as _code_complexity
 from complexipy._complexipy import FileComplexity
 
@@ -166,26 +168,32 @@ def compute_diff(
     return entries
 
 
-def _format_entry(e: DiffEntry) -> str:
-    location = f"{e.file_path}::{e.func_name}"
+def _status_style(status: str) -> str:
+    """Return Rich markup for a diff status label."""
+    if status == _STATUS_REGRESSED:
+        return "[bold red]REGRESSED[/bold red]"
+    if status == _STATUS_IMPROVED:
+        return "[bold green]IMPROVED[/bold green]"
+    if status == _STATUS_NEW:
+        return "[bold yellow]NEW[/bold yellow]"
+    if status == _STATUS_REMOVED:
+        return "[dim]REMOVED[/dim]"
+    return status
 
+
+def _format_change(e: DiffEntry) -> str:
+    """Return the change column value for a diff entry."""
     if e.status == _STATUS_NEW:
-        label = f"[bold yellow]{_STATUS_NEW}[/bold yellow]"
-        return f"  {label:<30}  {location:<55}  {e.new_complexity}  (new)"
+        return f"[bold yellow]{e.new_complexity}[/bold yellow]  (new)"
     if e.status == _STATUS_REMOVED:
-        label = f"[dim]{_STATUS_REMOVED}[/dim]"
-        return f"  {label:<30}  {location:<55}  {e.old_complexity}  (removed)"
-    if e.status == _STATUS_REGRESSED:
-        label = f"[bold red]{_STATUS_REGRESSED}[/bold red]"
-    elif e.status == _STATUS_IMPROVED:
-        label = f"[bold green]{_STATUS_IMPROVED}[/bold green]"
-    else:
-        label = e.status
-
+        return f"[dim]{e.old_complexity}[/dim]  (removed)"
     delta = e.delta
     sign = "+" if delta and delta > 0 else ""
-    score = f"{e.old_complexity} → {e.new_complexity}  ({sign}{delta})"
-    return f"  {label:<30}  {location:<55}  {score}  "
+    if e.status == _STATUS_REGRESSED:
+        return f"[red]{e.old_complexity} → {e.new_complexity}  ({sign}{delta})[/red]"
+    if e.status == _STATUS_IMPROVED:
+        return f"[green]{e.old_complexity} → {e.new_complexity}  ({sign}{delta})[/green]"
+    return f"{e.old_complexity} → {e.new_complexity}  ({sign}{delta})"
 
 
 def _build_diff_summary(changed: List[DiffEntry]) -> str:
@@ -242,10 +250,13 @@ def has_regressions(entries: List[DiffEntry], max_complexity: int) -> bool:
     return False
 
 
-def format_diff(entries: List[DiffEntry], git_ref: str) -> str:
-    """Return a human-readable diff table as a string."""
+def format_diff(
+    console: Console, entries: List[DiffEntry], git_ref: str
+) -> None:
+    """Render a complexity diff table to the console."""
     if not entries:
-        return f"No functions changed relative to {git_ref}.\n"
+        console.print(f"No functions changed relative to {git_ref}.")
+        return
 
     changed = [
         e
@@ -254,13 +265,31 @@ def format_diff(entries: List[DiffEntry], git_ref: str) -> str:
         in (_STATUS_REGRESSED, _STATUS_IMPROVED, _STATUS_NEW, _STATUS_REMOVED)
     ]
 
-    sep = "─" * 72
-    lines: List[str] = [
-        f"Complexity diff  (vs {git_ref})",
-        sep,
-        *[_format_entry(e) for e in changed],
-        sep,
-        f"Net: {_build_diff_summary(changed)}",
-    ]
+    if not changed:
+        console.print(f"No functions changed relative to {git_ref}.")
+        return
 
-    return "\n".join(lines) + "\n"
+    from rich.table import Table
+
+    table = Table(
+        show_header=True,
+        header_style="bold",
+        box=None,
+        pad_edge=False,
+        padding=(0, 2),
+    )
+    table.add_column("Status")
+    table.add_column("Location")
+    table.add_column("Change", justify="right")
+
+    for e in changed:
+        table.add_row(
+            _status_style(e.status),
+            f"{e.file_path}::{e.func_name}",
+            _format_change(e),
+        )
+
+    console.print()
+    console.rule(f"Complexity diff (vs {git_ref})")
+    console.print(table)
+    console.print(f"\nNet: {_build_diff_summary(changed)}")

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -7,7 +7,6 @@ from typing import (
     Tuple,
 )
 
-from rich.align import Align
 from rich.console import Console
 from rich.text import Text
 
@@ -18,7 +17,7 @@ from complexipy._complexipy import (
 from complexipy.types import (
     Sort,
 )
-from complexipy.utils import dataclasses as dc
+from complexipy.utils.dataclasses import FileEntry, FunctionRow
 
 
 def output_summary(
@@ -34,14 +33,10 @@ def output_summary(
     top: Optional[int] = None,
     suggest_refactors: bool = False,
 ) -> bool:
-    (
-        file_entries,
-        failing_functions,
-        total_functions,
-    ) = build_output_rows(
+    file_entries, total_functions, all_pass = build_output_rows(
         files, failed_only, sort, max_complexity, snapshot_map
     )
-    has_success = not failing_functions or ignore_complexity
+    has_success = all_pass or ignore_complexity
 
     if top is not None:
         file_entries = truncate_top_n(file_entries, top)
@@ -56,16 +51,12 @@ def output_summary(
         )
     elif total_functions == 0:
         console.print(
-            Align.center(
-                "No files were found with functions. No complexity was calculated."
-            )
+            "No files were found with functions. No complexity was calculated."
         )
     else:
         output_file_entries(
             console,
             file_entries,
-            failing_functions,
-            ignore_complexity,
             previous_functions,
             max_complexity,
             suggest_refactors,
@@ -75,7 +66,7 @@ def output_summary(
 
 def output_plain(
     console: Console,
-    file_entries: List[dc.FileEntry],
+    file_entries: List[FileEntry],
 ) -> None:
     for entry in file_entries:
         for function in entry.functions:
@@ -84,10 +75,10 @@ def output_plain(
 
 
 def truncate_top_n(
-    file_entries: List[dc.FileEntry],
+    file_entries: List[FileEntry],
     n: int,
-) -> List[dc.FileEntry]:
-    all_functions: List[Tuple[str, dc.FunctionRow]] = []
+) -> List[FileEntry]:
+    all_functions: List[Tuple[str, FunctionRow]] = []
     for entry in file_entries:
         for function in entry.functions:
             all_functions.append((entry.path, function))
@@ -95,56 +86,53 @@ def truncate_top_n(
     all_functions.sort(key=lambda x: x[1].complexity, reverse=True)
     top_functions = all_functions[:n]
 
-    # Preserve global descending order across files: emit a new entry whenever
-    # the path changes, rather than regrouping (which would collapse runs and
-    # lose the global rank order for multi-file results).
-    result: List[dc.FileEntry] = []
+    result: List[FileEntry] = []
     for path, function in top_functions:
         if result and result[-1].path == path:
             result[-1].functions.append(function)
         else:
-            result.append(dc.FileEntry(path=path, functions=[function]))
+            result.append(FileEntry(path=path, functions=[function]))
     return result
 
 
 def output_file_entries(
     console: Console,
-    file_entries: List[dc.FileEntry],
-    failing_functions: Dict[str, List[str]],
-    ignore_complexity: bool,
+    file_entries: List[FileEntry],
     previous_functions: Optional[Dict[Tuple[str, str, str], int]],
     max_complexity: int,
     suggest_refactors: bool = False,
 ) -> None:
-    for entry in file_entries:
+    for i, entry in enumerate(file_entries):
         console.print(f"[bold]{entry.path}[/bold]")
         for function in entry.functions:
             status_text = format_status_text(function.passed)
+            complexity_text = colorize_complexity(
+                function.complexity, max_complexity
+            )
             delta_text = output_delta_text(
                 previous_functions, function, max_complexity
             )
             console.print(
-                f"    {function.name} {function.complexity}{delta_text} {status_text}"
+                f"    {function.name} {complexity_text}{delta_text} {status_text}"
             )
             if suggest_refactors:
                 output_refactor_plans(console, function)
-        console.print()
+        if i < len(file_entries) - 1:
+            console.print()
 
-    if failing_functions:
-        console.print("[bold red]Failed functions:[/bold red]")
-        for path, functions in failing_functions.items():
-            console.print(f" - {path}: {', '.join(sorted(functions))}")
-        if ignore_complexity:
-            console.print(
-                "[yellow]--ignore-complexity enabled: failures will not affect the exit code.[/yellow]"
-            )
-    else:
+    if not file_entries:
+        return
+
+    all_pass = all(
+        fn.passed for entry in file_entries for fn in entry.functions
+    )
+    if all_pass:
         console.print(
             "[bold green]All functions are within the allowed complexity.[/bold green]"
         )
 
 
-def output_refactor_plans(console: Console, function: dc.FunctionRow) -> None:
+def output_refactor_plans(console: Console, function: FunctionRow) -> None:
     if not function.refactor_plans:
         return
 
@@ -172,7 +160,7 @@ def format_status_text(passed: bool) -> str:
 
 def output_delta_text(
     previous_functions: Optional[Dict[Tuple[str, str, str], int]],
-    function: dc.FunctionRow,
+    function: FunctionRow,
     max_complexity: int,
 ) -> str:
     if previous_functions is None:
@@ -212,14 +200,14 @@ def build_output_rows(
     sort: Sort,
     max_complexity: int,
     snapshot_map: Optional[Dict[Tuple[str, str, str], int]] = None,
-) -> Tuple[List[dc.FileEntry], Dict[str, List[str]], int]:
-    file_entries: List[dc.FileEntry] = []
-    failing_functions: Dict[str, List[str]] = {}
+) -> Tuple[List[FileEntry], int, bool]:
+    file_entries: List[FileEntry] = []
     total_functions = 0
+    all_pass = True
 
     for file in files:
         sorted_functions = sort_functions(file.functions, sort)
-        displayable_functions: List[dc.FunctionRow] = []
+        displayable_functions: List[FunctionRow] = []
 
         for function in sorted_functions:
             total_functions += 1
@@ -231,17 +219,14 @@ def build_output_rows(
                 snapshot_map,
             )
 
+            if not passed:
+                all_pass = False
+
             if failed_only and passed:
                 continue
 
-            if not passed:
-                full_path = normalize_path(file.path, file.file_name)
-                failing_functions.setdefault(full_path, []).append(
-                    function.name
-                )
-
             displayable_functions.append(
-                dc.FunctionRow(
+                FunctionRow(
                     name=function.name,
                     complexity=function.complexity,
                     passed=passed,
@@ -253,13 +238,13 @@ def build_output_rows(
 
         if displayable_functions:
             file_entries.append(
-                dc.FileEntry(
+                FileEntry(
                     path=normalize_path(file.path, file.file_name),
                     functions=displayable_functions,
                 )
             )
 
-    return file_entries, failing_functions, total_functions
+    return file_entries, total_functions, all_pass
 
 
 def sort_functions(
@@ -278,6 +263,12 @@ def normalize_path(path: str, file_name: str) -> str:
     if cleaned_path:
         return f"{cleaned_path}/{file_name}"
     return file_name
+
+
+def colorize_complexity(complexity: int, max_complexity: int) -> str:
+    if complexity <= max_complexity:
+        return f"[green]{complexity}[/green]"
+    return f"[red]{complexity}[/red]"
 
 
 def print_invalid_paths(
@@ -302,11 +293,20 @@ def print_invalid_paths(
 
 
 def has_success_functions(
-    files: List[FileComplexity], max_complexity: int
+    files: List[FileComplexity],
+    max_complexity: int,
+    snapshot_map: Optional[Dict[Tuple[str, str, str], int]] = None,
 ) -> bool:
     return all(
         all(
-            function.complexity <= max_complexity for function in file.functions
+            _is_function_passing(
+                function,
+                file.path,
+                file.file_name,
+                max_complexity,
+                snapshot_map,
+            )
+            for function in file.functions
         )
         for file in files
     )

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -127,6 +127,7 @@ def output_file_entries(
         fn.passed for entry in file_entries for fn in entry.functions
     )
     if all_pass:
+        console.print()
         console.print(
             "[bold green]All functions are within the allowed complexity.[/bold green]"
         )

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -214,32 +214,33 @@ Las claves TOML heredadas como `output-json = true` y las flags de CLI como
 
 ### Opciones de CLI
 
-| Opción                          | Descripción                                                                                                                                                                                          | Predeterminado |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `--exclude`                     | Excluye patrones glob relativos a cada ruta proporcionada. Usa patrones como `tests/**` para directorios o `src/legacy/file.py` para archivos específicos.                                           |                |
-| `--max-complexity-allowed`      | Umbral de complejidad                                                                                                                                                                                | `15`           |
-| `--snapshot-create`             | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                  | `false`        |
-| `--snapshot-ignore`             | Omite la comparación con un snapshot aunque exista                                                                                                                                                   | `false`        |
-| `--failed`                      | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                      | `false`        |
-| `--suggest-refactors`           | Muestra planes deterministas de refactorización basados en el AST de Rust en la salida CLI enriquecida. Ignorado por `--plain`                                                                       | `false`        |
-| `--color <auto\|yes\|no>`       | Usa color                                                                                                                                                                                            | `auto`         |
-| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                                | `asc`          |
-| `--quiet`                       | Suprime la salida                                                                                                                                                                                    | `false`        |
-| `--ignore-complexity`           | No termina con error al superar el umbral                                                                                                                                                            | `false`        |
-| `--version`                     | Muestra la versión instalada de complexipy y sale                                                                                                                                                    | -              |
-| `--top <n>`                     | Muestra solo las `n` funciones más complejas, ordenadas globalmente por complejidad descendente                                                                                                      | —              |
-| `--plain`                       | Emite líneas de texto plano como `<path> <function> <complexity>`. No se puede combinar con `--quiet`                                                                                                | `false`        |
-| `--output-format <format>`      | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                         | —              |
-| `--output <path>`               | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                   | —              |
-| `--diff <ref>`                  | Muestra un diff de complejidad contra una referencia de git (por ejemplo, `HEAD~1`, `main`)                                                                                                          | —              |
-| `--ratchet`, `-R`               | Junto con `--diff`, falla solo cuando un cambio lleva una función por encima de `--max-complexity-allowed` (o empeora una que ya estaba por encima). Ver [Modo Ratchet](usage-guide.md#modo-ratchet) | `false`        |
-| `--check-script`                | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                 | `false`        |
-| `--no-ignore`                   | Analiza cada función, ignorando los comentarios de ignore en línea (`# complexipy: ignore`, `# noqa: complexipy`)                                                                                    | `false`        |
-| `--report-ignored`              | Lista cada archivo:línea donde un comentario de ignore suprime una función. Se imprime incluso bajo `--quiet`                                                                                        | `false`        |
-| `--output-json`                 | Alias deprecado de `--output-format json`                                                                                                                                                            | `false`        |
-| `--output-csv`                  | Alias deprecado de `--output-format csv`                                                                                                                                                             | `false`        |
-| `--output-gitlab`               | Alias deprecado de `--output-format gitlab`                                                                                                                                                          | `false`        |
-| `--output-sarif`                | Alias deprecado de `--output-format sarif`                                                                                                                                                           | `false`        |
+| Opción                          | Descripción                                                                                                                                                                                         | Predeterminado |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `--exclude`                     | Excluye patrones glob relativos a cada ruta proporcionada. Usa patrones como `tests/**` para directorios o `src/legacy/file.py` para archivos específicos.                                          |                |
+| `--max-complexity-allowed`      | Umbral de complejidad                                                                                                                                                                               | `15`           |
+| `--snapshot-create`             | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json`                                                                                                                 | `false`        |
+| `--snapshot-ignore`             | Omite la comparación con un snapshot aunque exista                                                                                                                                                  | `false`        |
+| `--failed`                      | Muestra solo las funciones que superen el umbral de complejidad                                                                                                                                     | `false`        |
+| `--suggest-refactors`           | Muestra planes deterministas de refactorización basados en el AST de Rust en la salida CLI enriquecida. Ignorado por `--plain`                                                                      | `false`        |
+| `--color <auto\|yes\|no>`       | Usa color                                                                                                                                                                                           | `auto`         |
+| `--sort <asc\|desc\|file_name>` | Ordena los resultados                                                                                                                                                                               | `asc`          |
+| `--quiet`                       | Suprime la salida                                                                                                                                                                                   | `false`        |
+| `--ignore-complexity`           | No termina con error al superar el umbral                                                                                                                                                           | `false`        |
+| `--version`                     | Muestra la versión instalada de complexipy y sale                                                                                                                                                   | -              |
+| `--top <n>`                     | Muestra solo las `n` funciones más complejas, ordenadas globalmente por complejidad descendente                                                                                                     | —              |
+| `--plain`                       | Emite líneas de texto plano como `<path> <function> <complexity>`. No se puede combinar con `--quiet`                                                                                               | `false`        |
+| `--output-format <format>`      | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`)                                                                        | —              |
+| `--output <path>`               | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos                                                                                  | —              |
+| `--diff <ref>`                  | Muestra un diff de complejidad contra una referencia de git y aplica el umbral. Falla si hay regresiones por encima de `--max-complexity-allowed` (ver [Diff de Complejidad](#diff-de-complejidad)) | —              |
+| `--diff-only <ref>`             | Muestra un diff de complejidad visualmente sin afectar el código de salida (ver [Diff de Complejidad](#diff-de-complejidad))                                                                        | —              |
+| `--ratchet`, `-R`               | **Deprecado.** Usa `--diff` en su lugar, que ahora aplica por defecto                                                                                                                               | `false`        |
+| `--check-script`                | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>`                                                                                                                | `false`        |
+| `--no-ignore`                   | Analiza cada función, ignorando los comentarios de ignore en línea (`# complexipy: ignore`, `# noqa: complexipy`)                                                                                   | `false`        |
+| `--report-ignored`              | Lista cada archivo:línea donde un comentario de ignore suprime una función. Se imprime incluso bajo `--quiet`                                                                                       | `false`        |
+| `--output-json`                 | Alias deprecado de `--output-format json`                                                                                                                                                           | `false`        |
+| `--output-csv`                  | Alias deprecado de `--output-format csv`                                                                                                                                                            | `false`        |
+| `--output-gitlab`               | Alias deprecado de `--output-format gitlab`                                                                                                                                                         | `false`        |
+| `--output-sarif`                | Alias deprecado de `--output-format sarif`                                                                                                                                                          | `false`        |
 
 Ejemplo:
 
@@ -303,23 +304,33 @@ complexipy . --diff HEAD~1
 complexipy . --diff main
 ```
 
-El diff se añade después de la salida normal del análisis y no afecta el código de salida. Requiere que `git` esté disponible y que las rutas analizadas estén dentro de un repositorio git.
+Por defecto `--diff` **aplica** el umbral de complejidad: la ejecución termina con código `1` solo cuando un cambio rompe el contrato definido por `--max-complexity-allowed`:
+
+- Se introduce una función nueva por encima del umbral, o
+- una función existente aumenta su complejidad **y** queda por encima del umbral (también falla cuando una función ya sobre el umbral empeora).
+
+Las funciones que aumentan su complejidad pero se mantienen en o por debajo del umbral (por ejemplo `3 → 4` con `-mx 15`) no se marcan — el umbral sigue siendo el contrato principal, y `--diff` solo detecta las regresiones que realmente lo rompen.
+
+Para ver el diff visualmente sin afectar el código de salida, usa `--diff-only` en su lugar:
+
+```bash
+complexipy . --diff-only HEAD~1
+```
+
+Requiere que `git` esté disponible y que las rutas analizadas estén dentro de un repositorio git.
 
 #### Modo Ratchet
 
-Agrega `--ratchet` (`-R`) sobre `--diff` para convertirlo en un gate de regresiones para CI:
+!!! warning "Deprecado"
 
-```bash
-complexipy . --diff main --ratchet
-complexipy . --diff HEAD~1 -R -mx 15
-```
+    `--ratchet` (`-R`) está deprecado y será eliminado en una versión futura. `--diff` ahora aplica por defecto con el mismo comportamiento. Migra a `--diff` sin `--ratchet`:
 
-La ejecución termina con código `1` **solo** cuando:
-
-- se introduce una función nueva por encima de `--max-complexity-allowed`, o
-- una función existente aumenta su complejidad **y** queda por encima del umbral (también falla cuando una función ya sobre el umbral empeora).
-
-Pequeños aumentos que se mantienen en o por debajo del umbral (por ejemplo `3 → 4` con `-mx 15`) no se marcan — el umbral sigue siendo el contrato principal, y ratchet solo detecta las regresiones que realmente lo rompen. Esto lo hace ideal para códigos legados donde quieres bloquear regresiones sin tener que arreglar primero a todos los ofensores existentes. Ver la [sección de Modo Ratchet](usage-guide.md#modo-ratchet) para más detalle.
+    ```bash
+    # Antes
+    complexipy . --diff main --ratchet
+    # Después
+    complexipy . --diff main
+    ```
 
 ### Complejidad de Script
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -144,32 +144,33 @@ complexipy . --diff main
 complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
 ```
 
-El diff se añade después de la salida normal del análisis y no afecta el código
-de salida. Esto requiere `git` y una ruta dentro de un repositorio.
-
-### Modo Ratchet
-
-Combina `--diff` con `--ratchet` (`-R`) para convertir el diff en una verificación de regresión lista para CI:
-
-```bash
-complexipy . --diff main --ratchet
-complexipy . --diff HEAD~1 -R -mx 15
-```
-
-El modo ratchet sale con código `1` solo cuando un cambio rompe el contrato de complejidad definido por `--max-complexity-allowed`:
+Por defecto `--diff` **aplica** el umbral de complejidad: la ejecución termina con código `1` solo cuando un cambio rompe el contrato definido por `--max-complexity-allowed`:
 
 - Una función **nueva** introducida por encima del umbral.
 - Una función **modificada** cuya complejidad aumentó **y** queda por encima del umbral (incluye funciones ya sobre el umbral que empeoran).
 
-Las funciones que aumentan su complejidad pero se mantienen en o por debajo del umbral (por ejemplo `3 → 4` con `--max-complexity-allowed 15`) **no** son fallos. El umbral sigue siendo el contrato principal; ratchet solo evita que los cambios empeoren la situación una vez cruzado ese umbral.
+Las funciones que aumentan su complejidad pero se mantienen en o por debajo del umbral (por ejemplo `3 → 4` con `--max-complexity-allowed 15`) **no** son fallos.
 
-**Cuándo usarlo**
+Para ver el diff visualmente sin afectar el código de salida, usa `--diff-only` en su lugar:
 
-- Limpieza incremental de un código legado: no puedes arreglar hoy cada función sobre el umbral, pero no quieres que los PRs las empeoren. `--ratchet` bloquea únicamente las regresiones que importan.
-- Pipelines de CI donde `--max-complexity-allowed` por sí solo es demasiado estricto o ruidoso: ratchet mantiene CI en verde para PRs no relacionados y falla solo cuando el PR realmente cruza el límite.
-- Adopción gradual: puedes ir bajando `--max-complexity-allowed` con el tiempo mientras `--ratchet` garantiza progreso sin retrocesos.
+```bash
+complexipy . --diff-only HEAD~1
+```
 
-`--ratchet` requiere `--diff`; usarlo sin una referencia de diff termina con error.
+Esto requiere `git` y una ruta dentro de un repositorio.
+
+### Modo Ratchet
+
+!!! warning "Deprecado"
+
+    `--ratchet` (`-R`) está deprecado y será eliminado en una versión futura. `--diff` ahora aplica por defecto con el mismo comportamiento. Migra a `--diff` sin `--ratchet`:
+
+    ```bash
+    # Antes
+    complexipy . --diff main --ratchet
+    # Después
+    complexipy . --diff main
+    ```
 
 ### Salida en Texto Plano
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -213,32 +213,33 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 
 ### CLI Options
 
-| Flag                            | Description                                                                                                                                                                          | Default |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `--exclude`                     | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files.                                       |         |
-| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                                                 | `15`    |
-| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                                      | `false` |
-| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                                                | `false` |
-| `--failed`                      | Show only functions above the complexity threshold                                                                                                                                   | `false` |
-| `--suggest-refactors`           | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain`                                                                                            | `false` |
-| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                                            | `auto`  |
-| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                                         | `asc`   |
-| `--quiet`                       | Suppress output                                                                                                                                                                      | `false` |
-| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                                            | `false` |
-| `--version`                     | Show installed complexipy version and exit                                                                                                                                           | -       |
-| `--top <n>`                     | Show only the `n` most complex functions, globally sorted by complexity descending                                                                                                   | —       |
-| `--plain`                       | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                                         | `false` |
-| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                                     | —       |
-| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                                                 | —       |
-| `--diff <ref>`                  | Show a complexity diff against a git reference (e.g. `HEAD~1`, `main`)                                                                                                               | —       |
-| `--ratchet`, `-R`               | With `--diff`, fail only when a change pushes a function above `--max-complexity-allowed` (or makes an already-over function worse). See [Ratchet Mode](usage-guide.md#ratchet-mode) | `false` |
-| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                                              | `false` |
-| `--no-ignore`                   | Analyze every function, disregarding inline ignore comments (`# complexipy: ignore`, `# noqa: complexipy`)                                                                           | `false` |
-| `--report-ignored`              | List every file:line where an ignore comment suppresses a function. Prints even under `--quiet`                                                                                      | `false` |
-| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                                          | `false` |
-| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                                           | `false` |
-| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                                        | `false` |
-| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                                         | `false` |
+| Flag                            | Description                                                                                                                                                               | Default |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--exclude`                     | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files.                            |         |
+| `--max-complexity-allowed`      | Complexity threshold                                                                                                                                                      | `15`    |
+| `--snapshot-create`             | Save the current violations above the threshold into `complexipy-snapshot.json`                                                                                           | `false` |
+| `--snapshot-ignore`             | Skip comparing against the snapshot even if it exists                                                                                                                     | `false` |
+| `--failed`                      | Show only functions above the complexity threshold                                                                                                                        | `false` |
+| `--suggest-refactors`           | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain`                                                                                 | `false` |
+| `--color <auto\|yes\|no>`       | Use color                                                                                                                                                                 | `auto`  |
+| `--sort <asc\|desc\|file_name>` | Sort results                                                                                                                                                              | `asc`   |
+| `--quiet`                       | Suppress output                                                                                                                                                           | `false` |
+| `--ignore-complexity`           | Don't exit with error on threshold breach                                                                                                                                 | `false` |
+| `--version`                     | Show installed complexipy version and exit                                                                                                                                | -       |
+| `--top <n>`                     | Show only the `n` most complex functions, globally sorted by complexity descending                                                                                        | —       |
+| `--plain`                       | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet`                                                                              | `false` |
+| `--output-format <format>`      | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`)                                                          | —       |
+| `--output <path>`               | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats                                                                      | —       |
+| `--diff <ref>`                  | Show a complexity diff against a git reference and enforce the threshold. Fails on regressions above `--max-complexity-allowed` (see [Complexity Diff](#complexity-diff)) | —       |
+| `--diff-only <ref>`             | Show a complexity diff visually without affecting the exit code (see [Complexity Diff](#complexity-diff))                                                                 | —       |
+| `--ratchet`, `-R`               | **Deprecated.** Use `--diff` instead, which now enforces by default                                                                                                       | `false` |
+| `--check-script`                | Report module-level (script) complexity as a synthetic `<module>` entry                                                                                                   | `false` |
+| `--no-ignore`                   | Analyze every function, disregarding inline ignore comments (`# complexipy: ignore`, `# noqa: complexipy`)                                                                | `false` |
+| `--report-ignored`              | List every file:line where an ignore comment suppresses a function. Prints even under `--quiet`                                                                           | `false` |
+| `--output-json`                 | Deprecated alias for `--output-format json`                                                                                                                               | `false` |
+| `--output-csv`                  | Deprecated alias for `--output-format csv`                                                                                                                                | `false` |
+| `--output-gitlab`               | Deprecated alias for `--output-format gitlab`                                                                                                                             | `false` |
+| `--output-sarif`                | Deprecated alias for `--output-format sarif`                                                                                                                              | `false` |
 
 Example:
 
@@ -302,23 +303,33 @@ complexipy . --diff HEAD~1
 complexipy . --diff main
 ```
 
-The diff is appended after the normal analysis output and does not affect the exit code. Requires `git` to be available and the analysed paths to be inside a git repository.
+By default `--diff` **enforces** the complexity threshold: the run exits with code `1` only when a change breaches the contract relative to `--max-complexity-allowed`:
+
+- A new function is introduced above the threshold, or
+- an existing function's complexity increases **and** ends above the threshold (already-over functions getting worse also fail).
+
+Functions that regress but stay at or below the threshold (e.g. `3 → 4` with `-mx 15`) are **not** flagged — the threshold is still the main contract, and `--diff` only catches regressions that actually break it.
+
+To see the diff visually without affecting the exit code, use `--diff-only` instead:
+
+```bash
+complexipy . --diff-only HEAD~1
+```
+
+Requires `git` to be available and the analysed paths to be inside a git repository.
 
 #### Ratchet Mode
 
-Add `--ratchet` (`-R`) on top of `--diff` to turn it into a regression-only gate for CI:
+!!! warning "Deprecated"
 
-```bash
-complexipy . --diff main --ratchet
-complexipy . --diff HEAD~1 -R -mx 15
-```
+    `--ratchet` (`-R`) is deprecated and will be removed in a future version. `--diff` now enforces by default with the same behavior. Migrate to `--diff` without `--ratchet`:
 
-The run exits with code `1` **only** when:
-
-- a new function is introduced above `--max-complexity-allowed`, or
-- an existing function's complexity increases **and** ends above the threshold (already-over functions getting worse also fail).
-
-Small upward changes that stay at or below the threshold (e.g. `3 → 4` with `-mx 15`) are not flagged — the threshold is still the main contract, and ratchet only catches regressions that actually break it. This makes it ideal for legacy codebases where you want to block regressions without fixing every existing offender first. See the [Ratchet Mode section](usage-guide.md#ratchet-mode) for more detail.
+    ```bash
+    # Before
+    complexipy . --diff main --ratchet
+    # After
+    complexipy . --diff main
+    ```
 
 ### Script Complexity
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -149,31 +149,33 @@ complexipy . --diff main
 complexipy src/ --max-complexity-allowed 10 --diff HEAD~1
 ```
 
-The diff is appended after the regular analysis output and does not affect the exit code. This requires `git` and a repository-backed path.
-
-### Ratchet Mode
-
-Pair `--diff` with `--ratchet` (`-R`) to turn the diff into a CI-friendly regression check:
-
-```bash
-complexipy . --diff main --ratchet
-complexipy . --diff HEAD~1 -R -mx 15
-```
-
-Ratchet mode exits with code `1` only when a change breaches the complexity contract relative to `--max-complexity-allowed`:
+By default `--diff` **enforces** the complexity threshold: the run exits with code `1` only when a change breaches the contract relative to `--max-complexity-allowed`:
 
 - A **new** function introduced above the threshold.
 - A **modified** function whose complexity increased **and** ends above the threshold (including already-over functions that get worse).
 
-Functions that regress but stay at or below the threshold (e.g. `3 → 4` with `--max-complexity-allowed 15`) are **not** failures. The threshold remains the main contract; ratchet just prevents changes from making things worse once the threshold is crossed.
+Functions that regress but stay at or below the threshold (e.g. `3 → 4` with `--max-complexity-allowed 15`) are **not** failures.
 
-**When to use it**
+To see the diff visually without affecting the exit code, use `--diff-only` instead:
 
-- Incremental cleanup of a legacy codebase: you can't fix every over-threshold function today, but you don't want PRs making them worse. `--ratchet` blocks only the regressions that matter.
-- CI pipelines where `--max-complexity-allowed` alone is too strict or too noisy: ratchet keeps CI green for unrelated PRs and fires only when a PR actually pushes complexity past the limit.
-- Gradual adoption: lower `--max-complexity-allowed` over time while `--ratchet` guarantees forward-only progress.
+```bash
+complexipy . --diff-only HEAD~1
+```
 
-`--ratchet` requires `--diff`; running it without a diff reference exits with an error.
+This requires `git` and a repository-backed path.
+
+### Ratchet Mode
+
+!!! warning "Deprecated"
+
+    `--ratchet` (`-R`) is deprecated and will be removed in a future version. `--diff` now enforces by default with the same behavior. Migrate to `--diff` without `--ratchet`:
+
+    ```bash
+    # Before
+    complexipy . --diff main --ratchet
+    # After
+    complexipy . --diff main
+    ```
 
 ### Plain Output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ output-format = []
 cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "**/*.rs"}]
 
 [tool.ruff]
-exclude = ["tests"]
 line-length = 80
 indent-width = 4
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ cache-keys = [{file = "pyproject.toml"}, {file = "Cargo.toml"}, {file = "**/*.rs
 line-length = 80
 indent-width = 4
 
+[tool.ruff.lint]
+exclude = ["tests/**"]
+
 [tool.yamlfix]
 explicit_start = true
 line_length = 120

--- a/tests/main.py
+++ b/tests/main.py
@@ -289,7 +289,9 @@ def hello_world(s: str) -> str:
         files_explicit, _ = _complexipy.main(
             [path.resolve().as_posix()], False, [], False, False
         )
-        assert sum(f.complexity for f in files_default) == sum(f.complexity for f in files_explicit)
+        assert sum(f.complexity for f in files_default) == sum(
+            f.complexity for f in files_explicit
+        )
 
     def test_no_ignore_code_complexity_api(self):
         """Python API: code_complexity() with no_ignore analyzes ignored functions."""
@@ -339,7 +341,9 @@ def hello_world(s: str) -> str:
             encoding="utf-8",
         )
 
-        result = runner.invoke(main_module.app, ["--report-ignored", str(source_file)])
+        result = runner.invoke(
+            main_module.app, ["--report-ignored", str(source_file)]
+        )
         assert result.exit_code == 0
         assert "sample.py:1" in result.output
         assert "# complexipy: ignore" in result.output
@@ -355,7 +359,9 @@ def hello_world(s: str) -> str:
         source_file = tmp_path / "clean.py"
         source_file.write_text("def foo():\n    return 1\n", encoding="utf-8")
 
-        result = runner.invoke(main_module.app, ["--report-ignored", str(source_file)])
+        result = runner.invoke(
+            main_module.app, ["--report-ignored", str(source_file)]
+        )
         assert result.exit_code == 0
         assert "No ignore comments found" in result.output
 
@@ -376,7 +382,8 @@ def hello_world(s: str) -> str:
         )
 
         result = runner.invoke(
-            main_module.app, ["--report-ignored", "--no-ignore", str(source_file)]
+            main_module.app,
+            ["--report-ignored", "--no-ignore", str(source_file)],
         )
         assert result.exit_code == 0
         assert "sample.py:1" in result.output
@@ -886,7 +893,9 @@ class TestPaperConformance:
         assert self._c(code) == 3
 
     def test_with_does_not_nest(self):
-        code = "def f(x, y):\n    with open(x):\n        if y:\n            pass\n"
+        code = (
+            "def f(x, y):\n    with open(x):\n        if y:\n            pass\n"
+        )
         assert self._c(code) == 1
 
     def test_direct_recursion_increments(self):
@@ -911,7 +920,8 @@ class TestPaperConformance:
     def test_comprehension_loop_and_filter(self):
         assert self._c("def f(xs):\n    return [x for x in xs if x > 0]\n") == 2
         assert (
-            self._c("def f(xs):\n    return [y for x in xs for y in x if y]\n") == 3
+            self._c("def f(xs):\n    return [y for x in xs for y in x if y]\n")
+            == 3
         )
         assert self._c("def f(xs):\n    return any(x and x for x in xs)\n") == 2
 

--- a/tests/src/test_utf8_comment.py
+++ b/tests/src/test_utf8_comment.py
@@ -25,7 +25,9 @@ def accent_before(b):  # noqa: complexipy café multi-byte accent after marker
         return 0
 
 
-def mixed_comment_marker(a, b, c):  # complexipy: ignore — 🚀 mixed em-dash & emoji
+def mixed_comment_marker(
+    a, b, c
+):  # complexipy: ignore — 🚀 mixed em-dash & emoji
     if a and b:
         return a + b
     elif b and c:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -50,7 +50,9 @@ class TestCache:
         readme = cache_dir / "README.md"
         assert readme.exists()
         assert readme.is_file()
-        assert "complexipy cache directory" in readme.read_text(encoding="utf-8")
+        assert "complexipy cache directory" in readme.read_text(
+            encoding="utf-8"
+        )
 
         cache_file = cache_dir / "v" / "cache" / FUNCTIONS_CACHE_KEY
         assert cache_file.exists()
@@ -85,12 +87,16 @@ class TestCache:
         content = gitignore_file.read_text(encoding="utf-8")
         assert content == custom_content
 
-    def test_cache_reuses_single_functions_file_for_target_sets(self, tmp_path: Path):
+    def test_cache_reuses_single_functions_file_for_target_sets(
+        self, tmp_path: Path
+    ):
         """Test that target-set caches are entries in one value file."""
         first_file = tmp_path / "first.py"
         first_file.write_text("def first():\n    return 1\n", encoding="utf-8")
         second_file = tmp_path / "second.py"
-        second_file.write_text("def second():\n    return 2\n", encoding="utf-8")
+        second_file.write_text(
+            "def second():\n    return 2\n", encoding="utf-8"
+        )
 
         first_files, _ = _complexipy.main([str(first_file)], False, [])
         second_files, _ = _complexipy.main([str(second_file)], False, [])
@@ -119,7 +125,9 @@ class TestCache:
 
         cache_dir = tmp_path / CACHE_DIR_NAME
         value_files = [path for path in cache_dir.rglob("*") if path.is_file()]
-        cache_values = [path for path in value_files if path.name == FUNCTIONS_CACHE_KEY]
+        cache_values = [
+            path for path in value_files if path.name == FUNCTIONS_CACHE_KEY
+        ]
         legacy_json_files = list(cache_dir.glob("*.json"))
 
         assert len(cache_values) == 1
@@ -137,7 +145,9 @@ class TestCache:
             files_complexities=files,
         )
 
-        cache_file = tmp_path / CACHE_DIR_NAME / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        cache_file = (
+            tmp_path / CACHE_DIR_NAME / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        )
         cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
         [cache_key] = cache_payload["entries"].keys()
         cache_file.unlink()
@@ -178,7 +188,9 @@ class TestCache:
                 files_complexities=complexities,
             )
 
-        cache_file = tmp_path / CACHE_DIR_NAME / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        cache_file = (
+            tmp_path / CACHE_DIR_NAME / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        )
         cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
 
         assert len(cache_payload["entries"]) == MAX_CACHE_ENTRIES

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -12,6 +12,7 @@ from complexipy.utils.diff import (
     _STATUS_REMOVED,
     _STATUS_UNCHANGED,
     DiffEntry,
+    _resolve_git_path,
     compute_diff,
     format_diff,
     has_regressions,
@@ -333,3 +334,99 @@ class TestHasRegressions:
             DiffEntry("f.py", "same", 3, 3),  # UNCHANGED
         ]
         assert has_regressions(entries, max_complexity=15) is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_git_path tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveGitPath:
+    """Tests for the git path resolution helper.
+
+    The Rust runner computes ``file.path`` relative to the *parent* of the
+    target directory.  When the invocation path equals the git root (e.g.
+    ``complexipy .``), this produces paths with an extra leading component.
+    ``_resolve_git_path`` strips components until ``git show`` finds the file.
+    """
+
+    # Paths that exist at the mocked git ref.
+    _KNOWN = {"complexipy/main.py", "complexipy/utils/output.py", "src/app.py"}
+
+    def _mock_content(self, git_ref, path, cwd):
+        return "content" if path in self._KNOWN else None
+
+    def test_path_exists_as_is(self):
+        """Path found directly — no stripping needed."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            side_effect=self._mock_content,
+        ):
+            result = _resolve_git_path(
+                "complexipy/main.py", "main", "/repo"
+            )
+        assert result == "complexipy/main.py"
+
+    def test_extra_prefix_stripped(self):
+        """Runner produced a double-nested path — strip the extra prefix."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            side_effect=self._mock_content,
+        ):
+            result = _resolve_git_path(
+                "complexipy/complexipy/main.py", "main", "/repo"
+            )
+        assert result == "complexipy/main.py"
+
+    def test_extra_prefix_stripped_nested_path(self):
+        """Extra prefix with a nested subdirectory path."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            side_effect=self._mock_content,
+        ):
+            result = _resolve_git_path(
+                "complexipy/complexipy/utils/output.py", "main", "/repo"
+            )
+        assert result == "complexipy/utils/output.py"
+
+    def test_no_match_returns_original(self):
+        """File doesn't exist at the ref — return original path."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=None,
+        ):
+            result = _resolve_git_path(
+                "nonexistent/file.py", "main", "/repo"
+            )
+        assert result == "nonexistent/file.py"
+
+    def test_single_segment_path(self):
+        """Path with no slashes — nothing to strip."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            side_effect=self._mock_content,
+        ):
+            result = _resolve_git_path("app.py", "main", "/repo")
+        assert result == "app.py"
+
+    def test_backslash_normalization(self):
+        """Windows-style backslashes are converted to forward slashes."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            side_effect=self._mock_content,
+        ):
+            result = _resolve_git_path(
+                "complexipy\\complexipy\\main.py", "main", "/repo"
+            )
+        assert result == "complexipy/main.py"
+
+    def test_triple_nested_prefix(self):
+        """Three extra components — strip until a match is found."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            side_effect=self._mock_content,
+        ):
+            result = _resolve_git_path(
+                "a/b/complexipy/main.py", "main", "/repo"
+            )
+        assert result == "complexipy/main.py"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -5,6 +5,7 @@ import tempfile
 from unittest.mock import patch
 
 from complexipy._complexipy import main as _main
+from complexipy.main import resolve_final_success
 from complexipy.utils.diff import (
     _STATUS_IMPROVED,
     _STATUS_NEW,
@@ -17,10 +18,6 @@ from complexipy.utils.diff import (
     format_diff,
     has_regressions,
 )
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 _SIMPLE = """\
 def simple(x):
@@ -63,11 +60,6 @@ def _make_file_complexity(code: str, path: str = "src/example.py"):
     return files[0]
 
 
-# ---------------------------------------------------------------------------
-# DiffEntry tests
-# ---------------------------------------------------------------------------
-
-
 class TestDiffEntry:
     def test_status_new(self):
         e = DiffEntry("f.py", "foo", None, 5)
@@ -100,11 +92,6 @@ class TestDiffEntry:
     def test_delta_none_for_removed(self):
         e = DiffEntry("f.py", "foo", 5, None)
         assert e.delta is None
-
-
-# ---------------------------------------------------------------------------
-# compute_diff tests (git operations mocked)
-# ---------------------------------------------------------------------------
 
 
 class TestComputeDiff:
@@ -205,11 +192,6 @@ class TestComputeDiff:
         assert isinstance(entries, list)
 
 
-# ---------------------------------------------------------------------------
-# format_diff tests
-# ---------------------------------------------------------------------------
-
-
 class TestFormatDiff:
     def test_empty_entries_no_changes(self):
         entries = [DiffEntry("f.py", "foo", 3, 3)]  # UNCHANGED
@@ -263,11 +245,6 @@ class TestFormatDiff:
     def test_no_changes_message(self):
         output = format_diff([], "HEAD~1")
         assert "No functions changed" in output
-
-
-# ---------------------------------------------------------------------------
-# has_regressions tests
-# ---------------------------------------------------------------------------
 
 
 class TestHasRegressions:
@@ -336,11 +313,6 @@ class TestHasRegressions:
         assert has_regressions(entries, max_complexity=15) is False
 
 
-# ---------------------------------------------------------------------------
-# _resolve_git_path tests
-# ---------------------------------------------------------------------------
-
-
 class TestResolveGitPath:
     """Tests for the git path resolution helper.
 
@@ -362,9 +334,7 @@ class TestResolveGitPath:
             "complexipy.utils.diff._file_content_at_ref",
             side_effect=self._mock_content,
         ):
-            result = _resolve_git_path(
-                "complexipy/main.py", "main", "/repo"
-            )
+            result = _resolve_git_path("complexipy/main.py", "main", "/repo")
         assert result == "complexipy/main.py"
 
     def test_extra_prefix_stripped(self):
@@ -395,9 +365,7 @@ class TestResolveGitPath:
             "complexipy.utils.diff._file_content_at_ref",
             return_value=None,
         ):
-            result = _resolve_git_path(
-                "nonexistent/file.py", "main", "/repo"
-            )
+            result = _resolve_git_path("nonexistent/file.py", "main", "/repo")
         assert result == "nonexistent/file.py"
 
     def test_single_segment_path(self):
@@ -430,3 +398,75 @@ class TestResolveGitPath:
                 "a/b/complexipy/main.py", "main", "/repo"
             )
         assert result == "complexipy/main.py"
+
+
+class TestResolveFinalSuccess:
+    """Tests for the final exit-code decision logic.
+
+    When ``enforce`` is True (--diff), regressions above the threshold
+    cause failure.  When ``enforce`` is False (--diff-only), diff entries
+    are ignored and the normal has_success check applies.
+    """
+
+    def test_enforce_true_regression_above_threshold_fails(self):
+        entries = [DiffEntry("f.py", "foo", 5, 20)]
+        assert (
+            resolve_final_success(True, True, True, True, entries, 15) is False
+        )
+
+    def test_enforce_true_regression_within_threshold_passes(self):
+        entries = [DiffEntry("f.py", "foo", 5, 12)]
+        assert (
+            resolve_final_success(True, True, True, True, entries, 15) is True
+        )
+
+    def test_enforce_true_new_above_threshold_fails(self):
+        entries = [DiffEntry("f.py", "foo", None, 20)]
+        assert (
+            resolve_final_success(True, True, True, True, entries, 15) is False
+        )
+
+    def test_enforce_true_new_within_threshold_passes(self):
+        entries = [DiffEntry("f.py", "foo", None, 10)]
+        assert (
+            resolve_final_success(True, True, True, True, entries, 15) is True
+        )
+
+    def test_enforce_true_no_regressions_passes(self):
+        entries = [DiffEntry("f.py", "foo", 5, 8)]
+        assert (
+            resolve_final_success(True, True, True, True, entries, 15) is True
+        )
+
+    def test_enforce_false_ignores_diff_entries(self):
+        """--diff-only: regression exists but enforce=False, so it passes."""
+        entries = [DiffEntry("f.py", "foo", 5, 20)]
+        assert (
+            resolve_final_success(True, True, True, False, entries, 15) is True
+        )
+
+    def test_enforce_false_uses_has_success(self):
+        """--diff-only: falls back to has_success (threshold check)."""
+        assert (
+            resolve_final_success(False, True, True, False, None, 15) is False
+        )
+
+    def test_enforce_true_invalid_paths_fails(self):
+        entries = [DiffEntry("f.py", "foo", 5, 8)]
+        assert (
+            resolve_final_success(True, False, True, True, entries, 15) is False
+        )
+
+    def test_enforce_true_snapshot_failure_fails(self):
+        entries = [DiffEntry("f.py", "foo", 5, 8)]
+        assert (
+            resolve_final_success(True, True, False, True, entries, 15) is False
+        )
+
+    def test_enforce_true_no_entries_passes(self):
+        """No diff entries (empty diff) — enforce has nothing to check."""
+        assert resolve_final_success(True, True, True, True, [], 15) is True
+
+    def test_enforce_true_none_entries_passes(self):
+        """diff_entries is None when --diff was not used."""
+        assert resolve_final_success(True, True, True, True, None, 15) is True

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -193,36 +193,47 @@ class TestComputeDiff:
 
 
 class TestFormatDiff:
+    @staticmethod
+    def _render(entries, git_ref="HEAD~1"):
+        """Render diff to a string via a capturing Console."""
+        import io
+
+        from rich.console import Console
+
+        buf = io.StringIO()
+        console = Console(file=buf, color_system=None, highlight=False)
+        format_diff(console, entries, git_ref)
+        return buf.getvalue()
+
     def test_empty_entries_no_changes(self):
         entries = [DiffEntry("f.py", "foo", 3, 3)]  # UNCHANGED
-        output = format_diff(entries, "HEAD~1")
-        assert "No functions changed" not in output  # UNCHANGED is filtered but
-        # header is still shown since entries list is non-empty
-        # Actually UNCHANGED entries are filtered from display:
+        output = self._render(entries)
+        # All entries are UNCHANGED — filtered out, shows no-changes message
+        assert "No functions changed" in output
         assert "foo" not in output
 
     def test_regressed_entry_shown(self):
         entries = [DiffEntry("f.py", "handle", 10, 18)]
-        output = format_diff(entries, "HEAD~1")
+        output = self._render(entries)
         assert "REGRESSED" in output
         assert "handle" in output
         assert "10 → 18" in output
 
     def test_improved_entry_shown(self):
         entries = [DiffEntry("f.py", "helper", 20, 8)]
-        output = format_diff(entries, "HEAD~1")
+        output = self._render(entries)
         assert "IMPROVED" in output
         assert "20 → 8" in output
 
     def test_new_entry_shown(self):
         entries = [DiffEntry("f.py", "newcomer", None, 5)]
-        output = format_diff(entries, "HEAD~1")
+        output = self._render(entries)
         assert "NEW" in output
         assert "newcomer" in output
 
     def test_removed_entry_shown(self):
         entries = [DiffEntry("f.py", "gone", 7, None)]
-        output = format_diff(entries, "HEAD~1")
+        output = self._render(entries)
         assert "REMOVED" in output
         assert "gone" in output
 
@@ -232,18 +243,18 @@ class TestFormatDiff:
             DiffEntry("f.py", "b", 10, 5),  # IMPROVED
             DiffEntry("f.py", "c", None, 3),  # NEW
         ]
-        output = format_diff(entries, "HEAD~1")
+        output = self._render(entries)
         assert "1 regressed" in output
         assert "1 improved" in output
         assert "1 new" in output
 
     def test_ref_name_in_header(self):
         entries = [DiffEntry("f.py", "fn", 3, 7)]
-        output = format_diff(entries, "abc1234")
+        output = self._render(entries, "abc1234")
         assert "abc1234" in output
 
     def test_no_changes_message(self):
-        output = format_diff([], "HEAD~1")
+        output = self._render([], "HEAD~1")
         assert "No functions changed" in output
 
 

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -69,7 +69,9 @@ class TestGitlabOutput:
         assert entry["fingerprint"]
         assert "complex_func" in entry["description"]
 
-    def test_gitlab_report_is_empty_when_threshold_is_high(self, tmp_path: Path):
+    def test_gitlab_report_is_empty_when_threshold_is_high(
+        self, tmp_path: Path
+    ):
         source_file = tmp_path / "sample.py"
         source_file.write_text(_SNIPPET, encoding="utf-8")
         output_file = tmp_path / "results.gitlab.json"
@@ -83,7 +85,9 @@ class TestGitlabOutput:
         report = json.loads(output_file.read_text(encoding="utf-8"))
         assert report == []
 
-    def test_cli_output_gitlab_creates_expected_file(self, tmp_path: Path, monkeypatch):
+    def test_cli_output_gitlab_creates_expected_file(
+        self, tmp_path: Path, monkeypatch
+    ):
         import complexipy.main as main_module
 
         runner = CliRunner()
@@ -93,7 +97,12 @@ class TestGitlabOutput:
 
         result = runner.invoke(
             main_module.app,
-            ["--output-gitlab", "--max-complexity-allowed", "5", str(source_file)],
+            [
+                "--output-gitlab",
+                "--max-complexity-allowed",
+                "5",
+                str(source_file),
+            ],
         )
 
         assert result.exit_code == 1, result.output

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -42,7 +42,9 @@ class TestJsonOutput:
         assert data[0]["function_name"] == "simple"
         assert data[0]["refactor_plans"] == []
 
-    def test_cli_json_output_has_final_newline(self, tmp_path: Path, monkeypatch):
+    def test_cli_json_output_has_final_newline(
+        self, tmp_path: Path, monkeypatch
+    ):
         import complexipy.main as main_module
 
         runner = CliRunner()

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 from typer.testing import CliRunner
 
@@ -208,8 +209,6 @@ class TestTopOutput:
         runner = CliRunner()
         file_a = tmp_path / "a.py"
         file_b = tmp_path / "b.py"
-        # a.py has the most complex and the least complex function;
-        # b.py has a middle-complexity function. Global order must interleave.
         file_a.write_text(
             """\
 def a_high(x):
@@ -249,8 +248,6 @@ def b_mid(x):
         assert len(lines) == 3
         complexities = [int(line.split()[-1]) for line in lines]
         assert complexities == sorted(complexities, reverse=True)
-        # Ensure the middle entry is from b.py — proves the output is not
-        # regrouped by file (which would cluster both a.py rows together).
         names = [line.split()[1] for line in lines]
         assert names[0] == "a_high"
         assert names[1] == "b_mid"
@@ -286,7 +283,9 @@ class TestSuggestRefactorsOutput:
 
         assert result.exit_code == 0, result.output
         assert "Refactor plans:" in result.output
-        assert "Flatten nested condition block with guard clauses" in result.output
+        assert (
+            "Flatten nested condition block with guard clauses" in result.output
+        )
         assert "estimated: 7 -> 5 (-2)" in result.output
         assert "invert the outer condition" in result.output
 
@@ -298,8 +297,7 @@ class TestSuggestRefactorsOutput:
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(
-            _REFACTOR_SNIPPET
-            + "\n\ndef simple(value):\n    return value\n",
+            _REFACTOR_SNIPPET + "\n\ndef simple(value):\n    return value\n",
             encoding="utf-8",
         )
 
@@ -428,6 +426,238 @@ class TestPlainOutput:
             "sample.py", ""
         )
         assert "Analysis completed" not in result.output
+
+
+class TestDiffCli:
+    """Tests for --diff (enforcing), --diff-only (visual), and --ratchet deprecation."""
+
+    _SIMPLE = "def simple(x):\n    return x + 1\n"
+    _COMPLEX = (
+        "def simple(x):\n"
+        "    if x:\n"
+        "        for i in range(x):\n"
+        "            if i > 0:\n"
+        "                if i % 2:\n"
+        "                    return i\n"
+        "    return 0\n"
+    )
+
+    def test_diff_enforces_on_regression_above_threshold(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(self._COMPLEX, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=self._SIMPLE,
+        ), patch(
+            "complexipy.utils.diff._git_root",
+            return_value=str(tmp_path),
+        ):
+            result = runner.invoke(
+                main_module.app,
+                ["--diff", "main", "-mx", "5", str(source_file)],
+            )
+
+        assert result.exit_code == 1
+        assert "REGRESSED" in result.output
+
+    def test_diff_passes_when_within_threshold(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(self._COMPLEX, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=self._SIMPLE,
+        ), patch(
+            "complexipy.utils.diff._git_root",
+            return_value=str(tmp_path),
+        ):
+            result = runner.invoke(
+                main_module.app,
+                ["--diff", "main", "-mx", "50", str(source_file)],
+            )
+
+        assert result.exit_code == 0
+
+    def test_diff_shows_diff_output(self, tmp_path: Path, monkeypatch):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(self._COMPLEX, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=self._SIMPLE,
+        ), patch(
+            "complexipy.utils.diff._git_root",
+            return_value=str(tmp_path),
+        ):
+            result = runner.invoke(
+                main_module.app,
+                ["--diff", "main", "-mx", "50", str(source_file)],
+            )
+
+        assert "Complexity diff" in result.output
+        assert "main" in result.output
+
+    def test_diff_only_does_not_enforce(self, tmp_path: Path, monkeypatch):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(self._COMPLEX, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=self._SIMPLE,
+        ), patch(
+            "complexipy.utils.diff._git_root",
+            return_value=str(tmp_path),
+        ):
+            # --diff-only: regression exists but threshold is high enough
+            # for normal check to pass.  Exit code should be 0.
+            result = runner.invoke(
+                main_module.app,
+                [
+                    "--diff-only",
+                    "main",
+                    "-mx",
+                    "50",
+                    str(source_file),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "Complexity diff" in result.output
+
+    def test_diff_only_visual_no_enforcement_even_with_regression(
+        self, tmp_path: Path, monkeypatch
+    ):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(self._COMPLEX, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=self._SIMPLE,
+        ), patch(
+            "complexipy.utils.diff._git_root",
+            return_value=str(tmp_path),
+        ):
+            # --diff-only with low threshold: regression above threshold,
+            # but --diff-only should NOT enforce.  Exit code comes from
+            # normal threshold check (which WILL fail at mx=5).
+            result = runner.invoke(
+                main_module.app,
+                [
+                    "--diff-only",
+                    "main",
+                    "-mx",
+                    "5",
+                    str(source_file),
+                ],
+            )
+
+        # Exit 1 from threshold check, NOT from diff enforcement.
+        # Verify diff is shown.
+        assert "Complexity diff" in result.output
+        assert "REGRESSED" in result.output
+
+    def test_ratchet_deprecation_warning(self, tmp_path: Path, monkeypatch):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(self._SIMPLE, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=self._SIMPLE,
+        ), patch(
+            "complexipy.utils.diff._git_root",
+            return_value=str(tmp_path),
+        ):
+            result = runner.invoke(
+                main_module.app,
+                [
+                    "--ratchet",
+                    "--diff",
+                    "main",
+                    "-mx",
+                    "15",
+                    str(source_file),
+                ],
+            )
+
+        assert "Deprecated" in result.output
+        assert "--ratchet" in result.output
+
+    def test_ratchet_without_diff_errors(self, tmp_path: Path):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(self._SIMPLE, encoding="utf-8")
+
+        result = runner.invoke(
+            main_module.app,
+            ["--ratchet", str(source_file)],
+        )
+
+        assert result.exit_code == 2
+        assert "requires" in result.output.lower() or "--diff" in result.output
+
+    def test_diff_and_diff_only_conflict(self, tmp_path: Path, monkeypatch):
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(self._COMPLEX, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=self._SIMPLE,
+        ), patch(
+            "complexipy.utils.diff._git_root",
+            return_value=str(tmp_path),
+        ):
+            # Both --diff and --diff-only: warning printed, --diff-only wins
+            # (no enforcement).  With high threshold, exit 0.
+            result = runner.invoke(
+                main_module.app,
+                [
+                    "--diff",
+                    "main",
+                    "--diff-only",
+                    "main",
+                    "-mx",
+                    "50",
+                    str(source_file),
+                ],
+            )
+
+        assert "Warning" in result.output
+        assert result.exit_code == 0
 
 
 class TestOutputToml:

--- a/tests/test_refactor_plans.py
+++ b/tests/test_refactor_plans.py
@@ -27,7 +27,9 @@ def sample(a, b, c, d):
     )
 
     assert func.complexity == 7
-    plan = next(plan for plan in func.refactor_plans if plan.kind == "flatten_condition")
+    plan = next(
+        plan for plan in func.refactor_plans if plan.kind == "flatten_condition"
+    )
     assert plan.title == "Flatten nested condition block with guard clauses"
     assert plan.line_start == 5
     assert plan.line_end == 6
@@ -82,7 +84,9 @@ def sample(kind):
 """
     )
 
-    plan = next(plan for plan in func.refactor_plans if plan.kind == "split_dispatcher")
+    plan = next(
+        plan for plan in func.refactor_plans if plan.kind == "split_dispatcher"
+    )
     assert plan.line_start == 3
     assert plan.line_end == 10
 
@@ -117,7 +121,9 @@ def sample(a, b, c, d):
 """
     )
 
-    plan = next(plan for plan in func.refactor_plans if plan.kind == "extract_predicate")
+    plan = next(
+        plan for plan in func.refactor_plans if plan.kind == "extract_predicate"
+    )
     assert plan.line_start == 3
     assert plan.line_end == 3
 
@@ -149,7 +155,9 @@ def sample(a, b, c, d):
     assert func.refactor_plans[0].estimated_complexity_after <= func.complexity
 
 
-def test_manual_cli_json_includes_refactor_plans_and_snapshot_stays_unchanged(tmp_path) -> None:
+def test_manual_cli_json_includes_refactor_plans_and_snapshot_stays_unchanged(
+    tmp_path,
+) -> None:
     source = tmp_path / "sample.py"
     source.write_text(
         """
@@ -178,9 +186,15 @@ def sample(a, b, c, d):
                     "title": func.refactor_plans[0].title,
                     "line_start": func.refactor_plans[0].line_start,
                     "line_end": func.refactor_plans[0].line_end,
-                    "current_complexity": func.refactor_plans[0].current_complexity,
-                    "estimated_reduction": func.refactor_plans[0].estimated_reduction,
-                    "estimated_complexity_after": func.refactor_plans[0].estimated_complexity_after,
+                    "current_complexity": func.refactor_plans[
+                        0
+                    ].current_complexity,
+                    "estimated_reduction": func.refactor_plans[
+                        0
+                    ].estimated_reduction,
+                    "estimated_complexity_after": func.refactor_plans[
+                        0
+                    ].estimated_complexity_after,
                     "steps": list(func.refactor_plans[0].steps),
                 }
             ],
@@ -188,6 +202,8 @@ def sample(a, b, c, d):
     ]
 
     snapshot_path = tmp_path / "complexipy-snapshot.json"
-    complexipy._complexipy.create_snapshot_file(str(snapshot_path), 0, [file_result])
+    complexipy._complexipy.create_snapshot_file(
+        str(snapshot_path), 0, [file_result]
+    )
     snapshot_data = json.loads(snapshot_path.read_text())
     assert "refactor_plans" not in snapshot_data[0]["functions"][0]

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -26,7 +26,9 @@ def complex_func(data):
 
 class TestSarif:
     def _build_file_complexity(self, max_complexity: int = 5):
-        with tempfile.NamedTemporaryFile(suffix=".py", mode="w", delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".py", mode="w", delete=False
+        ) as f:
             f.write(_SNIPPET)
             tmp_path = f.name
         try:


### PR DESCRIPTION
Simplify diff API and improve CLI output

## What

Consolidate the `--diff`/`--ratchet` API into a cleaner two-flag design (`--diff` for enforcement, `--diff-only` for visual), fix a path resolution bug in diff comparison, and improve the overall output formatting.

## Why

The previous API required users to discover `--ratchet` and combine it with `--diff` to get enforcement. New users had to read documentation to find this hidden behavior. The diff output was also appended after the completion rule with inconsistent styling, and the "Failed functions" section was redundant.

## Changes

### CLI API simplification
- `--diff <ref>` now enforces by default (fails on regressions above threshold)
- `--diff-only <ref>` is the new visual-only flag (never affects exit code)
- `--ratchet` is deprecated with a warning, still works for migration
- Removed `validate_ratchet` function, extracted `resolve_diff_flags` helper

### Output improvements
- Removed redundant "Failed functions" section that re-listed failures without complexity numbers
- Added `colorize_complexity` helper for green/red complexity numbers based on threshold
- Diff output now uses a Rich Table for properly aligned columns
- Diff section appears before the completion rule (not appended after)
- Diff header uses `console.rule()` to match the opening rule style
- Change numbers in diff are color-coded (red/green/yellow/dim)

### Bug fixes
- Fixed diff path resolution: `compute_diff` now correctly resolves git-relative paths when the invocation path equals the git root (e.g. `complexipy .`)
- Fixed `has_success_functions` to be snapshot-aware, preserving correct exit codes with snapshot watermarking
- Fixed quiet-mode exit code to respect snapshot map
- Fixed `handle_diff_output` to return `[]` instead of `None` when diff requested but no files found
- Fixed console initialization order so deprecation warnings respect `--color` flag

### Tests
- Added `TestResolveGitPath` (7 tests) for path resolution edge cases
- Added `TestResolveFinalSuccess` (11 tests) for exit code decision logic
- Added `TestDiffCli` (8 tests) for `--diff`, `--diff-only`, `--ratchet` deprecation CLI behavior
- Updated `TestFormatDiff` to use capturing Console pattern
- Total: 178 tests passing (was 152)

### Documentation
- Updated CLI options tables in all 5 doc files (EN + ES)
- Updated Complexity Diff sections with new `--diff` behavior
- Replaced Ratchet Mode sections with deprecation notices
- Updated examples to use `--diff` without `--ratchet`