### PR TITLE
docs(footer): fix footer markdown rendering

### DIFF
--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -463,11 +463,9 @@ ______________________________________________________________________
 
 <div align="center">
 
-<sub>Inspirado en la investigación de <a href="https://www.sonarsource.com/resources/cognitive-complexity/">Complejidad Cognitiva</a> de G. Ann Campbell</sub><br>
-<sub>complexipy es un proyecto independiente y no está afiliado ni respaldado por SonarSource</sub>
-
-**[Documentación](https://rohaquinlop.github.io/complexipy/) • [PyPI](https://pypi.org/project/complexipy/) • [GitHub](https://github.com/rohaquinlop/complexipy)**
-
-<sub>Desarrollado con ❤️ por <a href="https://github.com/rohaquinlop">@rohaquinlop</a> y <a href="https://github.com/rohaquinlop/complexipy/graphs/contributors">colaboradores</a></sub>
+<p style="margin: 0.25rem 0"><sub>Inspirado en la investigación de <a href="https://www.sonarsource.com/resources/cognitive-complexity/">Complejidad Cognitiva</a> de G. Ann Campbell</sub></p>
+<p style="margin: 0.25rem 0"><sub>complexipy es un proyecto independiente y no está afiliado ni respaldado por SonarSource</sub></p>
+<p style="margin: 0.25rem 0"><strong><a href="https://rohaquinlop.github.io/complexipy/">Documentación</a> • <a href="https://pypi.org/project/complexipy/">PyPI</a> • <a href="https://github.com/rohaquinlop/complexipy">GitHub</a></strong></p>
+<p style="margin: 0.25rem 0"><sub>Desarrollado con ❤️ por <a href="https://github.com/rohaquinlop">@rohaquinlop</a> y <a href="https://github.com/rohaquinlop/complexipy/graphs/contributors">colaboradores</a></sub></p>
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -462,11 +462,9 @@ ______________________________________________________________________
 
 <div align="center">
 
-<sub>Inspired by the <a href="https://www.sonarsource.com/resources/cognitive-complexity/">Cognitive Complexity</a> research by G. Ann Campbell</sub><br>
-<sub>complexipy is an independent project and is not affiliated with or endorsed by SonarSource</sub>
-
-**[Documentation](https://rohaquinlop.github.io/complexipy/) • [PyPI](https://pypi.org/project/complexipy/) • [GitHub](https://github.com/rohaquinlop/complexipy)**
-
-<sub>Built with ❤️ by <a href="https://github.com/rohaquinlop">@rohaquinlop</a> and <a href="https://github.com/rohaquinlop/complexipy/graphs/contributors">contributors</a></sub>
+<p style="margin: 0.25rem 0"><sub>Inspired by the <a href="https://www.sonarsource.com/resources/cognitive-complexity/">Cognitive Complexity</a> research by G. Ann Campbell</sub></p>
+<p style="margin: 0.25rem 0"><sub>complexipy is an independent project and is not affiliated with or endorsed by SonarSource</sub></p>
+<p style="margin: 0.25rem 0"><strong><a href="https://rohaquinlop.github.io/complexipy/">Documentation</a> • <a href="https://pypi.org/project/complexipy/">PyPI</a> • <a href="https://github.com/rohaquinlop/complexipy">GitHub</a></strong></p>
+<p style="margin: 0.25rem 0"><sub>Built with ❤️ by <a href="https://github.com/rohaquinlop">@rohaquinlop</a> and <a href="https://github.com/rohaquinlop/complexipy/graphs/contributors">contributors</a></sub></p>
 
 </div>


### PR DESCRIPTION
## What

Fixes the footer of the docs landing page: the markdown links now render as styled links instead of raw `**[Documentation](...)` text.

## Why

Issue #214: the footer wrote markdown (`**[Documentation](...) • [PyPI](...) • [GitHub](...)**`) inside a raw HTML block (`<div align="center">`), and Python-Markdown does not process markdown inside HTML blocks — the links were passed through literally. After converting the links to HTML, the remaining elements were all inline, so the lines collapsed into one run of text; each line is now a block-level `<p>` with a compact margin, rendering as four clean centered lines.

## Changes

- `docs/index.md`: footer link line converted from markdown to HTML (`<strong><a>…</a></strong>`), each footer line wrapped in `<p style="margin: 0.25rem 0">` for proper stacking and tight spacing
- `docs/es/index.md`: same fix for the Spanish page (`Documentación`)
- README footer left untouched — GitHub's GFM renderer does process markdown inside HTML blocks, so it renders correctly

Fixes #214