### PR TITLE
docs: add community standards files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+______________________________________________________________________
+
+## name: Bug Report about: Report a bug in complexipy title: '' labels: bug assignees: ''
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+
+1. Run '...'
+1. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual behavior
+
+A clear and concise description of what actually happened.
+
+## Environment
+
+- OS: [e.g., Ubuntu 22.04, macOS 14, Windows 11]
+- Python version: [e.g., 3.11.5]
+- complexipy version: [e.g., 0.8.0]
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+---
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+______________________________________________________________________
+
+## name: Feature Request about: Suggest a new feature or improvement title: '' labels: enhancement assignees: ''
+
+## Is your feature request related to a problem?
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## What
+
+One sentence explaining what this PR does.
+
+## Why
+
+Brief context on why this change is needed.
+
+## Changes
+
+- Bullet points of specific changes made
+- Group related changes together
+- Mention any files deleted or renamed
+
+## Related issue
+
+Closes #<!-- issue number -->
+
+## Checklist
+
+- [ ] Tests pass (`uv run pytest tests/`)
+- [ ] Code is formatted (`uv run ruff check .` and `uv run ruff format .`)
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by opening an
+issue on the repository.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to complexipy
+
+Thanks for your interest in contributing! Here's how to get started.
+
+## Reporting Bugs
+
+Open a [bug report](https://github.com/rohaquinlop/complexipy/issues/new?template=bug_report.md) using the issue template. Include steps to reproduce, expected vs. actual behavior, and your environment details.
+
+## Suggesting Features
+
+Open a [feature request](https://github.com/rohaquinlop/complexipy/issues/new?template=feature_request.md) using the issue template. Describe the problem you're trying to solve and your proposed solution.
+
+## Development Setup
+
+1. Clone the repository:
+
+    ```bash
+    git clone https://github.com/rohaquinlop/complexipy.git
+    cd complexipy
+    ```
+
+1. Install dependencies:
+
+    ```bash
+    uv sync
+    ```
+
+1. Build the Rust extension:
+
+    ```bash
+    uv run maturin develop
+    ```
+
+## Running Tests
+
+```bash
+uv run pytest tests/
+```
+
+## Linting & Formatting
+
+```bash
+uv run ruff check .
+uv run ruff format .
+```
+
+## Pull Requests
+
+- PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description` (e.g., `fix(diff): resolve path for nested invocation`). This is enforced by CI.
+- Keep code clean — no comments. Use descriptive variable and function names instead.
+- Run tests and linter before submitting.
+- Keep changes focused. One feature or fix per PR.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in complexipy, please report it responsibly through [GitHub Security Advisories](https://github.com/rohaquinlop/complexipy/security/advisories/new). This allows us to address the issue privately before any public disclosure.
+
+**Do not open a public issue for security vulnerabilities.**
+
+We will acknowledge your report within 7 days and work with you to understand and address the issue.


### PR DESCRIPTION
## What

Add the missing GitHub Community Standards files to reach a 100% community profile score.

## Why

The repository was missing 5 of the 9 community standards GitHub evaluates: Code of Conduct, Contributing guide, Security Policy, Issue Templates, and PR Template. Adding these improves the project's accessibility to new contributors and establishes clear guidelines for collaboration.

## Changes

- Add `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- Add `CONTRIBUTING.md` — dev setup, tests, linting, and PR conventions
- Add `SECURITY.md` — vulnerability reporting via GitHub Security Advisories
- Add `.github/ISSUE_TEMPLATE/bug_report.md` — bug report template
- Add `.github/ISSUE_TEMPLATE/feature_request.md` — feature request template
- Add `.github/ISSUE_TEMPLATE/config.yml` — template chooser configuration
- Add `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist aligned with create-pr skill format