### PR TITLE
feat(ignore): report removable ignore comments automatically

### DIFF
--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -20,6 +20,8 @@ Before staging or committing:
 1. Check project guidance files when present, such as `AGENTS.md`, `CONTRIBUTING.md`,
    `README.md`, or `.github/` templates.
 1. Follow explicit project conventions over this generic default.
+1. Derive the repo's commit shape from the log — subject-only vs bodies, scoped vs
+   unscoped, bundled vs split — and match it.
 
 If no stronger project convention exists, use Conventional Commits.
 
@@ -85,6 +87,12 @@ ______________________________________________________________________
 ## Body
 
 Add a body only when the subject cannot explain the why, risk, or migration impact.
+
+If recent commits in this repo are subject-only, stay subject-only: write a subject
+that carries the intent rather than compensating with a body. The exceptions are
+breaking changes (`BREAKING CHANGE:`) and migration/rollout impact. When the repo
+merges via PRs with descriptions, the PR description — not the commit body — is
+where the explanation belongs.
 
 Body rules:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,13 +159,15 @@ complexipy/main.py       Typer CLI — pure orchestrator, no logic of its own
 
 Every Rust-side type crosses into Python through `src/classes.rs` (`FileComplexity`,
 `FunctionComplexity`, `LineComplexity`, `RefactorPlan`, `CodeSuggestion`,
-`RuleCategory`, `Applicability`, `IgnoredLocation`, `CodeComplexity`). Changing one of
+`RuleCategory`, `Applicability`, `IgnoredLocation`, `RemovableIgnore`,
+`CodeComplexity`). Changing one of
 those structs means updating **three** places in lockstep: `src/classes.rs` → the
 `#[pymodule]` export list in `src/lib.rs` → the stubs in `complexipy/_complexipy.pyi`.
 
 `complexipy/__init__.py` is the public Python API surface: `code_complexity`,
-`file_complexity`, `collect_all_ignored_locations`, `compute_diff`, `has_regressions`,
-and the `DiffEntry` / `DiffStatus` types. Those exports, their signatures, and the
+`file_complexity`, `collect_all_ignored_locations`,
+`collect_removable_ignored_locations`, `compute_diff`, `has_regressions`, and the
+`DiffEntry` / `DiffStatus` types. Those exports, their signatures, and the
 `DiffStatus` values are a compatibility promise — internal refactors must keep them
 stable, and new exports belong in `__init__.py` + `__all__` with docs in `docs/` (EN + ES).
 
@@ -181,7 +183,8 @@ stable, and new exports belong in `__init__.py` + `__all__` with docs in `docs/`
   structure, they consume regions.
 - `src/rules/` — the refactor rule system (see below).
 - `src/runner.rs` — path/dir/git-URL expansion, exclusion globs, progress bar, and the
-  `#[pyfunction]`s (`main`, `file_complexity`, `collect_all_ignored_locations`).
+  `#[pyfunction]`s (`main`, `file_complexity`, `collect_all_ignored_locations`,
+  `collect_removable_ignored_locations`).
 - `src/utils.rs` — CSV/JSON writers, snapshot file I/O, and AST helpers
   (`count_bool_ops`, noqa/ignore-comment scanning).
 - `src/wasm.rs` — the browser entry point; calls the same

--- a/complexipy/__init__.py
+++ b/complexipy/__init__.py
@@ -9,8 +9,10 @@ from complexipy._complexipy import (
     IgnoredLocation,
     LineComplexity,
     RefactorPlan,
+    RemovableIgnore,
     RuleCategory,
     collect_all_ignored_locations,
+    collect_removable_ignored_locations,
 )
 from complexipy.api import (
     code_complexity,
@@ -34,9 +36,11 @@ __all__ = [
     "IgnoredLocation",
     "LineComplexity",
     "RefactorPlan",
+    "RemovableIgnore",
     "RuleCategory",
     "code_complexity",
     "collect_all_ignored_locations",
+    "collect_removable_ignored_locations",
     "compute_diff",
     "file_complexity",
     "has_regressions",

--- a/complexipy/_complexipy.pyi
+++ b/complexipy/_complexipy.pyi
@@ -415,6 +415,45 @@ class IgnoredLocation:
 
     def __init__(self, path: str, line: int, comment: str) -> None: ...
 
+class RemovableIgnore:
+    """
+    Represents an ignore comment that is no longer necessary because the
+    suppressed function's complexity is within the allowed limit.
+
+    This class backs the automatic report of stale ignore comments shown
+    at the end of every analysis run, and the
+    `collect_removable_ignored_locations()` API.
+
+    Example:
+        >>> rem = RemovableIgnore(
+        ...     path="src/legacy.py",
+        ...     line=42,
+        ...     comment="# complexipy: ignore",
+        ...     function="parse_legacy_config",
+        ...     complexity=8
+        ... )
+        >>> print(f"{rem.path}:{rem.line}  {rem.comment} can be removed")
+    """
+
+    path: str
+    """Relative path to the file containing the ignore comment."""
+
+    line: int
+    """Line number (1-indexed) of the function the ignore comment suppresses."""
+
+    comment: str
+    """The canonical ignore marker (e.g. '# complexipy: ignore' or '# noqa: complexipy')."""
+
+    function: str
+    """Name of the function the ignore comment suppresses."""
+
+    complexity: int
+    """The function's cognitive complexity measured without the ignore comment."""
+
+    def __init__(
+        self, path: str, line: int, comment: str, function: str, complexity: int
+    ) -> None: ...
+
 def main(
     paths: List[str],
     quiet: bool,
@@ -725,5 +764,46 @@ def collect_all_ignored_locations(
         ... )
         >>> for loc in locations:
         ...     print(f"{loc.path}:{loc.line}  {loc.comment}")
+    """
+    ...
+
+def collect_removable_ignored_locations(
+    paths: List[str],
+    exclude: List[str],
+    max_complexity_allowed: int,
+    invocation_path: str = ".",
+) -> Tuple[List[RemovableIgnore], List[str]]:
+    """
+    Scan all processed Python files for ignore comments that are no longer
+    necessary because the suppressed function's complexity is within the
+    allowed limit.
+
+    This is the backend for the automatic stale-ignore report shown at the
+    end of every analysis run. It discovers the same set of files as the
+    main analysis (respecting --exclude and .gitignore), computes each
+    suppressed function's complexity as if the ignore comment were absent,
+    and keeps only the markers whose function complexity is less than or
+    equal to `max_complexity_allowed`.
+
+    Args:
+        paths: List of file paths, directory paths, or Git repository URLs.
+        exclude: List of file/directory paths or globs to exclude from scanning.
+        max_complexity_allowed: Complexity threshold; markers suppressing
+            functions at or below this value are reported as removable.
+        invocation_path: Working directory for resolving relative paths.
+
+    Returns:
+        A tuple of (removable_ignores, failed_paths) where:
+        - removable_ignores: List of RemovableIgnore objects, sorted by (path, line).
+        - failed_paths: List of paths that could not be processed.
+
+    Example:
+        >>> removable, failed = collect_removable_ignored_locations(
+        ...     paths=["/project/src"],
+        ...     exclude=["tests/"],
+        ...     max_complexity_allowed=15,
+        ... )
+        >>> for rem in removable:
+        ...     print(f"{rem.path}:{rem.line}  function={rem.function} complexity={rem.complexity}")
     """
     ...

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -36,7 +36,10 @@ from complexipy.utils.diff import (
     has_regressions,
     resolve_diff_flags,
 )
-from complexipy.utils.ignored import handle_report_ignored
+from complexipy.utils.ignored import (
+    handle_removable_ignores,
+    handle_report_ignored,
+)
 from complexipy.utils.output import (
     emit_deprecated_output_warnings,
     handle_console_settings,
@@ -355,6 +358,15 @@ def main(
         cfg.no_ignore,
         INVOCATION_PATH,
     )
+
+    if not cfg.quiet:
+        handle_removable_ignores(
+            console,
+            cfg.paths,
+            cfg.exclude,
+            cfg.max_complexity_allowed,
+            INVOCATION_PATH,
+        )
 
     if cfg.quiet:
         snapshot_ok = snap.watermark_success if snap.should_run else True

--- a/complexipy/utils/ignored.py
+++ b/complexipy/utils/ignored.py
@@ -56,3 +56,26 @@ def handle_report_ignored(
             json.dump(ignored_data, f, indent=2)
             f.write("\n")
         console.print(f"Ignored locations saved at {ignored_json_path}")
+
+
+def handle_removable_ignores(
+    console: Console,
+    paths: Optional[List[str]],
+    exclude: Optional[List[str]],
+    max_complexity_allowed: int,
+    invocation_path: str,
+) -> None:
+    removable_ignores, _ = _complexipy.collect_removable_ignored_locations(
+        paths or [], exclude or [], max_complexity_allowed, invocation_path
+    )
+    if not removable_ignores:
+        return
+    console.print(
+        "\nThe following ignore comment(s) are no longer necessary "
+        "(complexity is within the allowed limit) and can be removed:"
+    )
+    for rem in removable_ignores:
+        console.print(
+            f"{rem.path}:{rem.line}  function={rem.function} "
+            f"complexity={rem.complexity}  {rem.comment}"
+        )

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -701,6 +701,41 @@ for loc in locations:
     print(f"{loc.path}:{loc.line}  {loc.comment}")
 ```
 
+### Eliminar Comentarios de Ignore Obsoletos
+
+Un comentario de ignore solo es necesario mientras la complejidad de la función
+suprimida supere `--max-complexity-allowed`. Cuando la complejidad de la función
+baje al límite o por debajo de él, el comentario queda obsoleto y puede
+eliminarse. complexipy detecta esto automáticamente en cada ejecución e informa
+las ubicaciones que puedes limpiar:
+
+```bash
+complexipy .
+```
+
+Ejemplo de salida:
+
+```text
+The following ignore comment(s) are no longer necessary (complexity is within the allowed limit) and can be removed:
+src/legacy.py:42  function=parse_legacy_config complexity=8  # complexipy: ignore
+```
+
+El informe es puramente informativo: nunca afecta al código de salida y se
+suprime bajo `--quiet`. La misma detección está disponible programáticamente vía
+`collect_removable_ignored_locations()`:
+
+```python
+from complexipy import collect_removable_ignored_locations
+
+removable, failed = collect_removable_ignored_locations(
+    paths=["src"],
+    exclude=["tests/"],
+    max_complexity_allowed=15,
+)
+for rem in removable:
+    print(f"{rem.path}:{rem.line}  function={rem.function} complexity={rem.complexity}")
+```
+
 ## Integración con CI/CD
 
 ### GitHub Actions

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -703,6 +703,40 @@ for loc in locations:
     print(f"{loc.path}:{loc.line}  {loc.comment}")
 ```
 
+### Removing Stale Ignore Comments
+
+An ignore comment is only necessary while the suppressed function's complexity
+exceeds `--max-complexity-allowed`. Once the function's complexity drops to or
+below the limit, the comment is stale and can be removed. complexipy detects
+this automatically on every run and reports the locations to clean up:
+
+```bash
+complexipy .
+```
+
+Example output:
+
+```text
+The following ignore comment(s) are no longer necessary (complexity is within the allowed limit) and can be removed:
+src/legacy.py:42  function=parse_legacy_config complexity=8  # complexipy: ignore
+```
+
+The report is purely informational: it never affects the exit code, and it is
+suppressed under `--quiet`. The same detection is available programmatically
+via `collect_removable_ignored_locations()`:
+
+```python
+from complexipy import collect_removable_ignored_locations
+
+removable, failed = collect_removable_ignored_locations(
+    paths=["src"],
+    exclude=["tests/"],
+    max_complexity_allowed=15,
+)
+for rem in removable:
+    print(f"{rem.path}:{rem.line}  function={rem.function} complexity={rem.complexity}")
+```
+
 ## CI/CD Integration
 
 ### GitHub Actions

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -158,3 +158,18 @@ pub struct IgnoredLocation {
     pub line: u64,
     pub comment: String,
 }
+
+#[cfg(feature = "python")]
+#[cfg_attr(
+    feature = "python",
+    pyclass(module = "complexipy", get_all, from_py_object)
+)]
+#[cfg_attr(feature = "python", derive(Serialize, Deserialize))]
+#[derive(Clone)]
+pub struct RemovableIgnore {
+    pub path: String,
+    pub line: u64,
+    pub comment: String,
+    pub function: String,
+    pub complexity: u64,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,12 @@ use pyo3::prelude::*;
 mod _complexipy {
     use super::classes::{
         Applicability, CodeComplexity, CodeSuggestion, FileComplexity, FunctionComplexity,
-        IgnoredLocation, LineComplexity, RefactorPlan, RuleCategory,
+        IgnoredLocation, LineComplexity, RefactorPlan, RemovableIgnore, RuleCategory,
     };
     use super::cognitive_complexity::code_complexity;
-    use super::runner::{collect_all_ignored_locations, file_complexity, main};
+    use super::runner::{
+        collect_all_ignored_locations, collect_removable_ignored_locations, file_complexity, main,
+    };
     use super::utils::{create_snapshot_file, load_snapshot_file, output_csv, output_json};
     use pyo3::prelude::*;
 
@@ -33,6 +35,7 @@ mod _complexipy {
         m.add_function(wrap_pyfunction!(file_complexity, m)?)?;
         m.add_function(wrap_pyfunction!(code_complexity, m)?)?;
         m.add_function(wrap_pyfunction!(collect_all_ignored_locations, m)?)?;
+        m.add_function(wrap_pyfunction!(collect_removable_ignored_locations, m)?)?;
         m.add_function(wrap_pyfunction!(output_csv, m)?)?;
         m.add_function(wrap_pyfunction!(output_json, m)?)?;
         m.add_function(wrap_pyfunction!(create_snapshot_file, m)?)?;
@@ -45,6 +48,7 @@ mod _complexipy {
         m.add_class::<IgnoredLocation>()?;
         m.add_class::<LineComplexity>()?;
         m.add_class::<RefactorPlan>()?;
+        m.add_class::<RemovableIgnore>()?;
         m.add_class::<RuleCategory>()?;
         Ok(())
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,16 +1,17 @@
-use crate::classes::{FileComplexity, IgnoredLocation};
-use crate::cognitive_complexity::code_complexity;
+use crate::classes::{FileComplexity, IgnoredLocation, RemovableIgnore};
+use crate::cognitive_complexity::{code_complexity, function_level_cognitive_complexity_shared};
 use crate::helpers::exclude::get_paths_to_process;
-use crate::utils::{collect_ignored_locations, get_repo_name};
+use crate::utils::{collect_ignored_locations, filter_removable_ignores, get_repo_name};
 use indicatif::ProgressBar;
 use indicatif::ProgressStyle;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use regex::Regex;
+use ruff_python_parser::parse_module;
 use std::env;
 use std::path;
 use std::process;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use tempfile::tempdir;
 
@@ -35,14 +36,11 @@ pub fn main(
 ) -> PyResult<ComplexitiesAndFailedPaths> {
     let _ = invocation_path;
 
-    let re = Regex::new(r"^(https:\/\/|http:\/\/|www\.|git@)(github|gitlab)\.com(\/[\w.-]+){2,}$")
-        .map_err(|e| PyValueError::new_err(format!("Invalid repository pattern: {}", e)))?;
-
     let mut successful = Vec::new();
     let mut failed_paths = Vec::new();
 
     for path in paths {
-        let is_url = re.is_match(&path);
+        let is_url = is_repo_url(&path);
         let path_obj = path::Path::new(&path);
         let exists = path_obj.exists();
         let is_dir = path_obj.is_dir();
@@ -306,24 +304,63 @@ pub fn collect_all_ignored_locations(
     let _invocation_dir = path::Path::new(invocation_path)
         .canonicalize()
         .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
+    collect_locations(&paths, &exclude, collect_file_ignored_locations)
+}
 
+#[pyfunction]
+#[pyo3(signature = (paths, exclude, max_complexity_allowed, invocation_path="."))]
+pub fn collect_removable_ignored_locations(
+    paths: Vec<String>,
+    exclude: Vec<String>,
+    max_complexity_allowed: u64,
+    invocation_path: &str,
+) -> PyResult<(Vec<RemovableIgnore>, Vec<String>)> {
+    let _invocation_dir = path::Path::new(invocation_path)
+        .canonicalize()
+        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
+    collect_locations(&paths, &exclude, |file_path, base_dir| {
+        collect_removable_ignores_from_file(file_path, base_dir, max_complexity_allowed)
+    })
+}
+
+trait Located {
+    fn sort_key(&self) -> (String, u64);
+}
+
+impl Located for IgnoredLocation {
+    fn sort_key(&self) -> (String, u64) {
+        (self.path.clone(), self.line)
+    }
+}
+
+impl Located for RemovableIgnore {
+    fn sort_key(&self) -> (String, u64) {
+        (self.path.clone(), self.line)
+    }
+}
+
+fn collect_locations<T, F>(
+    paths: &[String],
+    exclude: &[String],
+    collect_file: F,
+) -> PyResult<(Vec<T>, Vec<String>)>
+where
+    T: Located,
+    F: Fn(&str, &str) -> PyResult<Vec<T>> + Copy,
+{
     let mut all_locations = Vec::new();
     let mut failed_paths = Vec::new();
 
-    let re = Regex::new(r"^(https:\/\/|http:\/\/|www\.|git@)(github|gitlab)\.com(\/[\w.-]+){2,}$")
-        .map_err(|e| PyValueError::new_err(format!("Invalid repository pattern: {}", e)))?;
-
-    for path_str in &paths {
+    for path_str in paths {
         let path_obj = path::Path::new(path_str);
-        let is_url = re.is_match(path_str);
 
-        if is_url {
-            match collect_ignored_locations_from_url(path_str, &exclude) {
+        if is_repo_url(path_str) {
+            match collect_from_url(path_str, exclude, collect_file) {
                 Ok(locs) => all_locations.extend(locs),
                 Err(_) => failed_paths.push(path_str.to_string()),
             }
         } else if path_obj.is_dir() {
-            let files = match get_paths_to_process(path_str, exclude.clone()) {
+            let files = match get_paths_to_process(path_str, exclude.to_vec()) {
                 Ok(paths) => paths,
                 Err(e) => {
                     failed_paths.push(format!("{}: {}", path_str, e));
@@ -338,13 +375,13 @@ pub fn collect_all_ignored_locations(
                 .to_string_lossy()
                 .replace('\\', "/");
             for file_path in &files {
-                if let Ok(locs) = collect_file_ignored_locations(file_path, &base_dir) {
+                if let Ok(locs) = collect_file(file_path, &base_dir) {
                     all_locations.extend(locs)
                 }
             }
         } else if path_obj.is_file() {
             let parent_dir = path_obj.parent().and_then(|p| p.to_str()).unwrap_or(".");
-            if let Ok(locs) = collect_file_ignored_locations(path_str, parent_dir) {
+            if let Ok(locs) = collect_file(path_str, parent_dir) {
                 all_locations.extend(locs)
             }
         } else {
@@ -352,14 +389,20 @@ pub fn collect_all_ignored_locations(
         }
     }
 
-    all_locations.sort_by_key(|loc| (loc.path.clone(), loc.line));
+    all_locations.sort_by_key(Located::sort_key);
     Ok((all_locations, failed_paths))
 }
 
-fn collect_ignored_locations_from_url(
-    url: &str,
-    exclude: &[String],
-) -> PyResult<Vec<IgnoredLocation>> {
+fn is_repo_url(path: &str) -> bool {
+    static REPO_URL_RE: OnceLock<Regex> = OnceLock::new();
+    let re = REPO_URL_RE.get_or_init(|| {
+        Regex::new(r"^(https:\/\/|http:\/\/|www\.|git@)(github|gitlab)\.com(\/[\w.-]+){2,}$")
+            .expect("valid repository pattern")
+    });
+    re.is_match(path)
+}
+
+fn clone_repo_to_tempdir(url: &str) -> PyResult<(tempfile::TempDir, String)> {
     let dir = tempdir()?;
     let repo_name = get_repo_name(url)?;
     env::set_current_dir(&dir)?;
@@ -389,6 +432,14 @@ fn collect_ignored_locations_from_url(
     }
 
     let repo_path = dir.path().join(&repo_name).to_string_lossy().to_string();
+    Ok((dir, repo_path))
+}
+
+fn collect_from_url<T, F>(url: &str, exclude: &[String], collect_file: F) -> PyResult<Vec<T>>
+where
+    F: Fn(&str, &str) -> PyResult<Vec<T>>,
+{
+    let (dir, repo_path) = clone_repo_to_tempdir(url)?;
     let files =
         get_paths_to_process(&repo_path, exclude.to_vec()).map_err(PyValueError::new_err)?;
     let base_dir = path::Path::new(&repo_path)
@@ -401,11 +452,46 @@ fn collect_ignored_locations_from_url(
 
     let mut locations = Vec::new();
     for file_path in &files {
-        if let Ok(locs) = collect_file_ignored_locations(file_path, &base_dir) {
+        if let Ok(locs) = collect_file(file_path, &base_dir) {
             locations.extend(locs);
         }
     }
 
     dir.close()?;
     Ok(locations)
+}
+
+fn collect_removable_ignores_from_file(
+    file_path: &str,
+    base_path: &str,
+    max_complexity_allowed: u64,
+) -> PyResult<Vec<RemovableIgnore>> {
+    let path = path::Path::new(file_path);
+    let relative_path = path
+        .strip_prefix(base_path)
+        .ok()
+        .and_then(|p| p.to_str())
+        .unwrap_or(file_path);
+    let code = std::fs::read_to_string(file_path).map_err(|e| {
+        PyValueError::new_err(format!("Failed to read file '{}': {}", file_path, e))
+    })?;
+    let locations = collect_ignored_locations(&code);
+    if locations.is_empty() {
+        return Ok(vec![]);
+    }
+    let parsed = parse_module(&code)
+        .map_err(|e| PyValueError::new_err(format!("Failed to parse code: {}", e)))?;
+    let ast_body = parsed.into_suite();
+    let (functions, _) = function_level_cognitive_complexity_shared(&ast_body, &code, false, true);
+    let removable = filter_removable_ignores(&locations, &functions, max_complexity_allowed);
+    Ok(removable
+        .into_iter()
+        .map(|(line, comment, function, complexity)| RemovableIgnore {
+            path: relative_path.to_string(),
+            line,
+            comment,
+            function,
+            complexity,
+        })
+        .collect())
 }

--- a/src/tests/removable.rs
+++ b/src/tests/removable.rs
@@ -1,0 +1,95 @@
+//! Unit tests for `crate::utils::filter_removable_ignores`.
+//!
+//! Wired in from `src/utils.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+//! so this stays a child module of the code it tests and can reach that
+//! module's private helpers through `super::` without widening visibility.
+
+use crate::classes::FunctionComplexity;
+
+fn function(name: &str, complexity: u64, line_start: u64, line_end: u64) -> FunctionComplexity {
+    FunctionComplexity {
+        name: name.to_string(),
+        complexity,
+        line_start,
+        line_end,
+        line_complexities: vec![],
+        refactor_plans: vec![],
+        additional_refactor_plans: 0,
+    }
+}
+
+#[test]
+fn marker_below_threshold_is_removable() {
+    let locations = vec![(1, "# complexipy: ignore".to_string())];
+    let functions = vec![function("simple", 2, 1, 3)];
+    let removable = super::filter_removable_ignores(&locations, &functions, 15);
+    assert_eq!(
+        removable,
+        vec![(
+            1,
+            "# complexipy: ignore".to_string(),
+            "simple".to_string(),
+            2
+        )]
+    );
+}
+
+#[test]
+fn marker_at_threshold_is_removable() {
+    let locations = vec![(5, "# complexipy: ignore".to_string())];
+    let functions = vec![function("edge", 15, 5, 9)];
+    let removable = super::filter_removable_ignores(&locations, &functions, 15);
+    assert_eq!(removable.len(), 1);
+}
+
+#[test]
+fn marker_above_threshold_is_kept() {
+    let locations = vec![(1, "# complexipy: ignore".to_string())];
+    let functions = vec![function("complex_fn", 20, 1, 12)];
+    let removable = super::filter_removable_ignores(&locations, &functions, 15);
+    assert!(removable.is_empty());
+}
+
+#[test]
+fn marker_matches_containing_function_range() {
+    let locations = vec![(3, "# noqa: complexipy".to_string())];
+    let functions = vec![function("decorated", 4, 1, 9)];
+    let removable = super::filter_removable_ignores(&locations, &functions, 15);
+    assert_eq!(removable.len(), 1);
+    assert_eq!(removable[0].2, "decorated");
+}
+
+#[test]
+fn marker_without_containing_function_is_skipped() {
+    let locations = vec![(7, "# complexipy: ignore".to_string())];
+    let functions = vec![function("first", 2, 1, 5), function("second", 3, 9, 11)];
+    let removable = super::filter_removable_ignores(&locations, &functions, 15);
+    assert!(removable.is_empty());
+}
+
+#[test]
+fn marker_never_matches_ignored_analysis() {
+    let locations = vec![(2, "# complexipy: ignore".to_string())];
+    let functions: Vec<FunctionComplexity> = vec![];
+    let removable = super::filter_removable_ignores(&locations, &functions, 15);
+    assert!(removable.is_empty());
+}
+
+#[test]
+fn multiple_markers_keep_source_order() {
+    let locations = vec![
+        (1, "# complexipy: ignore".to_string()),
+        (9, "# noqa: complexipy".to_string()),
+    ];
+    let functions = vec![
+        function("low", 3, 1, 4),
+        function("high", 30, 6, 20),
+        function("low_again", 5, 22, 30),
+    ];
+    let removable = super::filter_removable_ignores(&locations, &functions, 15);
+    assert_eq!(removable.len(), 1);
+    assert_eq!(
+        removable[0],
+        (1, "# complexipy: ignore".to_string(), "low".to_string(), 3)
+    );
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -555,3 +555,36 @@ pub fn collect_ignored_locations(code: &str) -> Vec<(u64, String)> {
 
     results
 }
+
+/// Keep only the ignored locations whose containing function no longer
+/// exceeds the allowed complexity threshold.
+///
+/// Returns `(line, comment, function_name, complexity)` for each removable
+/// marker; the function's complexity is measured without the marker applied.
+#[cfg(feature = "python")]
+pub fn filter_removable_ignores(
+    locations: &[(u64, String)],
+    functions: &[FunctionComplexity],
+    max_complexity_allowed: u64,
+) -> Vec<(u64, String, String, u64)> {
+    let mut removable = Vec::new();
+    for (line, comment) in locations {
+        if let Some(function) = functions
+            .iter()
+            .find(|f| *line >= f.line_start && *line <= f.line_end)
+            && function.complexity <= max_complexity_allowed
+        {
+            removable.push((
+                *line,
+                comment.clone(),
+                function.name.clone(),
+                function.complexity,
+            ));
+        }
+    }
+    removable
+}
+
+#[cfg(test)]
+#[path = "tests/removable.rs"]
+mod tests;

--- a/tests/main.py
+++ b/tests/main.py
@@ -436,6 +436,196 @@ def hello_world(s: str) -> str:
         assert "sample.py:1" in result.output
         assert "Found 1 suppressed location(s)" in result.output
 
+    # ── Removable ignore comments tests ──────────────────────────────
+
+    def test_removable_ignores_reported_automatically(
+        self, tmp_path, monkeypatch
+    ):
+        """Runs report ignore comments whose function is within the limit."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            "def simple(a):  # complexipy: ignore\n"
+            "    return a\n"
+            "\n"
+            "def complex_fn(a, b):  # complexipy: ignore\n"
+            "    if a and b:\n"
+            "        return a + b\n"
+            "    elif a or b:\n"
+            "        return a or b\n"
+            "    else:\n"
+            "        return 0\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            main_module.app,
+            ["--max-complexity-allowed", "5", str(source_file)],
+        )
+        assert result.exit_code == 0
+        assert "sample.py:1" in result.output
+        assert "function=simple" in result.output
+        assert "complexity=0" in result.output
+        assert "function=complex_fn" not in result.output
+
+    def test_removable_ignores_at_threshold(self, tmp_path, monkeypatch):
+        """A marker is removable when complexity equals the allowed limit."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            "def simple(a):  # complexipy: ignore\n    return a\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            main_module.app,
+            ["--max-complexity-allowed", "0", str(source_file)],
+        )
+        assert result.exit_code == 0
+        assert "function=simple" in result.output
+        assert "complexity=0" in result.output
+
+    def test_removable_ignores_legacy_noqa_and_decorated(
+        self, tmp_path, monkeypatch
+    ):
+        """Line-above markers, decorators, and legacy noqa are reported."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            "# complexipy: ignore\n"
+            "def above(a):\n"
+            "    return a\n"
+            "\n"
+            "@staticmethod\n"
+            "def decorated(a):  # noqa: complexipy\n"
+            "    return a\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(main_module.app, [str(source_file)])
+        assert result.exit_code == 0
+        assert "function=above" in result.output
+        assert "function=decorated" in result.output
+        assert "# noqa: complexipy" in result.output
+
+    def test_removable_ignores_no_markers(self, tmp_path, monkeypatch):
+        """A clean file produces no removable-ignore report."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "clean.py"
+        source_file.write_text("def foo():\n    return 1\n", encoding="utf-8")
+
+        result = runner.invoke(main_module.app, [str(source_file)])
+        assert result.exit_code == 0
+        assert "can be removed" not in result.output
+
+    def test_removable_ignores_suppressed_under_quiet(
+        self, tmp_path, monkeypatch
+    ):
+        """--quiet suppresses the automatic removable-ignore report."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            "def simple(a):  # complexipy: ignore\n    return a\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(main_module.app, ["--quiet", str(source_file)])
+        assert result.exit_code == 0
+        assert "can be removed" not in result.output
+
+    def test_removable_ignores_respects_exclude(self, tmp_path, monkeypatch):
+        """The removable-ignore report only scans files not excluded."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "a.py").write_text(
+            "def foo():  # complexipy: ignore\n    pass\n", encoding="utf-8"
+        )
+        (tmp_path / "src" / "b.py").write_text(
+            "def bar():  # complexipy: ignore\n    pass\n", encoding="utf-8"
+        )
+
+        result = runner.invoke(
+            main_module.app,
+            ["--exclude", "b.py", str(tmp_path / "src")],
+        )
+        assert result.exit_code == 0
+        assert "function=foo" in result.output
+        assert "function=bar" not in result.output
+
+    def test_removable_ignores_printed_with_failed(self, tmp_path, monkeypatch):
+        """The report still prints when --failed filters the display."""
+        import complexipy.main as main_module
+
+        runner = CliRunner()
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(tmp_path))
+
+        source_file = tmp_path / "sample.py"
+        source_file.write_text(
+            "def simple(a):  # complexipy: ignore\n"
+            "    return a\n"
+            "\n"
+            "def no_marker(a, b):\n"
+            "    if a and b:\n"
+            "        return a + b\n"
+            "    elif a or b:\n"
+            "        return a or b\n"
+            "    else:\n"
+            "        return 0\n",
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            main_module.app,
+            ["--failed", "--max-complexity-allowed", "5", str(source_file)],
+        )
+        assert result.exit_code == 1
+        assert "no_marker" in result.output
+        assert "function=simple" in result.output
+
+    def test_collect_removable_ignored_locations_api(self, tmp_path):
+        """Python API: collect_removable_ignored_locations returns removable markers."""
+        from complexipy import collect_removable_ignored_locations
+
+        source = tmp_path / "app.py"
+        source.write_text(
+            "def simple(a):  # complexipy: ignore\n    return a\n",
+            encoding="utf-8",
+        )
+        removable, failed = collect_removable_ignored_locations(
+            [str(source)], [], 15
+        )
+        assert failed == []
+        assert len(removable) == 1
+        assert removable[0].path == "app.py"
+        assert removable[0].line == 1
+        assert removable[0].function == "simple"
+        assert removable[0].complexity == 0
+        assert removable[0].comment == "# complexipy: ignore"
+
     def test_exclude(self):
         path = self.local_path / "src"
         files, _ = _complexipy.main(


### PR DESCRIPTION
## What

Automatically report `# complexipy: ignore` and `# noqa: complexipy` comments that are no longer necessary, because the suppressed function's complexity is now within `--max-complexity-allowed`.

## Why

Issue #183: an ignore comment is only needed while its function exceeds the allowed complexity limit. Once code is refactored below the limit, the comment is stale but nothing told users it could be removed. This implements option 1 of the issue — report the locations to clean up — without the risk of auto-removing comments that carry user context (e.g. technical-debt reasons).

## Changes

- Rust core: new `collect_removable_ignored_locations()` pyfunction with a new `RemovableIgnore` type (path, line, comment, function, complexity); shares a generic `collect_locations` walk with the existing ignore-location collector (files, directories, git URLs, `--exclude`)
- CLI: every run ends with an informational report of removable ignores (`path:line  function=X complexity=N  <comment>`) — exit code unaffected, suppressed under `--quiet`, works under `--plain`
- Public API: `collect_removable_ignored_locations()` and `RemovableIgnore` exported from `complexipy`
- Tests: 7 Rust unit tests + 8 CLI/API tests covering threshold boundary, decorators, legacy `# noqa`, `--exclude`, `--quiet`, `--failed`
- Docs: "Removing Stale Ignore Comments" section in `docs/usage-guide.md` (EN + ES)
- `AGENTS.md` kept current (FFI classes, public API surface, runner pyfunctions)
- Rides along: `chore(skills)` updating the git-commit skill to match this repo's subject-only commit shape
