### PR TITLE
fix(snapshot): preserve baseline on partial runs

### DIFF
--- a/complexipy/utils/snapshot.py
+++ b/complexipy/utils/snapshot.py
@@ -20,8 +20,11 @@ def handle_snapshot_file_creation(
     files_complexities: List[FileComplexity],
 ) -> None:
     if create_snapshot:
+        snapshot_files = handle_snapshot_functions_load(snapshot_file_path)
         create_snapshot_file(
-            snapshot_file_path, max_complexity_allowed, files_complexities
+            snapshot_file_path,
+            max_complexity_allowed,
+            merge_snapshot_files(snapshot_files, files_complexities),
         )
 
 
@@ -32,6 +35,23 @@ def handle_snapshot_functions_load(
         return load_snapshot_file(snapshot_file_path)
     else:
         return []
+
+
+def merge_snapshot_files(
+    snapshot_files: List[FileComplexity],
+    files_complexities: List[FileComplexity],
+) -> List[FileComplexity]:
+    analyzed_keys = {
+        (file_complexity.path, file_complexity.file_name)
+        for file_complexity in files_complexities
+    }
+    preserved = [
+        file_complexity
+        for file_complexity in snapshot_files
+        if (file_complexity.path, file_complexity.file_name)
+        not in analyzed_keys
+    ]
+    return [*preserved, *files_complexities]
 
 
 def handle_snapshot_watermark(
@@ -88,7 +108,9 @@ def handle_snapshot_watermark(
         return False, violations
 
     create_snapshot_file(
-        snapshot_file_path, max_complexity_allowed, files_complexities
+        snapshot_file_path,
+        max_complexity_allowed,
+        merge_snapshot_files(snapshot_files, files_complexities),
     )
 
     return True, []

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -294,6 +294,8 @@ El archivo de snapshot solo almacena las funciones cuya complejidad supera el um
 - falla si una función registrada se vuelve más compleja, y
 - pasa (y actualiza la snapshot) cuando todo es estable o ha mejorado, eliminando automáticamente las entradas que ahora cumplen el estándar.
 
+Las actualizaciones de la snapshot solo afectan a los archivos analizados en la ejecución: las entradas de archivos fuera del análisis se conservan, por lo que ejecutar sobre un subconjunto de archivos (por ejemplo, a través de un hook de pre-commit) nunca reduce la línea base.
+
 Usa `--snapshot-ignore` si necesitas omitir temporalmente el control de snapshot (por ejemplo, durante una refactorización o al regenerar la línea base).
 
 ### Diff de Complejidad

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -618,7 +618,7 @@ complexipy . --snapshot-ignore
 ]
 ```
 
-Los snapshots se guardan como un arreglo JSON de archivos analizados. Cada entrada contiene solo las funciones por encima del umbral cuando se escribió el snapshot. El archivo se reescribe después de verificaciones de snapshot exitosas, así que las funciones que mejoran se eliminan automáticamente. Es posible que los snapshots creados por versiones anteriores de complexipy deban regenerarse con `--snapshot-create`.
+Los snapshots se guardan como un arreglo JSON de archivos analizados. Cada entrada contiene solo las funciones por encima del umbral cuando se escribió el snapshot. El archivo se reescribe después de verificaciones de snapshot exitosas, así que las funciones que mejoran se eliminan automáticamente. Las actualizaciones solo afectan a los archivos analizados en la ejecución — las entradas de archivos fuera del análisis se conservan, por lo que ejecutar sobre un subconjunto de archivos (por ejemplo, a través de un hook de pre-commit) nunca reduce la línea base. Es posible que los snapshots creados por versiones anteriores de complexipy deban regenerarse con `--snapshot-create`.
 
 ## Ignorar en Línea
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -293,6 +293,8 @@ The snapshot file only stores functions whose complexity exceeds the configured 
 - fail if a tracked function becomes more complex, and
 - pass (and update the snapshot) when everything is stable or improved, automatically removing entries that now meet the standard.
 
+Snapshot updates only touch the files analyzed in the run: entries for files outside the analysis are preserved, so running on a subset of files (for example through a pre-commit hook) never shrinks the baseline.
+
 Use `--snapshot-ignore` if you need to temporarily bypass the snapshot gate (for example during a refactor or while regenerating the baseline).
 
 ### Complexity Diff

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -620,7 +620,7 @@ Use this when:
 ]
 ```
 
-Snapshots are stored as a JSON array of analyzed files. Each entry contains only functions above the threshold at the time the snapshot was written. The file is rewritten after successful snapshot checks, so improved functions are removed automatically. Snapshots created by older complexipy versions may need to be regenerated with `--snapshot-create`.
+Snapshots are stored as a JSON array of analyzed files. Each entry contains only functions above the threshold at the time the snapshot was written. The file is rewritten after successful snapshot checks, so improved functions are removed automatically. Updates only touch the files analyzed in the run — entries for files outside the analysis are preserved, so running on a subset of files (for example through a pre-commit hook) never shrinks the baseline. Snapshots created by older complexipy versions may need to be regenerated with `--snapshot-create`.
 
 ## Inline Ignores
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 
-import pytest
-
 from complexipy import _complexipy
-from complexipy._complexipy import FileComplexity
 from complexipy.utils.snapshot import (
     evaluate_snapshot,
 )
@@ -100,3 +97,62 @@ class TestEvaluateSnapshot:
 
         assert result.should_run is False
         assert result.snapshot_result is True
+
+    def test_partial_run_preserves_unanalyzed_files(self, tmp_path: Path):
+        tracked_a = tmp_path / "tracked_a.py"
+        tracked_a.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_b = tmp_path / "tracked_b.py"
+        tracked_b.write_text(*self.tracked_function_body, encoding="utf-8")
+        files, _ = self._analyze_paths([tracked_a, tracked_b])
+        snapshot_path = tmp_path / self.complexipy_snapshot_file
+
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files)
+
+        files_a, _ = self._analyze_paths([tracked_a])
+        result = evaluate_snapshot(False, False, str(snapshot_path), 0, files_a)
+
+        assert result.watermark_success is True
+        snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
+        assert {entry.file_name for entry in snapshot_files} == {
+            "tracked_a.py",
+            "tracked_b.py",
+        }
+
+    def test_partial_run_removes_improved_function(self, tmp_path: Path):
+        tracked_a = tmp_path / "tracked_a.py"
+        tracked_a.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_b = tmp_path / "tracked_b.py"
+        tracked_b.write_text(*self.tracked_function_body, encoding="utf-8")
+        files, _ = self._analyze_paths([tracked_a, tracked_b])
+        snapshot_path = tmp_path / self.complexipy_snapshot_file
+
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files)
+
+        tracked_a.write_text("def simple():\n    return 1\n", encoding="utf-8")
+        files_a, _ = self._analyze_paths([tracked_a])
+        result = evaluate_snapshot(False, False, str(snapshot_path), 0, files_a)
+
+        assert result.watermark_success is True
+        snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
+        assert [entry.file_name for entry in snapshot_files] == ["tracked_b.py"]
+
+    def test_snapshot_create_partial_run_preserves_baseline(
+        self, tmp_path: Path
+    ):
+        tracked_a = tmp_path / "tracked_a.py"
+        tracked_a.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_b = tmp_path / "tracked_b.py"
+        tracked_b.write_text(*self.tracked_function_body, encoding="utf-8")
+        files, _ = self._analyze_paths([tracked_a, tracked_b])
+        snapshot_path = tmp_path / self.complexipy_snapshot_file
+
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files)
+
+        files_a, _ = self._analyze_paths([tracked_a])
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files_a)
+
+        snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
+        assert {entry.file_name for entry in snapshot_files} == {
+            "tracked_a.py",
+            "tracked_b.py",
+        }


### PR DESCRIPTION
## What

Snapshot updates now merge with the existing snapshot instead of replacing it: only the files analyzed in a run are touched, and entries for unanalyzed files are preserved.

## Why

Issue #212: the pre-commit hook only passes the staged files to complexipy, and the snapshot update was rebuilding `complexipy-snapshot.json` from only the analyzed files. Each commit therefore replaced the baseline with just the committed files — the next commit touching any other legacy file failed with "exceeds N but was not part of the snapshot", making gradual adoption via snapshots impossible. Whole-project CLI runs masked the bug because rebuilding from the full set equals merging.

## Changes

- `snapshot.py`: new `merge_snapshot_files()` helper keeps every snapshot entry whose `(path, file_name)` was not analyzed; applied to both the watermark pass path and the `--snapshot-create` path (which now loads the existing snapshot before writing)
- Ratchet behavior unchanged: improved functions inside analyzed files are still removed automatically
- Tests: 3 new regression tests covering partial-run preservation, improved-function removal on partial runs, and the `--snapshot-create` partial path
- Docs: snapshot sections in `docs/index.md` and `docs/usage-guide.md` (EN + ES) now state that updates only touch analyzed files

Fixes #212
