### PR TITLE
feat(diff): add TOML config for diff section

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,31 @@ Legacy TOML keys such as `output-json = true` and CLI flags such as
 `--output-json` still work for now, but they are deprecated in favor of
 `output-format` and `--output-format`.
 
+#### Diff Configuration
+
+The comparison policy can be declared once in the repo, so CI jobs and
+contributors don't repeat `--diff` flags:
+
+```toml
+# complexipy.toml or .complexipy.toml
+[diff]
+branch = "main"
+staged = true
+```
+
+```toml
+# pyproject.toml
+[tool.complexipy.diff]
+branch = "main"
+staged = true
+```
+
+`branch` makes a plain `complexipy .` behave like `complexipy . --diff main`
+(enforcement included); `staged` enables staged comparison by default. CLI
+flags always take precedence. See the [usage guide](docs/usage-guide.md)
+for details, including the empty-branch opt-out and missing-reference
+behavior.
+
 `check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
 
 ### CLI Options

--- a/complexipy/types.py
+++ b/complexipy/types.py
@@ -1,7 +1,7 @@
 import sys
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, MutableMapping, Optional, TypeVar
+from typing import List, MutableMapping, Optional, TypeVar, Union
 
 if sys.version_info >= (3, 10):
     from typing import TypeAlias
@@ -28,6 +28,8 @@ class OutputFormat(str, Enum):
     sarif = "sarif"
 
 
+TOMLDiffSection: TypeAlias = MutableMapping[str, Union[str, bool]]
+
 TOMLTypes = TypeVar(
     "TOMLTypes",
     int,
@@ -37,6 +39,7 @@ TOMLTypes = TypeVar(
     ColorTypes,
     OutputFormat,
     Sort,
+    TOMLDiffSection,
 )
 
 TOMLType: TypeAlias = MutableMapping[str, TOMLTypes]

--- a/complexipy/utils/config.py
+++ b/complexipy/utils/config.py
@@ -4,6 +4,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    cast,
 )
 
 import typer
@@ -13,6 +14,7 @@ from complexipy.types import (
     RunConfig,
     Sort,
     TOMLConfig,
+    TOMLDiffSection,
 )
 from complexipy.utils.toml import (
     get_argument_value,
@@ -114,7 +116,21 @@ def resolve_config(
     no_ignore = bool(no_ignore)
     report_ignored = bool(report_ignored)
     ratchet = bool(get_argument_value(toml_config, "ratchet", ratchet, False))
+
+    cli_staged = staged
     staged = bool(get_argument_value(toml_config, "staged", staged, False))
+
+    diff_section = (
+        cast(Optional[TOMLDiffSection], toml_config.get("diff"))
+        if toml_config is not None
+        else None
+    )
+    if diff_section is not None:
+        branch = diff_section.get("branch")
+        if diff is None and diff_only is None and branch:
+            diff = cast(str, branch)
+        if "staged" in diff_section and cli_staged is None:
+            staged = bool(diff_section["staged"])
 
     plain, suggest_refactors = validate_cli_arguments(
         plain, suggest_refactors, top, quiet

--- a/complexipy/utils/toml.py
+++ b/complexipy/utils/toml.py
@@ -7,8 +7,10 @@ from typing import (
     Dict,
     List,  # It's important to use this to make it compatible with python 3.8, don't remove it
     Literal,
+    MutableMapping,
     Optional,
     Tuple,
+    Union,
     cast,
     overload,
 )
@@ -22,6 +24,7 @@ from complexipy.types import (
     Sort,
     TOMLBase,
     TOMLConfig,
+    TOMLDiffSection,
     TOMLType,
     TOMLTypes,
 )
@@ -55,9 +58,18 @@ def load_values_from_toml_key(
     | Sort
     | ColorTypes
     | OutputFormat
-    | TOMLType,
+    | TOMLType
+    | TOMLDiffSection,
 ) -> (
-    int | bool | str | List[str] | ColorTypes | OutputFormat | Sort | TOMLType
+    int
+    | bool
+    | str
+    | List[str]
+    | ColorTypes
+    | OutputFormat
+    | Sort
+    | TOMLType
+    | TOMLDiffSection
 ): ...
 
 
@@ -70,7 +82,8 @@ def load_values_from_toml_key(
     | Sort
     | ColorTypes
     | OutputFormat
-    | TOMLType,
+    | TOMLType
+    | TOMLDiffSection,
 ):
     """Normalize TOML values to expected runtime types.
 
@@ -93,8 +106,19 @@ def load_values_from_toml_key(
         if isinstance(value, str):
             return [value]
         return value
+    elif key == "diff" and isinstance(value, MutableMapping):
+        return _normalize_diff_section(value)
 
     return value
+
+
+def _normalize_diff_section(value: MutableMapping) -> TOMLDiffSection:
+    section = cast(TOMLDiffSection, value)
+    normalized: Dict[str, Union[str, bool]] = {}
+    for nested_key, nested_value in section.items():
+        if isinstance(nested_value, (str, bool)):
+            normalized[nested_key] = nested_value
+    return cast(TOMLDiffSection, normalized)
 
 
 def get_dict_from_pyproject(

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -184,6 +184,10 @@ Igual que `--diff`, `--staged` aplica el umbral contra el contenido staged y fal
 
 Esto requiere `git` y una ruta dentro de un repositorio.
 
+En lugar de repetir la referencia en cada llamada, declara la política de
+comparación una sola vez en un archivo de configuración — ver
+[Configuración de Diff](#configuraci%C3%B3n-de-diff).
+
 ### Modo Ratchet
 
 !!! warning "Deprecado"
@@ -355,6 +359,46 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     ```
 
 `check-script` está soportado en TOML. `--top` y `--plain` son flags solo de CLI.
+
+### Configuración de Diff
+
+La política de comparación se puede declarar una sola vez en el repositorio
+en lugar de pasar los mismos flags en cada llamada. Añade una sección
+`[tool.complexipy.diff]` al mismo archivo de configuración:
+
+=== "complexipy.toml"
+
+    ```toml
+    [diff]
+    branch = "main"
+    staged = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.complexipy.diff]
+    branch = "main"
+    staged = true
+    ```
+
+- `branch` establece la referencia por defecto para `--diff` y
+  `--diff-only`. Un `complexipy .` simple entonces se comporta como
+  `complexipy . --diff main`, incluida la aplicación del umbral. Pasa
+  `--diff <ref>` o `--diff-only <ref>` para sobrescribir la referencia en
+  una ejecución concreta.
+- `staged` habilita la comparación staged por defecto, como pasar
+  `--staged` en cada llamada.
+- Los flags de CLI siempre tienen prioridad sobre los valores de la sección.
+- `branch = ""` deshabilita el diff para el repositorio actual (opt-out).
+- Las claves planas `staged = true` y `ratchet = true` todavía funcionan,
+  pero quedan superadas por la sección; se mantienen como legado y pueden
+  eliminarse en una versión mayor futura. Orden de resolución: flag de CLI,
+  luego la sección `diff`, luego las claves planas.
+- Si la `branch` configurada no existe en el clon local (por ejemplo un
+  clon recién hecho o shallow), cada función se reporta como `NEW` y la
+  aplicación del umbral sigue activa. Haz fetch de la rama o pasa
+  `--diff <ref>` con una referencia existente.
 
 ## API de Python
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -187,6 +187,9 @@ Like `--diff`, `--staged` enforces the threshold against the staged content and 
 
 This requires `git` and a repository-backed path.
 
+Instead of repeating the reference on every call, declare the comparison
+policy once in a configuration file — see [Diff Configuration](#diff-configuration).
+
 ### Ratchet Mode
 
 !!! warning "Deprecated"
@@ -357,6 +360,45 @@ complexipy loads configuration in this order (highest to lowest priority):
     ```
 
 `check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
+
+### Diff Configuration
+
+The comparison policy can be declared once in the repository instead of
+passing the same flags on every call. Add a `[tool.complexipy.diff]`
+section to the same configuration file:
+
+=== "complexipy.toml"
+
+    ```toml
+    [diff]
+    branch = "main"
+    staged = true
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.complexipy.diff]
+    branch = "main"
+    staged = true
+    ```
+
+- `branch` sets the default reference for `--diff` and `--diff-only`. A
+  plain `complexipy .` then behaves like `complexipy . --diff main`,
+  enforcement included. Pass `--diff <ref>` or `--diff-only <ref>` to
+  override the reference for a single run.
+- `staged` enables staged comparison by default, like passing `--staged`
+  on every call.
+- CLI flags always take precedence over the section values.
+- `branch = ""` disables the diff for the current repository (opt-out).
+- The flat keys `staged = true` and `ratchet = true` still work but are
+  superseded by the section; they are kept as legacy and may be removed in
+  a future major version. Resolution order: CLI flag, then the `diff`
+  section, then the flat keys.
+- If the configured `branch` does not exist in the local clone (for
+  example a fresh or shallow clone), every function reports as `NEW` and
+  the enforcement still applies. Fetch the branch or pass `--diff <ref>`
+  with an existing reference instead.
 
 ## Python API
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -984,3 +984,72 @@ class TestTomlOverrides:
             report_ignored=None,
         )
         assert cfg.max_complexity_allowed == 10
+
+
+class TestDiffSectionFromToml:
+    @staticmethod
+    def _resolve(toml_config, diff=None, diff_only=None, staged=None):
+        return resolve_config(
+            toml_config,
+            paths=["."],
+            max_complexity_allowed=None,
+            snapshot_create=None,
+            snapshot_ignore=None,
+            quiet=None,
+            ignore_complexity=None,
+            failed=None,
+            color=None,
+            sort=None,
+            output_format=None,
+            output=None,
+            output_csv=None,
+            output_json=None,
+            output_gitlab=None,
+            output_sarif=None,
+            diff=diff,
+            diff_only=diff_only,
+            ratchet=None,
+            staged=staged,
+            top=None,
+            plain=None,
+            suggest_refactors=None,
+            exclude=None,
+            check_script=None,
+            no_ignore=None,
+            report_ignored=None,
+        )
+
+    def test_branch_from_section_sets_diff(self):
+        cfg = self._resolve({"diff": {"branch": "main"}})
+        assert cfg.diff == "main"
+        assert cfg.diff_only is None
+
+    def test_cli_diff_overrides_section_branch(self):
+        cfg = self._resolve({"diff": {"branch": "main"}}, diff="develop")
+        assert cfg.diff == "develop"
+
+    def test_cli_diff_only_overrides_section_branch(self):
+        cfg = self._resolve({"diff": {"branch": "main"}}, diff_only="develop")
+        assert cfg.diff is None
+        assert cfg.diff_only == "develop"
+
+    def test_empty_branch_disables_diff(self):
+        cfg = self._resolve({"diff": {"branch": ""}})
+        assert cfg.diff is None
+        assert cfg.diff_only is None
+
+    def test_section_staged_enabled_by_default(self):
+        cfg = self._resolve({"diff": {"staged": True}})
+        assert cfg.staged is True
+
+    def test_section_staged_false_overrides_flat_true(self):
+        cfg = self._resolve({"staged": True, "diff": {"staged": False}})
+        assert cfg.staged is False
+
+    def test_cli_staged_overrides_section(self):
+        cfg = self._resolve({"diff": {"staged": False}}, staged=True)
+        assert cfg.staged is True
+
+    def test_flat_staged_legacy_without_section(self):
+        cfg = self._resolve({"staged": True})
+        assert cfg.staged is True

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -5,6 +5,8 @@ import subprocess
 import tempfile
 from unittest.mock import patch
 
+from typer.testing import CliRunner
+
 from complexipy import DiffStatus, file_complexity
 from complexipy._complexipy import main as _main
 from complexipy.types import ExitReport
@@ -16,6 +18,7 @@ from complexipy.utils.diff import (
     format_diff,
     has_regressions,
 )
+from complexipy.utils.toml import get_complexipy_toml_config
 
 _SIMPLE = """\
 def simple(x):
@@ -36,6 +39,16 @@ def complex_func(data):
             if item:
                 return item
     return None
+"""
+
+
+_COMPLEX_SIMPLE = """\
+def simple(x):
+    if x:
+        for i in range(x):
+            if i:
+                return i
+    return x + 1
 """
 
 
@@ -807,3 +820,71 @@ class TestPublicApi:
         assert entry.new_complexity > 1
         assert has_regressions(entries, 15) is False
         assert has_regressions(entries, 5) is True
+
+
+class TestDiffTomlCli:
+    def _git(self, repo, *args):
+        return subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def _committed_repo(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        target = repo / "calc.py"
+        target.write_text(_SIMPLE)
+        assert self._git(repo, "init", "-q").returncode == 0
+        assert self._git(repo, "add", ".").returncode == 0
+        assert self._git(repo, "commit", "-q", "-m", "v1").returncode == 0
+        target.write_text(_COMPLEX_SIMPLE)
+        return repo
+
+    def _run(self, main_module, monkeypatch, repo, args):
+        monkeypatch.setattr(main_module, "INVOCATION_PATH", str(repo))
+        monkeypatch.setattr(
+            main_module,
+            "TOML_CONFIG",
+            get_complexipy_toml_config(str(repo)),
+        )
+        return CliRunner().invoke(main_module.app, args)
+
+    def test_toml_branch_enforces_like_cli_diff(self, tmp_path, monkeypatch):
+        import complexipy.main as main_module
+
+        repo = self._committed_repo(tmp_path)
+        (repo / "complexipy.toml").write_text(
+            'max-complexity-allowed = 2\n[diff]\nbranch = "HEAD"\n'
+        )
+        result = self._run(main_module, monkeypatch, repo, [str(repo)])
+        assert result.exit_code == 1
+
+    def test_diff_only_overrides_toml_branch(self, tmp_path, monkeypatch):
+        import complexipy.main as main_module
+
+        repo = self._committed_repo(tmp_path)
+        (repo / "complexipy.toml").write_text(
+            'max-complexity-allowed = 2\n[diff]\nbranch = "HEAD"\n'
+        )
+        result = self._run(
+            main_module,
+            monkeypatch,
+            repo,
+            [str(repo), "--diff-only", "HEAD", "--ignore-complexity"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "REGRESSED" in result.output
+
+    def test_toml_staged_enables_staged_comparison(self, tmp_path, monkeypatch):
+        import complexipy.main as main_module
+
+        repo = self._committed_repo(tmp_path)
+        assert self._git(repo, "add", ".").returncode == 0
+        (repo / "complexipy.toml").write_text(
+            "max-complexity-allowed = 2\n[diff]\nstaged = true\n"
+        )
+        result = self._run(main_module, monkeypatch, repo, [str(repo)])
+        assert result.exit_code == 1

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from complexipy.utils.toml import (
+    get_complexipy_toml_config,
+    load_toml_config,
+    load_values_from_toml_key,
+)
+
+
+class TestDiffSectionParsing:
+    def test_diff_section_in_complexipy_toml(self, tmp_path):
+        (tmp_path / "complexipy.toml").write_text(
+            "max-complexity-allowed = 15\n"
+            "[diff]\n"
+            'branch = "main"\n'
+            "staged = true\n"
+        )
+        config = load_toml_config(str(tmp_path), "complexipy.toml")
+        assert config["diff"] == {"branch": "main", "staged": True}
+
+    def test_diff_section_in_dot_complexipy_toml(self, tmp_path):
+        (tmp_path / ".complexipy.toml").write_text('[diff]\nbranch = "main"\n')
+        config = load_toml_config(str(tmp_path), ".complexipy.toml")
+        assert config["diff"] == {"branch": "main"}
+
+    def test_diff_section_in_pyproject_toml(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.complexipy]\n"
+            "max-complexity-allowed = 15\n"
+            "[tool.complexipy.diff]\n"
+            'branch = "main"\n'
+            "staged = true\n"
+        )
+        config = get_complexipy_toml_config(str(tmp_path))
+        assert config["max-complexity-allowed"] == 15
+        assert config["diff"] == {"branch": "main", "staged": True}
+
+    def test_diff_section_with_only_staged(self, tmp_path):
+        (tmp_path / "complexipy.toml").write_text("[diff]\nstaged = true\n")
+        config = load_toml_config(str(tmp_path), "complexipy.toml")
+        assert config["diff"] == {"staged": True}
+
+    def test_empty_diff_section_parses(self, tmp_path):
+        (tmp_path / "complexipy.toml").write_text("[diff]\n")
+        config = load_toml_config(str(tmp_path), "complexipy.toml")
+        assert config["diff"] == {}
+
+    def test_diff_key_normalizes_nested_values(self):
+        normalized = load_values_from_toml_key(
+            "diff", {"branch": "main", "staged": True}
+        )
+        assert normalized == {"branch": "main", "staged": True}
+
+    def test_non_dict_diff_key_passes_through(self):
+        value = "main"
+        assert load_values_from_toml_key("diff", value) == "main"


### PR DESCRIPTION
## What

Adds a `[tool.complexipy.diff]` TOML section so the diff baseline (`branch`) and staged comparison (`staged`) can be declared once in the repository instead of repeating CLI flags on every run. Closes #217.

## Why

`--diff` and `--diff-only` take the comparison reference as a CLI-only argument, so every contributor and CI job must repeat the same flag and remember which branch is the baseline. `--staged` can only be enabled per run. In collaborative repositories the comparison policy should be declared once in the repository config.

## Changes

- **`[tool.complexipy.diff]` section** in `complexipy.toml`, `.complexipy.toml`, or `pyproject.toml`:
  - `branch = "main"` makes a plain `complexipy .` behave like `complexipy . --diff main`, enforcement included
  - `staged = true` enables staged comparison by default
- **Precedence**: CLI flags > section values > flat legacy keys (`staged`, `ratchet` still work, marked legacy in docs)
- **Opt-out**: `branch = ""` disables the diff
- **Missing ref**: a configured branch that does not exist locally keeps the current all-`NEW` behavior, documented
- **Type plumbing**: `TOMLDiffSection` added to the config type system; `diff` section normalized on load
- **Docs**: `docs/usage-guide.md`, `docs/es/usage-guide.md`, README updated
- **Tests**: 7 parsing tests (`tests/test_toml.py`), 8 precedence tests (`tests/test_config.py`), 3 CLI-level tests with real git repos (`tests/test_diff.py`)