### PR TITLE
ci(release): auto-update downstream repos on new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,6 +286,31 @@ jobs:
           packages-dir: dist/
           skip-existing: true
 
+  notify-downstream:
+    name: Notify downstream repos
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Notify complexipy-pre-commit
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: rohaquinlop/complexipy-pre-commit
+          event-type: complexipy-release
+          client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+      - name: Notify complexipy-action
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: rohaquinlop/complexipy-action
+          event-type: complexipy-release
+          client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+
   deploy-docs:
     name: Deploy docs
     needs: release


### PR DESCRIPTION
## What

Add a `notify-downstream` job to the release workflow that automatically updates complexipy-pre-commit and complexipy-action when a new version is published to PyPI.

## Why

The pre-commit hook and GitHub action both pin a specific complexipy version. Currently, updating them after each release is a manual process. This automates it so both downstream repos are updated and tagged within seconds of a new release.

## Changes

- Added `notify-downstream` job to `.github/workflows/release.yml` that runs after PyPI publish
- Uses `peter-evans/repository-dispatch@v3` to send `complexipy-release` events to both downstream repos
- Extracts version from the git tag (strips `v` prefix) and passes it as `client-payload`
- Requires `CROSS_REPO_TOKEN` secret (already configured)