### PR TITLE
fix(runner): show relative path from invocation directory in output

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -59,7 +59,7 @@ pub fn main(
             no_ignore,
         };
 
-        match process_path(&path, is_dir, is_url, &opts) {
+        match process_path(&path, is_dir, is_url, &opts, invocation_path) {
             Ok((mut complexities, mut f_paths)) => {
                 successful.append(&mut complexities);
                 failed_paths.append(&mut f_paths);
@@ -76,6 +76,7 @@ fn process_path(
     is_dir: bool,
     is_url: bool,
     opts: &ProcessOptions,
+    invocation_path: &str,
 ) -> Result<ComplexitiesAndFailedPaths, PyErr> {
     let mut file_complexities = Vec::new();
     let mut failed_paths = Vec::new();
@@ -129,21 +130,30 @@ fn process_path(
         }
 
         let repo_path = dir.path().join(&repo_name).to_string_lossy().to_string();
-        let (complexities, f_paths) = evaluate_dir(&repo_path, opts);
+        let (complexities, f_paths) = evaluate_dir(&repo_path, opts, invocation_path);
         dir.close()?;
         file_complexities = complexities;
         failed_paths = f_paths;
     } else if is_dir {
-        let (complexities, f_paths) = evaluate_dir(path, opts);
+        let (complexities, f_paths) = evaluate_dir(path, opts, invocation_path);
         file_complexities = complexities;
         failed_paths = f_paths;
     } else {
-        let parent_dir = path::Path::new(path)
-            .parent()
+        let inv_abs = path::Path::new(invocation_path)
+            .canonicalize()
+            .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
+        let inv_str = inv_abs.to_string_lossy().replace('\\', "/");
+        let file_abs = path::Path::new(path)
+            .canonicalize()
+            .unwrap_or_else(|_| path::Path::new(path).to_path_buf());
+        let rel = file_abs
+            .strip_prefix(&inv_abs)
+            .ok()
             .and_then(|p| p.to_str())
-            .unwrap_or(".");
-        if let Ok(complexity) = file_complexity(path, parent_dir, opts.check_script, opts.no_ignore)
-        {
+            .unwrap_or(path);
+        if let Ok(complexity) = file_complexity(path, &inv_str, opts.check_script, opts.no_ignore) {
+            let mut complexity = complexity;
+            complexity.path = rel.to_string();
             file_complexities.push(complexity);
         } else {
             failed_paths.push(path.to_string());
@@ -157,14 +167,15 @@ fn process_path(
     Ok((file_complexities, failed_paths))
 }
 
-fn evaluate_dir(path: &str, opts: &ProcessOptions) -> ComplexitiesAndFailedPaths {
-    let base_dir = path::Path::new(path)
+fn evaluate_dir(
+    path: &str,
+    opts: &ProcessOptions,
+    invocation_path: &str,
+) -> ComplexitiesAndFailedPaths {
+    let inv_abs = path::Path::new(invocation_path)
         .canonicalize()
-        .unwrap_or_else(|_| path::Path::new(path).to_path_buf())
-        .parent()
-        .unwrap_or(path::Path::new("."))
-        .to_string_lossy()
-        .replace('\\', "/");
+        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
+    let base_dir = inv_abs.to_string_lossy().replace('\\', "/");
     let files_paths_to_process = match get_paths_to_process(path, opts.exclude.clone()) {
         Ok(paths) => paths,
         Err(e) => return (vec![], vec![format!("{}: {}", path, e)]),

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -53,7 +53,12 @@ def _make_file_complexity(code: str, path: str = "src/example.py"):
     try:
         with open(tmp_path, "w") as f:
             f.write(code)
-        files, _ = _main([tmp_path], False, [])
+        files, _ = _main(
+            [tmp_path],
+            False,
+            [],
+            invocation_path=tmp_dir,
+        )
     finally:
         os.unlink(tmp_path)
         os.rmdir(tmp_dir)

--- a/tests/test_gitlab.py
+++ b/tests/test_gitlab.py
@@ -26,7 +26,12 @@ def complex_func(data):
 
 
 def _build_file_complexity(source_file: Path):
-    files, _ = _main([source_file.as_posix()], False, [])
+    files, _ = _main(
+        [source_file.as_posix()],
+        False,
+        [],
+        invocation_path=str(source_file.parent),
+    )
     return files
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -17,7 +17,12 @@ def simple(value):
 
 
 def _build_file_complexity(source_file: Path):
-    files, _ = _main([source_file.as_posix()], False, [])
+    files, _ = _main(
+        [source_file.as_posix()],
+        False,
+        [],
+        invocation_path=str(source_file.parent),
+    )
     return files
 
 

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -130,12 +130,13 @@ def complex_fn(x):
 
 
 class TestTopOutput:
-    def test_top_limits_to_n_functions(self, tmp_path: Path):
+    def test_top_limits_to_n_functions(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -148,12 +149,13 @@ class TestTopOutput:
         ]
         assert len(lines) == 2
 
-    def test_top_sorts_descending(self, tmp_path: Path):
+    def test_top_sorts_descending(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -166,12 +168,13 @@ class TestTopOutput:
         complexities = [int(line.split()[-1]) for line in lines]
         assert complexities == sorted(complexities, reverse=True)
 
-    def test_top_works_with_rich_output(self, tmp_path: Path):
+    def test_top_works_with_rich_output(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -182,12 +185,13 @@ class TestTopOutput:
         assert "complex_fn" in result.output
         assert "simple" not in result.output
 
-    def test_top_with_failed_filters_both(self, tmp_path: Path):
+    def test_top_with_failed_filters_both(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -202,7 +206,7 @@ class TestTopOutput:
         assert "complex_fn" in lines[0]
 
     def test_top_multi_file_preserves_global_descending_order(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch
     ):
         import complexipy.main as main_module
 
@@ -235,6 +239,7 @@ def b_mid(x):
 """,
             encoding="utf-8",
         )
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -253,12 +258,13 @@ def b_mid(x):
         assert names[1] == "b_mid"
         assert names[2] == "a_low"
 
-    def test_top_zero_errors(self, tmp_path: Path):
+    def test_top_zero_errors(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_MULTI_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -269,12 +275,15 @@ def b_mid(x):
 
 
 class TestSuggestRefactorsOutput:
-    def test_suggest_refactors_prints_plan_fragments(self, tmp_path: Path):
+    def test_suggest_refactors_prints_plan_fragments(
+        self, tmp_path: Path, monkeypatch
+    ):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_REFACTOR_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -290,7 +299,7 @@ class TestSuggestRefactorsOutput:
         assert "invert the outer condition" in result.output
 
     def test_failed_with_suggest_refactors_only_shows_displayed_failures(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch
     ):
         import complexipy.main as main_module
 
@@ -300,6 +309,7 @@ class TestSuggestRefactorsOutput:
             _REFACTOR_SNIPPET + "\n\ndef simple(value):\n    return value\n",
             encoding="utf-8",
         )
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -312,13 +322,14 @@ class TestSuggestRefactorsOutput:
         assert "simple" not in result.output
 
     def test_plain_with_suggest_refactors_preserves_plain_output(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch
     ):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_REFACTOR_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         without_flag = runner.invoke(
             main_module.app,
@@ -336,12 +347,15 @@ class TestSuggestRefactorsOutput:
 
 
 class TestPlainOutput:
-    def test_plain_outputs_one_line_per_function(self, tmp_path: Path):
+    def test_plain_outputs_one_line_per_function(
+        self, tmp_path: Path, monkeypatch
+    ):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -358,12 +372,15 @@ class TestPlainOutput:
         assert parts[1] == "simple"
         assert parts[2] == "1"
 
-    def test_plain_with_failed_shows_only_failures(self, tmp_path: Path):
+    def test_plain_with_failed_shows_only_failures(
+        self, tmp_path: Path, monkeypatch
+    ):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -377,12 +394,15 @@ class TestPlainOutput:
         assert len(lines) == 1
         assert "simple" in lines[0]
 
-    def test_plain_with_failed_no_failures_is_silent(self, tmp_path: Path):
+    def test_plain_with_failed_no_failures_is_silent(
+        self, tmp_path: Path, monkeypatch
+    ):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -395,12 +415,13 @@ class TestPlainOutput:
         ]
         assert len(lines) == 0
 
-    def test_plain_and_quiet_errors(self, tmp_path: Path):
+    def test_plain_and_quiet_errors(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -409,12 +430,13 @@ class TestPlainOutput:
 
         assert result.exit_code == 2
 
-    def test_plain_no_rich_decorations(self, tmp_path: Path):
+    def test_plain_no_rich_decorations(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(_SNIPPET, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,
@@ -611,12 +633,13 @@ class TestDiffCli:
         assert "Deprecated" in result.output
         assert "--ratchet" in result.output
 
-    def test_ratchet_without_diff_errors(self, tmp_path: Path):
+    def test_ratchet_without_diff_errors(self, tmp_path: Path, monkeypatch):
         import complexipy.main as main_module
 
         runner = CliRunner()
         source_file = tmp_path / "sample.py"
         source_file.write_text(self._SIMPLE, encoding="utf-8")
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
 
         result = runner.invoke(
             main_module.app,

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -7,7 +7,6 @@ import tempfile
 from complexipy._complexipy import main as _main
 from complexipy.utils.sarif import _RULE_ID, store_sarif
 
-# Minimal snippet with one complex and one simple function.
 _SNIPPET = """\
 def simple(x):
     return x + 1
@@ -32,7 +31,13 @@ class TestSarif:
             f.write(_SNIPPET)
             tmp_path = f.name
         try:
-            files, _ = _main([tmp_path], False, [])
+            inv_dir = os.path.dirname(tmp_path)
+            files, _ = _main(
+                [tmp_path],
+                False,
+                [],
+                invocation_path=inv_dir,
+            )
         finally:
             os.unlink(tmp_path)
         return files, max_complexity


### PR DESCRIPTION
## What

Fix file paths in console output to always show the relative path from the current working directory, regardless of whether a single file or directory is analyzed.

## Why

When running `complexipy path/to/file.py`, the output showed only `file.py` (directory stripped). When running `complexipy .` from a project root, the output showed `project/inner/file.py` (target dir name included). Neither was the correct relative path from CWD.

## Changes

- Thread `invocation_path` through `process_path()` and `evaluate_dir()` in `src/runner.rs`
- Single-file path: canonicalize both invocation path and file path, strip CWD prefix to get relative path
- Directory path: use canonicalized `invocation_path` as `base_dir` instead of `parent(target_dir)`
- Update test helpers in `test_diff.py`, `test_gitlab.py`, `test_json.py`, `test_sarif.py` to pass `invocation_path` when calling `_main()` directly
- Add `monkeypatch.setattr(INVOCATION_PATH, tmp_path)` to 15 CLI tests in `test_output_cli.py` that use absolute tmp paths

Closes #195