### PR TITLE
feat(api): expose diff analysis in the public Python API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,12 @@ Every Rust-side type crosses into Python through `src/classes.rs` (`FileComplexi
 those structs means updating **three** places in lockstep: `src/classes.rs` → the
 `#[pymodule]` export list in `src/lib.rs` → the stubs in `complexipy/_complexipy.pyi`.
 
+`complexipy/__init__.py` is the public Python API surface: `code_complexity`,
+`file_complexity`, `collect_all_ignored_locations`, `compute_diff`, `has_regressions`,
+and the `DiffEntry` / `DiffStatus` types. Those exports, their signatures, and the
+`DiffStatus` values are a compatibility promise — internal refactors must keep them
+stable, and new exports belong in `__init__.py` + `__all__` with docs in `docs/` (EN + ES).
+
 ### Rust core
 
 - `src/cognitive_complexity.rs` — the algorithm. Parses with `ruff_python_parser`,

--- a/complexipy/__init__.py
+++ b/complexipy/__init__.py
@@ -16,11 +16,19 @@ from complexipy.api import (
     code_complexity,
     file_complexity,
 )
+from complexipy.utils.diff import (
+    DiffEntry,
+    DiffStatus,
+    compute_diff,
+    has_regressions,
+)
 
 __all__ = [
     "Applicability",
     "CodeComplexity",
     "CodeSuggestion",
+    "DiffEntry",
+    "DiffStatus",
     "FileComplexity",
     "FunctionComplexity",
     "IgnoredLocation",
@@ -29,5 +37,7 @@ __all__ = [
     "RuleCategory",
     "code_complexity",
     "collect_all_ignored_locations",
+    "compute_diff",
     "file_complexity",
+    "has_regressions",
 ]

--- a/complexipy/api.py
+++ b/complexipy/api.py
@@ -84,11 +84,17 @@ def file_complexity(
         ...     if func.complexity > 10:
         ...         print(f"Complex function: {func.name} ({func.complexity})")
     """
-    path = Path(file_path)
-    base_path = path.parent
+    path = Path(file_path).resolve()
+    cwd = Path.cwd().resolve()
+    try:
+        path.relative_to(cwd)
+    except ValueError:
+        base_path = path.parent
+    else:
+        base_path = cwd
     return _complexipy.file_complexity(
-        path.resolve().as_posix(),
-        base_path.resolve().as_posix(),
+        path.as_posix(),
+        base_path.as_posix(),
         check_script,
         no_ignore,
     )

--- a/complexipy/utils/diff.py
+++ b/complexipy/utils/diff.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 from dataclasses import dataclass
+from enum import Enum
 from typing import Dict, List, Optional, Tuple
 
 import typer
@@ -15,11 +16,15 @@ from complexipy._complexipy import (
     code_complexity as _code_complexity,
 )
 
-_STATUS_REGRESSED = "REGRESSED"
-_STATUS_IMPROVED = "IMPROVED"
-_STATUS_UNCHANGED = "UNCHANGED"
-_STATUS_NEW = "NEW"
-_STATUS_REMOVED = "REMOVED"
+
+class DiffStatus(str, Enum):
+    """Comparison status of a function between two analyzed versions."""
+
+    REGRESSED = "REGRESSED"
+    IMPROVED = "IMPROVED"
+    UNCHANGED = "UNCHANGED"
+    NEW = "NEW"
+    REMOVED = "REMOVED"
 
 
 @dataclass
@@ -30,16 +35,16 @@ class DiffEntry:
     new_complexity: Optional[int]
 
     @property
-    def status(self) -> str:
+    def status(self) -> DiffStatus:
         if self.old_complexity is None:
-            return _STATUS_NEW
+            return DiffStatus.NEW
         if self.new_complexity is None:
-            return _STATUS_REMOVED
+            return DiffStatus.REMOVED
         if self.new_complexity > self.old_complexity:
-            return _STATUS_REGRESSED
+            return DiffStatus.REGRESSED
         if self.new_complexity < self.old_complexity:
-            return _STATUS_IMPROVED
-        return _STATUS_UNCHANGED
+            return DiffStatus.IMPROVED
+        return DiffStatus.UNCHANGED
 
     @property
     def delta(self) -> Optional[int]:
@@ -88,6 +93,23 @@ def _build_func_map(file: FileComplexity) -> Dict[str, int]:
     return {f.name: f.complexity for f in file.functions}
 
 
+def _git_tracked_paths(cwd: str) -> List[str]:
+    """Return repo-root-relative paths of tracked files, or [] on error."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--full-name"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0:
+            return result.stdout.splitlines()
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    return []
+
+
 def _resolve_git_path(
     file_path: str, git_ref: str, invocation_path: str
 ) -> str:
@@ -100,7 +122,10 @@ def _resolve_git_path(
     ``complexipy/main.py``.
 
     We fix this by trying the path as-is first, then progressively stripping
-    leading components until ``git show`` can locate the file.
+    leading components until ``git show`` can locate the file.  As a last
+    resort the basename is looked up among tracked files: a unique match is
+    returned, an ambiguous one keeps the original path (the file then
+    reports as NEW).
     """
     normalized = file_path.replace(os.sep, "/").replace("\\", "/")
     parts = normalized.split("/")
@@ -113,13 +138,22 @@ def _resolve_git_path(
         ):
             return candidate
 
+    basename = parts[-1]
+    matches = [
+        tracked
+        for tracked in _git_tracked_paths(invocation_path)
+        if tracked == basename or tracked.endswith("/" + basename)
+    ]
+    if len(matches) == 1:
+        return matches[0]
+
     return normalized
 
 
 def compute_diff(
     current_files: List[FileComplexity],
     git_ref: str,
-    invocation_path: str,
+    invocation_path: Optional[str] = None,
 ) -> List[DiffEntry]:
     """Compare the current complexity results against *git_ref*.
 
@@ -129,12 +163,15 @@ def compute_diff(
     only in the historical version are marked NEW / REMOVED respectively.
 
     The *invocation_path* is used as the ``cwd`` for git commands and to
-    resolve file paths relative to the repository root.
+    resolve file paths relative to the repository root.  It defaults to the
+    current working directory.
 
     Returns a list of :class:`DiffEntry` objects, one per function that
     either changed or is new/removed.  Unchanged functions are included so
     callers can choose how to filter.
     """
+    if invocation_path is None:
+        invocation_path = os.getcwd()
     entries: List[DiffEntry] = []
 
     for file in current_files:
@@ -170,48 +207,48 @@ def compute_diff(
 
 def _status_style(status: str) -> str:
     """Return Rich markup for a diff status label."""
-    if status == _STATUS_REGRESSED:
+    if status == DiffStatus.REGRESSED:
         return "[bold red]REGRESSED[/bold red]"
-    if status == _STATUS_IMPROVED:
+    if status == DiffStatus.IMPROVED:
         return "[bold green]IMPROVED[/bold green]"
-    if status == _STATUS_NEW:
+    if status == DiffStatus.NEW:
         return "[bold yellow]NEW[/bold yellow]"
-    if status == _STATUS_REMOVED:
+    if status == DiffStatus.REMOVED:
         return "[dim]REMOVED[/dim]"
     return status
 
 
 def _format_change(e: DiffEntry) -> str:
     """Return the change column value for a diff entry."""
-    if e.status == _STATUS_NEW:
+    if e.status == DiffStatus.NEW:
         return f"[bold yellow]{e.new_complexity}[/bold yellow]  (new)"
-    if e.status == _STATUS_REMOVED:
+    if e.status == DiffStatus.REMOVED:
         return f"[dim]{e.old_complexity}[/dim]  (removed)"
     delta = e.delta
     sign = "+" if delta and delta > 0 else ""
-    if e.status == _STATUS_REGRESSED:
+    if e.status == DiffStatus.REGRESSED:
         return f"[red]{e.old_complexity} → {e.new_complexity}  ({sign}{delta})[/red]"
-    if e.status == _STATUS_IMPROVED:
+    if e.status == DiffStatus.IMPROVED:
         return f"[green]{e.old_complexity} → {e.new_complexity}  ({sign}{delta})[/green]"
     return f"{e.old_complexity} → {e.new_complexity}  ({sign}{delta})"
 
 
 def _build_diff_summary(changed: List[DiffEntry]) -> str:
     counts = {
-        _STATUS_REGRESSED: 0,
-        _STATUS_IMPROVED: 0,
-        _STATUS_NEW: 0,
-        _STATUS_REMOVED: 0,
+        DiffStatus.REGRESSED: 0,
+        DiffStatus.IMPROVED: 0,
+        DiffStatus.NEW: 0,
+        DiffStatus.REMOVED: 0,
     }
     for e in changed:
         if e.status in counts:
             counts[e.status] += 1
 
     labels = [
-        (_STATUS_REGRESSED, "regressed", "red"),
-        (_STATUS_IMPROVED, "improved", "green"),
-        (_STATUS_NEW, "new", "yellow"),
-        (_STATUS_REMOVED, "removed", "dim"),
+        (DiffStatus.REGRESSED, "regressed", "red"),
+        (DiffStatus.IMPROVED, "improved", "green"),
+        (DiffStatus.NEW, "new", "yellow"),
+        (DiffStatus.REMOVED, "removed", "dim"),
     ]
     parts = [
         f"[{style}]{counts[s]} {label}[/{style}]"
@@ -236,13 +273,13 @@ def has_regressions(entries: List[DiffEntry], max_complexity: int) -> bool:
     """
     for e in entries:
         if (
-            e.status == _STATUS_REGRESSED
+            e.status == DiffStatus.REGRESSED
             and e.new_complexity is not None
             and e.new_complexity > max_complexity
         ):
             return True
         if (
-            e.status == _STATUS_NEW
+            e.status == DiffStatus.NEW
             and e.new_complexity is not None
             and e.new_complexity > max_complexity
         ):
@@ -262,7 +299,12 @@ def format_diff(
         e
         for e in entries
         if e.status
-        in (_STATUS_REGRESSED, _STATUS_IMPROVED, _STATUS_NEW, _STATUS_REMOVED)
+        in (
+            DiffStatus.REGRESSED,
+            DiffStatus.IMPROVED,
+            DiffStatus.NEW,
+            DiffStatus.REMOVED,
+        )
     ]
 
     if not changed:

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -388,10 +388,12 @@ Cuando `--output-format json` también está activo, las ubicaciones ignoradas s
 file_complexity(path: str, check_script: bool = False, no_ignore: bool = False) -> FileComplexity
 code_complexity(source: str, check_script: bool = False, no_ignore: bool = False) -> CodeComplexity
 collect_all_ignored_locations(paths: List[str], exclude: List[str] = [], invocation_path: str = "") -> Tuple[List[IgnoredLocation], List[str]]
+compute_diff(files: List[FileComplexity], git_ref: str, invocation_path: Optional[str] = None) -> List[DiffEntry]
+has_regressions(entries: List[DiffEntry], max_complexity: int) -> bool
 
 # Tipos de retorno
 FileComplexity:
-  ├─ path: str
+  ├─ path: str (relative to the working directory, or absolute when outside it)
   ├─ file_name: str
   ├─ complexity: int
   └─ functions: List[FunctionComplexity]
@@ -443,6 +445,16 @@ IgnoredLocation:
 CodeComplexity:
   ├─ complexity: int
   └─ functions: List[FunctionComplexity]
+
+DiffEntry:
+  ├─ file_path: str
+  ├─ func_name: str
+  ├─ old_complexity: Optional[int]
+  ├─ new_complexity: Optional[int]
+  ├─ status: DiffStatus (property)
+  └─ delta: Optional[int] (property)
+
+DiffStatus: REGRESSED | IMPROVED | UNCHANGED | NEW | REMOVED
 ```
 
 ______________________________________________________________________

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -393,6 +393,53 @@ for func in result.functions:
 result = code_complexity(code, no_ignore=True)
 ```
 
+### Comparar Contra una Referencia de Git
+
+`compute_diff` compara los resultados de complejidad actuales contra una
+referencia de git (commit, etiqueta o rama) y devuelve objetos `DiffEntry` —
+uno por función que cambió, apareció o desapareció. `has_regressions` informa
+si alguna entrada supera un umbral de complejidad (una función REGRESSED o NEW
+por encima de *max_complexity*).
+
+```python
+from complexipy import (
+    compute_diff,
+    has_regressions,
+    file_complexity,
+    DiffEntry,
+    DiffStatus,
+)
+
+# Analizar el estado actual de los archivos de interés
+current = [file_complexity(p) for p in changed_files]
+
+# Comparar contra una referencia de git (el directorio de trabajo es el cwd por defecto)
+entries = compute_diff(current, "origin/main")
+
+# Filtrar regresiones por encima de tu umbral
+regressions = [
+    e
+    for e in entries
+    if e.status == DiffStatus.REGRESSED and e.new_complexity > 15
+]
+
+# O usar la compuerta de ratchet directamente (falla con REGRESSED/NEW sobre el umbral)
+if has_regressions(entries, 15):
+    raise SystemExit("Regresiones de complejidad detectadas")
+```
+
+`DiffEntry` expone `file_path`, `func_name`, `old_complexity` y
+`new_complexity` (cualquiera puede ser `None` para funciones NEW / REMOVED),
+más las propiedades `status` y `delta`. `status` es un miembro de
+`DiffStatus` — un enum basado en `str`, por lo que compara igual a su valor
+de cadena (p. ej. `DiffStatus.REGRESSED == "REGRESSED"`).
+
+```python
+for e in entries:
+    if e.status != DiffStatus.UNCHANGED:
+        print(f"{e.file_path}::{e.func_name}: {e.status} {e.delta}")
+```
+
 ### Uso Práctico de la API
 
 **Ejemplo: Hook de Pre-commit**

--- a/docs/index.md
+++ b/docs/index.md
@@ -387,10 +387,12 @@ When `--output-format json` is also active, ignored locations are exported to `c
 file_complexity(path: str, check_script: bool = False, no_ignore: bool = False) -> FileComplexity
 code_complexity(source: str, check_script: bool = False, no_ignore: bool = False) -> CodeComplexity
 collect_all_ignored_locations(paths: List[str], exclude: List[str] = [], invocation_path: str = "") -> Tuple[List[IgnoredLocation], List[str]]
+compute_diff(files: List[FileComplexity], git_ref: str, invocation_path: Optional[str] = None) -> List[DiffEntry]
+has_regressions(entries: List[DiffEntry], max_complexity: int) -> bool
 
 # Return types
 FileComplexity:
-  ├─ path: str
+  ├─ path: str (relative to the working directory, or absolute when outside it)
   ├─ file_name: str
   ├─ complexity: int
   └─ functions: List[FunctionComplexity]
@@ -442,6 +444,16 @@ IgnoredLocation:
 CodeComplexity:
   ├─ complexity: int
   └─ functions: List[FunctionComplexity]
+
+DiffEntry:
+  ├─ file_path: str
+  ├─ func_name: str
+  ├─ old_complexity: Optional[int]
+  ├─ new_complexity: Optional[int]
+  ├─ status: DiffStatus (property)
+  └─ delta: Optional[int] (property)
+
+DiffStatus: REGRESSED | IMPROVED | UNCHANGED | NEW | REMOVED
 ```
 
 ______________________________________________________________________

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -395,6 +395,53 @@ for func in result.functions:
     print(f"{func.name}: {func.complexity}")
 ```
 
+### Comparing Against a Git Reference
+
+`compute_diff` compares current complexity results against a git reference
+(commit, tag, or branch) and returns `DiffEntry` objects — one per function
+that changed, appeared, or disappeared. `has_regressions` reports whether any
+entry breaches a complexity threshold (a REGRESSED or NEW function above
+*max_complexity*).
+
+```python
+from complexipy import (
+    compute_diff,
+    has_regressions,
+    file_complexity,
+    DiffEntry,
+    DiffStatus,
+)
+
+# Analyze the current state of the files you care about
+current = [file_complexity(p) for p in changed_files]
+
+# Compare against a git reference (the working directory is the default cwd)
+entries = compute_diff(current, "origin/main")
+
+# Filter for regressions above your threshold
+regressions = [
+    e
+    for e in entries
+    if e.status == DiffStatus.REGRESSED and e.new_complexity > 15
+]
+
+# Or use the ratchet gate directly (fails on REGRESSED/NEW above threshold)
+if has_regressions(entries, 15):
+    raise SystemExit("Complexity regressions detected")
+```
+
+`DiffEntry` exposes `file_path`, `func_name`, `old_complexity`, and
+`new_complexity` (either may be `None` for NEW / REMOVED functions), plus the
+`status` and `delta` properties. `status` is a `DiffStatus` member — a
+`str`-based enum, so it compares equal to its string value (e.g.
+`DiffStatus.REGRESSED == "REGRESSED"`).
+
+```python
+for e in entries:
+    if e.status != DiffStatus.UNCHANGED:
+        print(f"{e.file_path}::{e.func_name}: {e.status} {e.delta}")
+```
+
 ### Practical API Usage
 
 **Example: Pre-commit Hook**

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import tempfile
 from unittest.mock import patch
 
+from complexipy import DiffStatus, file_complexity
 from complexipy._complexipy import main as _main
 from complexipy.types import ExitReport
 from complexipy.utils.diff import (
-    _STATUS_IMPROVED,
-    _STATUS_NEW,
-    _STATUS_REGRESSED,
-    _STATUS_REMOVED,
-    _STATUS_UNCHANGED,
     DiffEntry,
     _resolve_git_path,
     compute_diff,
@@ -68,23 +65,23 @@ def _make_file_complexity(code: str, path: str = "src/example.py"):
 class TestDiffEntry:
     def test_status_new(self):
         e = DiffEntry("f.py", "foo", None, 5)
-        assert e.status == _STATUS_NEW
+        assert e.status == DiffStatus.NEW
 
     def test_status_removed(self):
         e = DiffEntry("f.py", "foo", 5, None)
-        assert e.status == _STATUS_REMOVED
+        assert e.status == DiffStatus.REMOVED
 
     def test_status_regressed(self):
         e = DiffEntry("f.py", "foo", 3, 7)
-        assert e.status == _STATUS_REGRESSED
+        assert e.status == DiffStatus.REGRESSED
 
     def test_status_improved(self):
         e = DiffEntry("f.py", "foo", 7, 3)
-        assert e.status == _STATUS_IMPROVED
+        assert e.status == DiffStatus.IMPROVED
 
     def test_status_unchanged(self):
         e = DiffEntry("f.py", "foo", 4, 4)
-        assert e.status == _STATUS_UNCHANGED
+        assert e.status == DiffStatus.UNCHANGED
 
     def test_delta_change(self):
         e = DiffEntry("f.py", "foo", 3, 7)
@@ -111,7 +108,7 @@ class TestComputeDiff:
         ), patch("complexipy.utils.diff._git_root", return_value="/repo"):
             entries = compute_diff(current, "HEAD~1", "/repo")
 
-        assert all(e.status == _STATUS_NEW for e in entries)
+        assert all(e.status == DiffStatus.NEW for e in entries)
         assert any(e.func_name == "with_if" for e in entries)
 
     def test_unchanged_function(self):
@@ -123,7 +120,7 @@ class TestComputeDiff:
             entries = compute_diff(current, "HEAD~1", "/repo")
 
         simple_entry = next(e for e in entries if e.func_name == "simple")
-        assert simple_entry.status == _STATUS_UNCHANGED
+        assert simple_entry.status == DiffStatus.UNCHANGED
 
     def test_regressed_function(self):
         current = [self._file(_COMPLEX)]
@@ -137,7 +134,7 @@ class TestComputeDiff:
             (e for e in entries if e.func_name == "complex_func"), None
         )
         assert complex_entry is not None
-        assert complex_entry.status == _STATUS_NEW  # not in old version
+        assert complex_entry.status == DiffStatus.NEW  # not in old version
 
     def test_improved_function(self):
         current = [self._file(_SIMPLE)]
@@ -152,7 +149,7 @@ class TestComputeDiff:
         )
         # simple didn't exist in old (complex) version → appears as new
         assert simple_entry is not None
-        assert simple_entry.status == _STATUS_NEW
+        assert simple_entry.status == DiffStatus.NEW
 
     def test_removed_function_appears_in_entries(self):
         # Current file has only `simple`; old had `simple` + `with_if`
@@ -165,7 +162,7 @@ class TestComputeDiff:
 
         removed = next((e for e in entries if e.func_name == "with_if"), None)
         assert removed is not None
-        assert removed.status == _STATUS_REMOVED
+        assert removed.status == DiffStatus.REMOVED
 
     def test_multiple_files(self):
         f1 = self._file(_SIMPLE, "a.py")
@@ -415,6 +412,54 @@ class TestResolveGitPath:
             )
         assert result == "complexipy/main.py"
 
+    def test_basename_fallback_unique_match(self):
+        """Bare basename resolves to the unique tracked file with that name."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=None,
+        ), patch(
+            "complexipy.utils.diff._git_tracked_paths",
+            return_value=["src/app.py", "complexipy/main.py"],
+        ):
+            result = _resolve_git_path("app.py", "main", "/repo")
+        assert result == "src/app.py"
+
+    def test_basename_fallback_exact_match(self):
+        """A tracked path equal to the bare basename is a match."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=None,
+        ), patch(
+            "complexipy.utils.diff._git_tracked_paths",
+            return_value=["app.py"],
+        ):
+            result = _resolve_git_path("app.py", "main", "/repo")
+        assert result == "app.py"
+
+    def test_basename_fallback_ambiguous_returns_original(self):
+        """Several tracked files share the basename — keep the original."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=None,
+        ), patch(
+            "complexipy.utils.diff._git_tracked_paths",
+            return_value=["src/app.py", "lib/app.py"],
+        ):
+            result = _resolve_git_path("app.py", "main", "/repo")
+        assert result == "app.py"
+
+    def test_basename_fallback_no_match_returns_original(self):
+        """No tracked file matches the basename — keep the original."""
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref",
+            return_value=None,
+        ), patch(
+            "complexipy.utils.diff._git_tracked_paths",
+            return_value=["src/app.py"],
+        ):
+            result = _resolve_git_path("other.py", "main", "/repo")
+        assert result == "other.py"
+
 
 class TestExitReport:
     def test_enforce_true_regression_above_threshold_fails(self):
@@ -537,3 +582,128 @@ class TestExitReport:
                 enforce_diff=enforce,
             )
             assert report.success is False
+
+
+class TestPublicApi:
+    def _file(self, code: str, path: str = "src/example.py"):
+        return _make_file_complexity(code, path)
+
+    def test_exported_names_are_public(self):
+        import complexipy
+
+        for name in (
+            "compute_diff",
+            "has_regressions",
+            "DiffEntry",
+            "DiffStatus",
+        ):
+            assert name in complexipy.__all__
+            assert getattr(complexipy, name) is not None
+
+    def test_reexports_are_the_same_objects(self):
+        import complexipy
+
+        from complexipy.utils.diff import DiffEntry as _DiffEntry
+        from complexipy.utils.diff import DiffStatus as _DiffStatus
+        from complexipy.utils.diff import compute_diff as _compute_diff
+        from complexipy.utils.diff import has_regressions as _has_regressions
+
+        assert complexipy.DiffEntry is _DiffEntry
+        assert complexipy.DiffStatus is _DiffStatus
+        assert complexipy.compute_diff is _compute_diff
+        assert complexipy.has_regressions is _has_regressions
+
+    def test_status_enum_is_str_comparable(self):
+        assert DiffStatus.REGRESSED == "REGRESSED"
+        assert DiffStatus.IMPROVED == "IMPROVED"
+        assert DiffStatus.UNCHANGED == "UNCHANGED"
+        assert DiffStatus.NEW == "NEW"
+        assert DiffStatus.REMOVED == "REMOVED"
+
+    def test_status_is_enum_member(self):
+        e = DiffEntry("f.py", "foo", 3, 7)
+        assert e.status is DiffStatus.REGRESSED
+
+    def test_issue_example_works_through_public_api(self):
+        current = [self._file(_WITH_IF)]
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref", return_value=_SIMPLE
+        ), patch("complexipy.utils.diff._git_root", return_value="/repo"):
+            entries = compute_diff(current, "origin/main", ".")
+
+        regressions = [
+            e
+            for e in entries
+            if e.status == DiffStatus.REGRESSED
+            and e.new_complexity is not None
+            and e.new_complexity > 15
+        ]
+        assert isinstance(entries, list)
+        assert all(isinstance(e, DiffEntry) for e in entries)
+        assert isinstance(regressions, list)
+        assert has_regressions(entries, 15) is False
+
+    def test_compute_diff_defaults_to_cwd(self, monkeypatch):
+        monkeypatch.setattr("complexipy.utils.diff.os.getcwd", lambda: "/cwd")
+        current = [self._file(_SIMPLE)]
+        with patch(
+            "complexipy.utils.diff._file_content_at_ref", return_value=_SIMPLE
+        ), patch("complexipy.utils.diff._git_root", return_value="/cwd"):
+            entries = compute_diff(current, "HEAD~1")
+        assert entries[0].status == DiffStatus.UNCHANGED
+
+    def test_file_complexity_path_is_cwd_relative(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        pkg = repo / "pkg"
+        pkg.mkdir(parents=True)
+        target = pkg / "calc.py"
+        target.write_text("def calc(x):\n    return x + 1\n")
+        monkeypatch.chdir(repo)
+
+        result = file_complexity(str(target))
+        assert result.path == "pkg/calc.py"
+
+    def test_issue_flow_real_git_repo(self, tmp_path):
+        """The issue's CI flow end to end against a real git repository.
+
+        ``file_complexity`` on a changed file, ``compute_diff`` against a
+        git ref, then status filtering and the ratchet gate — the exact
+        scenario from issue #202, without mocks.
+        """
+        repo = tmp_path / "repo"
+        pkg = repo / "pkg"
+        pkg.mkdir(parents=True)
+        target = pkg / "calc.py"
+        target.write_text("def calc(x):\n    return x + 1\n")
+
+        def _git(*args):
+            return subprocess.run(
+                ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        assert _git("init", "-q").returncode == 0
+        assert _git("add", ".").returncode == 0
+        assert _git("commit", "-q", "-m", "v1").returncode == 0
+
+        target.write_text(
+            "def calc(x):\n"
+            "    if x:\n"
+            "        for i in range(x):\n"
+            "            if i:\n"
+            "                return i\n"
+            "    return x + 1\n"
+        )
+
+        current = [file_complexity(str(target))]
+        entries = compute_diff(current, "HEAD", str(repo))
+
+        entry = next(e for e in entries if e.func_name == "calc")
+        assert entry.status == DiffStatus.REGRESSED
+        assert entry.old_complexity == 0
+        assert entry.new_complexity > 1
+        assert has_regressions(entries, 15) is False
+        assert has_regressions(entries, 5) is True


### PR DESCRIPTION
## What

Promotes `compute_diff`, `DiffEntry`, and `has_regressions` from the internal `complexipy.utils.diff` module to the public `complexipy` API so CI tools can consume diff results as objects instead of parsing CLI text output.

## Why

Issue #202: tools that run `--diff` in CI currently have to parse `REGRESSED / NEW / IMPROVED` lines from the terminal output, which is fragile (line wrapping, format churn). The three names have been stable across releases while internal helpers around them churn — exactly why importing from `utils.diff` directly is unsafe. Making them public turns the diff analysis into a documented compatibility contract.

## Changes

- **Public API** — `complexipy/__init__.py` re-exports `compute_diff`, `has_regressions`, `DiffEntry`, and `DiffStatus`
- **`DiffStatus` enum** — new `str`-based enum for status values; `e.status == "REGRESSED"` still works, but callers get named constants (`DiffStatus.REGRESSED`) instead of magic strings
- **`compute_diff`** — `invocation_path` is now optional and defaults to the current working directory
- **Path resolution fix** — `file_complexity()` now returns cwd-relative paths (matching `git diff --name-only`), and `_resolve_git_path` falls back to a `git ls-files` basename lookup for nested invocations. Without this, the issue's usage pattern (`[file_complexity(p) for p in changed_files]`) silently marked every function as NEW
- **Docs** — new "Comparing Against a Git Reference" section in `docs/usage-guide.md` and `docs/es/usage-guide.md`; `compute_diff` / `has_regressions` / `DiffEntry` / `DiffStatus` added to the API Reference in `docs/index.md` and `docs/es/index.md`
- **Tests** — real-git end-to-end test of the issue's CI flow (init repo → commit → modify → `compute_diff` → status assertions), plus path-shape, basename-fallback, and re-export identity tests (61 → 67 in `tests/test_diff.py`)
- **AGENTS.md** — records the new invariant: `complexipy/__init__.py` exports and their signatures are a compatibility promise

Closes #202