### PR TITLE
docs(changelog): add per-release changelog page

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -2,9 +2,12 @@
 name: release-notes
 description: >
     Generate polished release notes for a new version by inspecting git history
-    and past release formats. Supports creating the git tag and publishing the
-    release via `gh release create`. Invoke when the user asks to write release
-    notes, publish a release, or draft a changelog entry for a new version.
+    and past release formats. Keeps the project changelog in sync:
+    `CHANGELOG.md` and its Spanish mirror (`docs/es/changelog.md`) accumulate
+    entries under `## Unreleased` and move them into a dated section at release
+    time. Supports creating the git tag and publishing the release via
+    `gh release create`. Invoke when the user asks to write release notes,
+    publish a release, or draft a changelog entry for a new version.
 ---
 
 # Release Notes
@@ -76,7 +79,34 @@ Release, and optionally create the git tag.
     gh pr list --state merged --json author --jq '[.[].author.login] | unique'
     ```
 
-### 3. Study past release style
+### 3. Update the changelog
+
+The project changelog lives in `CHANGELOG.md` (English, single source of
+truth). `docs/changelog.md` embeds it and must stay a stub — never edit its
+content; only the root file changes. `docs/es/changelog.md` is the Spanish
+mirror.
+
+Before writing the release notes, make sure `## Unreleased` in
+`CHANGELOG.md` reflects every merged change since the last release:
+
+- Group changes under `### Added`, `### Changed`, `### Fixed`, `### Removed`
+  (Keep a Changelog order; omit empty subsections).
+- Write each bullet in the release-notes style: what changed, why, and
+  impact, with backticks for code and `(#PR)` references.
+- Removed flags, keys, and API breaks go under `### Removed`; a major
+  release with breaking changes gets a `!!! note "Migration"` callout
+  linking to the migration guide
+  (`https://rohaquinlop.github.io/complexipy/migration/`).
+- Mirror every entry in `docs/es/changelog.md` under `## Sin publicar`
+  (`### Añadido`, `### Cambiado`, `### Corregido`, `### Eliminado`); the ES
+  migration link points to
+  `https://rohaquinlop.github.io/complexipy/es/migracion/`.
+
+If a change is missing from `## Unreleased`, add it before drafting the
+notes. The release notes are drafted from this section, and at publish time
+it moves into a dated release section (step 8).
+
+### 4. Study past release style
 
 Read the last 2–3 releases to detect the current format convention:
 
@@ -94,7 +124,7 @@ Identify:
 - **New contributors**: whether `## New Contributors` is used.
 - **Full Changelog format**: always ends with `**Full Changelog**: ...`
 
-### 4. Categorise changes by conventional commit type
+### 5. Categorise changes by conventional commit type
 
 Group commits into sections based on their conventional commit prefix:
 
@@ -114,7 +144,7 @@ Group commits into sections based on their conventional commit prefix:
 For **patch releases**, prefix sections with `##`. For **minor feature releases**,
 `##` or `###` both appear in past practice — follow the most recent style.
 
-### 5. Write the release notes body and save to file
+### 6. Write the release notes body and save to file
 
 Use this structure, adapting to the detected project style:
 
@@ -157,9 +187,32 @@ RELEASE_NOTES_<version>.md
 ```
 
 Present a summary of the notes to the user, then ask whether they want to
-publish (create tag + GitHub release) or make edits first.
+publish (finalize the changelog, create tag + GitHub release) or make edits
+first.
 
-### 6. Create the tag (if requested)
+### 7. Finalize the changelog
+
+Once the user approves the notes, move `## Unreleased` in `CHANGELOG.md`
+into a dated release section:
+
+1. Rename `## Unreleased` to `## [<version>] - <date>` (date = the release
+   date; use today unless a specific date is intended).
+2. Reset `## Unreleased` to an empty section — it accumulates the next
+   release's changes.
+3. Append the release-link footer to the new section:
+   `See the [release notes](https://github.com/<owner>/<repo>/releases/tag/<version>) for the full details.`
+4. Mirror the new section in `docs/es/changelog.md` (`## [<version>] - <date>`,
+   same date and PR references, translated) and reset the Spanish
+   `## Sin publicar` to empty.
+5. If this is a major release with breaking changes, add a
+   `!!! note "Migration"` callout at the top of the new section linking to
+   the migration guide (`https://rohaquinlop.github.io/complexipy/migration/`;
+   Spanish: `https://rohaquinlop.github.io/complexipy/es/migracion/`).
+
+Never edit `docs/changelog.md` — it embeds the root file via the
+pymdownx.snippets include (`--8<-- "CHANGELOG.md"`).
+
+### 8. Create the tag (if requested)
 
 If the user asks to publish or create the release:
 
@@ -175,7 +228,13 @@ git push origin <version>
 Verify the tag points to the latest main commit — never to a detached or
 stale commit.
 
-### 7. Create the GitHub Release
+### 9. Create the GitHub Release
+
+Draft the release body from the `## [<version>] - <date>` section that just
+moved out of `## Unreleased`: keep the changelog's bullets, and add the
+opening summary paragraph, the `## PRs` list (full
+`[conventional-commit(scope): message] by @author in <pull-url>` lines), and
+the `**Full Changelog**` footer per the project style.
 
 ```bash
 gh release create <version> -F - <<'BODYEOF'
@@ -189,13 +248,17 @@ After creation, set the release title to match the version:
 gh release edit <version> --title "<version>"
 ```
 
-### 8. Verify
+### 10. Verify
 
 Confirm with:
 
 ```bash
 gh release view <version> --json name,tagName,url --jq '{name, tagName, url}'
 ```
+
+Confirm the changelog is finalized: `## [<version>] - <date>` exists in
+`CHANGELOG.md` and `docs/es/changelog.md`, `## Unreleased` is empty, and
+`docs/changelog.md` is still just the include stub.
 
 ## Edge Cases
 
@@ -207,6 +270,8 @@ gh release view <version> --json name,tagName,url --jq '{name, tagName, url}'
 | User wants a draft release                      | Add `--draft` to the `gh release create` command                                                                                                           |
 | User wants a prerelease                         | Add `--prerelease` to the `gh release create` command                                                                                                      |
 | No PRs in the release range                     | Generate notes from raw commit messages, grouped by conventional commit type                                                                               |
+| `## Unreleased` is missing entries              | Add the missing changes from the gathered PR list to `CHANGELOG.md` (and the Spanish mirror) before drafting the release notes (step 3)                   |
+| `docs/changelog.md` was edited                  | Restore it to a stub containing only `--8<-- "CHANGELOG.md"` — the root file is the single source of truth                                               |
 | Auto-release pipeline already created a release | Check with `gh release view <tag>`; if exists, prompt user before overwriting                                                                              |
 | Multiple repos                                  | Use the current working directory's git remote to infer owner/repo                                                                                         |
 
@@ -244,3 +309,20 @@ If missing, add to the downstream workflow:
 This project follows a professional tone without emoji section markers,
 using `##` headers and descriptive bullet points that explain the "what",
 "why", and impact of each change rather than just paraphrasing commit messages.
+
+## Changelog Conventions
+
+- `CHANGELOG.md` at the repo root is the single source of truth; the docs
+  page embeds it via pymdownx.snippets (`--8<-- "CHANGELOG.md"`), so
+  `docs/changelog.md` must stay a stub.
+- Sections are newest first: `## Unreleased` on top, then
+  `## [x.y.z] - YYYY-MM-DD`.
+- Subsection order: Added, Changed, Fixed, Removed; omit empty ones.
+- Every release section ends with a link back to its GitHub release notes.
+- Major releases with breaking changes carry a `!!! note "Migration"`
+  callout linking to the migration guide.
+- `docs/es/changelog.md` mirrors the root file: same headings, dates, and
+  PR references, translated.
+- At release time, Unreleased content moves into the dated section and
+  Unreleased resets empty — the changelog is the drafting ground for the
+  GitHub release notes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,710 @@
+# Changelog
+
+All notable changes to complexipy are documented here, newest first. Each
+release section links to its GitHub release notes for the full details.
+
+## Unreleased
+
+### Added
+
+- `--suggest-refactors` is now a clippy-style lint system: stable rule IDs
+  (C001–C005, C007, C011), category and applicability metadata,
+  `path:line:col` anchors with caret spans, verbatim suggestion rendering,
+  and a documentation link per rule. (#209)
+- Refactor-plan findings are included in JSON, SARIF, and GitLab exports
+  when `--suggest-refactors` is passed; the SARIF rule catalog is built
+  dynamically from the plans encountered. (#209)
+- `compute_diff`, `has_regressions`, `DiffEntry`, and `DiffStatus` are now
+  part of the public Python API, so CI tools can consume diff results as
+  objects instead of parsing terminal output; `DiffStatus` provides named
+  constants such as `DiffStatus.REGRESSED`. (#210)
+- `collect_removable_ignored_locations()` and `RemovableIgnore` are exported
+  from the Python API. Every run now reports ignore comments that are no
+  longer necessary (`path:line function=X complexity=N <comment>`) when the
+  suppressed function is back under the allowed limit — the exit code is
+  unaffected, the report is suppressed under `--quiet`, and it works under
+  `--plain`. (#213)
+- `--staged` flag for git-index comparison — answers "what complexity am I
+  about to commit?" instead of only what changed in the working tree;
+  `--staged` alone defaults the baseline to `HEAD` and enforces, while
+  `--diff <ref> --staged` enforces against the ref. (#218)
+- `[tool.complexipy.diff]` TOML section so the comparison policy lives in
+  the repository config: `branch = "main"` makes a plain `complexipy .` run
+  behave like `--diff main` (enforcement included), `staged = true` enables
+  staged comparison by default, and `branch = ""` opts out. CLI flags take
+  precedence over the section. (#219)
+
+### Changed
+
+- Refactor-plan reduction estimates are now honest: the reduction math was
+  rewritten and validated against measured before/after complexity, C004 no
+  longer suggests splitting `match` statements, C006 was deleted because its
+  gate could never fire, and C011 now fires on `try` → `with` → `try`
+  chains. Overlapping plans are deduped against every overlap and capped at
+  5, reporting dropped ones as "... and N more suggestions". (#209)
+- Condition extraction in the refactor rules now tracks bracket depth,
+  string literals, and walrus `:=` instead of a naive `rfind(':')`. (#209)
+- `file_complexity()` now returns cwd-relative paths (matching
+  `git diff --name-only`), and nested invocations resolve git paths via a
+  `git ls-files` basename lookup — without this, diffing per-file results
+  silently marked every function as NEW. (#210)
+- Community standards files were added: `CODE_OF_CONDUCT.md`,
+  `CONTRIBUTING.md`, `SECURITY.md`, issue templates, and a pull request
+  template. (#201)
+
+### Fixed
+
+- Snapshot updates now merge with the existing snapshot instead of
+  replacing it: only the files analyzed in a run are touched, so partial
+  runs (e.g. pre-commit hooks analyzing only staged files) no longer erase
+  the baseline for unanalyzed files. (#215)
+- The docs footer now renders its links as styled links instead of raw
+  markdown text, on both the English and Spanish landing pages. (#216)
+
+### Removed
+
+- `RefactorPlan.steps` — replaced by the concrete `suggestion` / `help`
+  fields on the plan. (#209)
+- `CodeSnippet` from the public API; `CodeSuggestion` is exported in its
+  place. (#209)
+- `--output-json` / `-j`, `--output-csv` / `-c`, `--output-gitlab`, and
+  `--output-sarif` / `-sr` — use `--output-format` instead. (#221)
+- `--ratchet` / `-R` — `--diff` enforces the threshold by default. (#221)
+- TOML keys `output-json`, `output-csv`, `output-gitlab`, `output-sarif`,
+  flat `staged`, flat `ratchet`, and the undocumented `details = "low"`
+  alias. (#221)
+
+These removals land in the next major version. See the
+[migration guide](https://rohaquinlop.github.io/complexipy/migration/) for
+each removed flag and key with its replacement.
+
+## [6.2.0] - 2026-07-23
+
+### Added
+
+- `--exclude` and `--output-format` now accept comma-separated values
+  (`--exclude tests/**,src/**`), avoiding shell expansion issues. (#199)
+
+### Fixed
+
+- Output now shows the correct relative path from the current working
+  directory when analyzing a single file or a directory. (#198)
+- `--output-sarif` help text now carries a deprecation notice, clarifying
+  that SARIF output is moving to a different mechanism. (#199)
+
+### Changed
+
+- Decomposed the monolithic 316-line `main()` function into a clean
+  orchestrator (~80 lines) with extracted business logic in domain-specific
+  `utils/` modules (`config.py`, `paths.py`, `ignored.py`). (#199)
+- Introduced `RunConfig`, `ExitReport`, and `SnapshotEvaluation` dataclasses,
+  replacing mutable accumulators and positional tuple unpacking. (#199)
+- Eliminated all `global console` declarations — the `console` instance is
+  constructed once and passed explicitly. (#199)
+- Refactored `get_arguments_value` from a 20-parameter function returning a
+  15-element tuple to a dict-based approach. (#199)
+- Added 30 new tests covering config resolution and snapshot evaluation
+  logic. (#199)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/6.2.0)
+for the full details.
+
+## [6.1.0] - 2026-07-21
+
+### Fixed
+
+- Fixed git path resolution when running `--diff` from a nested subdirectory
+  inside a repository, which previously caused "not a git repository"
+  errors. (#196)
+- Fixed ruff lint configuration to use a glob pattern instead of a directory
+  exclusion for test files. (#196)
+
+### Changed
+
+- Simplified the diff CLI — `--diff` now always enforces
+  `--max-complexity-allowed`, while `--diff-only` provides the visual-only
+  comparison. `--ratchet` is deprecated in favour of this model. (#196)
+- Integrated diff output into the main analysis flow instead of producing it
+  as a separate post-processing step. (#196)
+- Removed the redundant "Failed functions" output section — failed functions
+  are now shown inline in the per-file summary. (#196)
+- Added `AGENTS.md` for AI agent context.
+- Added a CI workflow that notifies downstream repositories on new
+  releases. (#197)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/6.1.0)
+for the full details.
+
+## [6.0.1] - 2026-07-03
+
+### Fixed
+
+- Normalized Windows paths for wax glob compatibility in the exclude
+  handling. (#194)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/6.0.1)
+for the full details.
+
+## [6.0.0] - 2026-06-26
+
+!!! note "Migration"
+
+    This release brings the cognitive complexity algorithm into full
+    conformance with the SonarSource white paper (v1.7). Scores change for
+    files using `match`, `try`/`except`, `with`, comprehensions, lambdas,
+    recursion, or nested ternaries — in most cases they increase. Re-run
+    `complexipy` after upgrading and review the new scores; if you use
+    `--max-complexity` / `--failed` in CI you will likely need to raise
+    thresholds. See the [migration guide](https://rohaquinlop.github.io/complexipy/migration/)
+    for upgrade guidance.
+
+### Fixed
+
+- `match` statements now apply a structural + nesting increment per the
+  paper, instead of being scored as 0. (#192)
+- `try`/`else`/`finally` blocks are now collected at the current nesting
+  level instead of `+1`, matching the paper's rule. (#192)
+- `except` handlers now charge `1 + nesting_level` instead of a flat
+  `+1`. (#192)
+- `with` blocks no longer incorrectly raise the nesting level. (#192)
+- Direct recursion now emits `+1` for each self-call via a scope-aware
+  `RecursionFinder`, correctly skipping nested function/class definitions
+  and lambdas. (#192)
+- Lambda expressions are now included in boolean-op counting, recursing
+  into the body at `nesting_level + 1`. (#192)
+- Comprehensions (`ListComp`, `SetComp`, `DictComp`, `Generator`) now charge
+  `1 + nesting_level` per generator and `+1` per `if` filter. (#192)
+- Nested ternaries now recurse at `nesting_level + 1`, so inner ternaries
+  receive the correct nesting increment. (#192)
+- `for`/`while` `else` clauses are now collected at the loop's own nesting
+  level, not `+1`. (#192)
+- Bare expression statements now count boolean ops (e.g.
+  `foo(a and b)`). (#192)
+- The `for` iterable now counts boolean ops, for parity with `while`. (#192)
+
+### Changed
+
+- Extracted all path orchestration (file I/O, directory traversal, URL
+  cloning) from `cognitive_complexity.rs` into a new `src/runner.rs` module,
+  gated `#[cfg(feature = "python")]`, which also resolves a pre-existing
+  wasm build failure. (#192)
+- Extracted `push_line`, `absorb`, `absorb_with_regions`, `finalize_region`,
+  `count_line_bool_ops`, `loop_complexity`, `is_ignored`, and
+  `analyze_function` helpers to eliminate the repeated fold/push pattern
+  across all statement arms. (#192)
+- Unified structurally identical `Stmt::For` and `Stmt::While` handling into
+  a single `loop_complexity` call. (#192)
+- Collapsed 7 near-identical statement arms through
+  `count_line_bool_ops`. (#192)
+- Derived `Default` on `ComplexityRegion` and `RegionKind`. (#192)
+- Eliminated `merge_child` and its internal `child.regions.clone()`. (#192)
+- Hardened the Windows release unit-test job against transient Cargo HTTP/2
+  framing failures. (#189)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/6.0.0)
+for the full details.
+
+## [5.6.1] - 2026-06-16
+
+### Fixed
+
+- Fixed a panic in `extract_comment_marker` when a multi-byte UTF-8
+  character (em-dash, emoji, accented letters, CJK) straddles byte offset 16
+  of a comment, which previously aborted analysis of the entire directory.
+  Error-prone byte-slicing was replaced with regex-based matching. (#187)
+
+### Removed
+
+- Removed the unreliable `release-plz.yml` auto-release workflow and its
+  supporting files (`CHANGELOG.md`, `cliff.toml`). Manual releases via
+  `release.yml` (tag → build → test → publish) are now the standard
+  path. (#188)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.6.1)
+for the full details.
+
+## [5.6.0] - 2026-06-14
+
+### Added
+
+- `--no-ignore` flag to disregard `# complexipy: ignore` and
+  `# noqa: complexipy` comments. (#182)
+- `--report-ignored` flag to list all suppressed functions, with optional
+  JSON export to `complexipy-ignored.json`. (#182)
+- `IgnoredLocation` type and `collect_all_ignored_locations()` to the
+  Python API. (#182)
+
+### Fixed
+
+- Fixed diff mode showing all files as NEW on Windows. (#177)
+
+### Changed
+
+- Migrated pyo3 to 0.29 and updated CI runners. (#185)
+- Added musllinux_1_2 wheel builds for Alpine Linux support. (#180)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.6.0)
+for the full details.
+
+## [5.5.0] - 2026-05-22
+
+### Added
+
+- Deterministic refactor plans: a new algorithm generates actionable,
+  deterministic suggestions to reduce cognitive complexity. Plans are
+  displayed in the rich CLI output and included in JSON output.
+- Recursive exclude globs: exclude patterns now support `**` (e.g.
+  `tests/**`). The glob engine was replaced with `wax` for correct recursive
+  matching relative to the caller's working directory.
+
+### Fixed
+
+- Fixed unbounded growth of target-set entries in the cache that could
+  degrade performance on large projects.
+
+### Changed
+
+- Output internals now use typed `FunctionRow` / `FileEntry` dataclasses
+  instead of untyped `Dict` structures, extracted into
+  `complexipy/utils/dataclasses.py`.
+- Docs deploys now trigger only on release events, not on every push.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.5.0)
+for the full details.
+
+## [5.4.1] - 2026-05-05
+
+### Fixed
+
+- Stabilized snapshot output by omitting transient line-level fields from
+  Python-facing serialized Rust structures.
+- Moved shared output constants into `complexipy.utils.constants` so output
+  filenames, legacy CLI flags, and legacy TOML keys are defined in one
+  place.
+- Clarified deprecated output flag messaging for `--output-csv`,
+  `--output-json`, and `--output-gitlab` to point users at
+  `--output-format`.
+
+### Changed
+
+- Updated CI so pull requests run a faster quick-test matrix, while full
+  wheel builds, source distribution builds, and full platform test jobs run
+  for tags or manual workflow dispatches.
+- Enabled uv dependency caching in CI jobs.
+- Updated README and docs to match the current Python API return types and
+  the current JSON array snapshot format.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.4.1)
+for the full details.
+
+## [5.4.0] - 2026-04-25
+
+### Removed
+
+- Removed comprehension complexity scoring — rolls back the
+  `ListComp`/`SetComp`/`Generator`/`DictComp` AST node handling from
+  `count_bool_ops()` and the `count_comprehension_complexity()` helper added
+  in v5.3.0. (#166)
+
+### Fixed
+
+- Fixed feature gating for WASM builds and included version metadata. (#164)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.4.0)
+for the full details.
+
+## [5.3.0] - 2026-04-16
+
+### Added
+
+- `--ratchet` flag — CI fails only when complexity increases past the
+  threshold; regressions are blocked, improvements always pass. (#159)
+- `--plain` flag — machine-readable plain-text output for
+  scripting/piping. (#158)
+- `--top N` flag — display the N most complex functions, globally sorted
+  across all files. (#157)
+- `--check-script` / `--script-strict` flags — analyse module-level (script)
+  complexity in addition to functions. (#156)
+- Unified output destinations — consistent `--output-*` routing across all
+  report formats. (#155)
+- GitLab Code Quality report via `--output-gitlab`. (#153)
+- SARIF 2.1.0 output via `--output-sarif` for IDE and GitHub Advanced
+  Security integration. (#141)
+- Git diff analysis — `--diff <ref>` reports complexity changes relative to
+  any git reference. (#140)
+- Comprehension complexity — list/dict/set comprehensions and generator
+  expressions now contribute to cognitive complexity scores. (#139)
+- `# complexipy: ignore` — new canonical inline suppression comment;
+  `# noqa: complexipy` is deprecated. (#146)
+- Glob patterns in the config `exclude` field. (#142)
+- Spanish documentation. (#147)
+
+### Fixed
+
+- `--top` results now preserve global descending order across multi-file
+  runs.
+- `--top N` rejects `N ≤ 0` with a clear error.
+- `--script-strict` now correctly requires `--check-script`.
+- Ignore markers (`# complexipy: ignore`) now work on multiline function
+  definitions.
+- JSON output includes a final newline (POSIX compliance). (#148)
+- Snapshot-allowed functions are now shown as `PASSED` in output.
+- The snapshot watermark correctly drives the exit code when active.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.3.0)
+for the full details.
+
+## [5.2.0] - 2026-01-28
+
+### Fixed
+
+- Fixed `# noqa: complexipy` comments on decorated functions. (#128)
+
+### Changed
+
+- Updated the pre-commit complexipy version in the docs. (#126)
+- Updated the documentation. (#132)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.2.0)
+for the full details.
+
+## [5.1.0] - 2025-12-09
+
+### Fixed
+
+- Fixed invalid results output paths on Windows. (#120)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.1.0)
+for the full details.
+
+## [5.0.0] - 2025-11-26
+
+!!! note "Migration"
+
+    Conditional scoring now counts each `elif`/`else` branch as +1
+    complexity (plus its boolean test), aligning with Sonar's
+    cognitive-complexity rules. Expect higher scores for branching. See the
+    [migration guide](https://rohaquinlop.github.io/complexipy/migration/)
+    for upgrade guidance.
+
+### Added
+
+- Snapshots: `--snapshot-create` writes `complexipy-snapshot.json`;
+  comparisons block regressions, auto-refresh on improvements, and can be
+  bypassed with `--snapshot-ignore`. (#111)
+- Change tracking: a per-target cache in `.complexipy_cache` shows
+  deltas/new failures for over-threshold functions using stable BLAKE2
+  keys. (#115)
+- Output controls: `--failed` to show only violations (#114); `--color auto|yes|no`
+  (#109); richer summaries of failing functions and invalid paths.
+- Python 3.14 support. (#106)
+
+### Changed
+
+- Excludes and errors: exclude entries are resolved relative to the root and
+  only applied when they match real files/dirs; missing paths are reported
+  cleanly instead of panicking. (#113)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/5.0.0)
+for the full details.
+
+## [4.2.0] - 2025-09-21
+
+### Added
+
+- Exclude files from analysis.
+- Inline ignores to exclude functions from analysis.
+
+### Fixed
+
+- Python 3.8 support. (#96)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/4.2.0)
+for the full details.
+
+## [4.1.0] - 2025-09-08
+
+### Added
+
+- Version support. (#93)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/4.1.0)
+for the full details.
+
+## [4.0.2] - 2025-08-22
+
+Patch release; no changes were recorded in its release notes.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/4.0.2)
+for the full details.
+
+## [4.0.1] - 2025-08-21
+
+### Fixed
+
+- Fixed the PyPI README error.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/4.0.1)
+for the full details.
+
+## [4.0.0] - 2025-08-21
+
+!!! note "Migration"
+
+    The logic for counting boolean operators in conditions was updated to
+    align with the definition from the original paper. Existing functions
+    may report higher complexities. See the
+    [migration guide](https://rohaquinlop.github.io/complexipy/migration/)
+    for upgrade guidance.
+
+### Added
+
+- Configuration support via `complexipy.toml` or `[tool.complexipy]` in
+  `pyproject.toml` — users can now define default arguments.
+
+### Fixed
+
+- Fixed an infinite loop when analyzing modules with invalid Python
+  syntax. (#85, resolved in #88)
+
+### Changed
+
+- Improved performance and Rust implementation details.
+- Updated and improved documentation.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/4.0.0)
+for the full details.
+
+## [3.3.0] - 2025-07-17
+
+### Added
+
+- `--max-complexity-allowed` (`-mx`) — customize the maximum allowed
+  cognitive complexity threshold per function. The default remains 15 to
+  maintain existing behavior.
+- GitHub Actions integration for the custom threshold.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/3.3.0)
+for the full details.
+
+## [3.2.0] - 2025-07-09
+
+### Fixed
+
+- Fixed an error when using complexipy on Windows, related to the `rich`
+  library used to draw the console output with emojis.
+- Fixed the `quiet` parameter still drawing output that wasn't handled in
+  the Rust code.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/3.2.0)
+for the full details.
+
+## [3.1.1] - 2025-07-06
+
+### Changed
+
+- The maximum complexity threshold is now `15`, matching the Sonar
+  threshold to make adoption of the library easier. (#78)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/3.1.1)
+for the full details.
+
+## [3.0.0] - 2025-06-16
+
+!!! note "Migration"
+
+    `--max-complexity` was removed; complexipy now uses a fixed cognitive
+    complexity threshold of 15. The tool exits with an error when a function
+    meets or exceeds the threshold. Use `--ignore-complexity` (`-i`) to show
+    all functions regardless of their complexity score. See the
+    [migration guide](https://rohaquinlop.github.io/complexipy/migration/)
+    for upgrade guidance.
+
+### Added
+
+- WebAssembly (WASM) support — the core analysis engine can now be compiled
+  to WebAssembly, enabling browser-based analysis and tools like the
+  VSCode extension. (#72)
+- JSON output via `--output-json` (`-j`) for machine-readable results. (#74)
+- `--ignore-complexity` (`-i`) flag to display all functions regardless of
+  whether they exceed the complexity threshold. (#73)
+- `--details` (`-d`) now also affects CSV and JSON outputs. (#73)
+- Sort results by complexity score (`asc`, `desc`) or by `name`. (#73)
+- Pre-commit hook support with documentation for easy setup. (#75)
+
+### Removed
+
+- The `--max-complexity` argument. (#73)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/3.0.0)
+for the full details.
+
+## [2.1.1] - 2025-04-24
+
+### Fixed
+
+- Fixed compatibility with Python 3.8. (#66)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/2.1.1)
+for the full details.
+
+## [2.1.0] - 2025-04-23
+
+### Fixed
+
+- Fixed dictionary expression bool op counting. (#64)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/2.1.0)
+for the full details.
+
+## [2.0.0] - 2025-04-18
+
+### Changed
+
+- Changed the parser from `rustpython` to `ruff_python_parser`. (#62)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/2.0.0)
+for the full details.
+
+## [1.2.0] - 2024-12-15
+
+### Fixed
+
+- Fixed the `output_summary` function call that was missing the
+  `files_complexities` argument. (#58)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/1.2.0)
+for the full details.
+
+## [1.1.0] - 2024-12-14
+
+### Added
+
+- Multiple paths support — pass several paths to analyze at once. (#56)
+
+### Removed
+
+- The deprecated `-l` option, simplifying the command-line interface. (#56)
+- File-level analysis, in order to focus on functions instead of the whole
+  file. (#56)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/1.1.0)
+for the full details.
+
+## [0.5.0] - 2024-10-28
+
+### Added
+
+- Python API — call complexipy from your own Python code with
+  `file_complexity()` and `code_complexity()`. (#45)
+- Library usage documented in the README. (#49)
+- Improved package usability. (#53)
+- Updated documentation. (#54)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.5.0)
+for the full details.
+
+## [0.4.0] - 2024-06-21
+
+### Added
+
+- The cognitive complexity now considers the `If Expression` used in the
+  code, including when used inside a `Call Expression` and so on. (#44)
+
+### Fixed
+
+- Fixed an edge case that could cause a memory overflow by filtering the
+  cognitive complexity of the `orelse` values in an `If Statement` and
+  keeping the nesting level subtraction propagation. (#44)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.4.0)
+for the full details.
+
+## [0.3.3] - 2024-04-27
+
+### Changed
+
+- Updated CI and removed unused dependencies. (#43)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.3.3)
+for the full details.
+
+## [0.3.2] - 2024-03-22
+
+### Changed
+
+- When using `--details low`, an empty summary table is no longer printed;
+  an informational message is shown instead. (#38)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.3.2)
+for the full details.
+
+## [0.3.1] - 2024-03-13
+
+### Added
+
+- `-s` / `--sort` optional parameter to sort the output. (#30)
+- Python >= 3.8 requirement. (#35)
+
+### Fixed
+
+- Fixed the logic used to calculate cognitive complexity: assignment
+  statements only add complexity when `IfExp` is used, and `BinOp` by
+  itself does not add complexity. (#34)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.3.1)
+for the full details.
+
+## [0.3.0] - 2024-03-07
+
+### Added
+
+- Function-level complexity analysis by default — the maximum complexity is
+  evaluated for each function inside the Python files; per-file cognitive
+  complexity is still available. (#21)
+- New parameters. (#14)
+- Progress bars. (#24)
+- `--quiet` option. (#26)
+- Unit testing. (#20)
+- Cognitive complexity explanation in the docs. (#22)
+
+### Changed
+
+- Enhanced the algorithm to measure cognitive complexity — results are
+  closer to the Sonar implementation. (#18)
+- Reduced verbosity, with more information about the stages when running
+  `complexipy` over git repositories (using the URL).
+- CSV report generation is now implemented in Rust instead of Python,
+  improving performance.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.3.0)
+for the full details.
+
+## [0.2.2] - 2024-02-27
+
+Patch release; no changes were recorded in its release notes.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.2.2)
+for the full details.
+
+## [0.2.1] - 2024-02-27
+
+### Changed
+
+- Updated the README.
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.2.1)
+for the full details.
+
+## [0.2.0] - 2024-02-27
+
+### Added
+
+- Ignore paths support. (#6)
+- Git repository URL support. (#7)
+- CSV output format. (#8)
+- Cognitive complexity algorithm fixes. (#10)
+- Updated README. (#9)
+
+See the [release notes](https://github.com/rohaquinlop/complexipy/releases/tag/0.2.0)
+for the full details.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     <a href="#quick-start">Quick Start</a> •
     <a href="#integrations">Integrations</a> •
     <a href="https://rohaquinlop.github.io/complexipy/">Documentation</a> •
+    <a href="https://rohaquinlop.github.io/complexipy/changelog/">Changelog</a> •
     <a href="https://www.complexipy-teams.com/">Complexipy Teams</a>
   </p>
 </div>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/docs/es/changelog.md
+++ b/docs/es/changelog.md
@@ -1,0 +1,752 @@
+# Registro de Cambios
+
+Todos los cambios notables de complexipy se documentan aquí, de más reciente
+a más antiguo. Cada sección de versión enlaza a sus notas de versión de
+GitHub con todos los detalles.
+
+## Sin publicar
+
+### Añadido
+
+- `--suggest-refactors` ahora es un sistema de lint estilo clippy: IDs de
+  reglas estables (C001–C005, C007, C011), metadatos de categoría y
+  aplicabilidad, anclas `path:line:col` con span de caret, renderizado
+  verbatim de las sugerencias y un enlace de documentación por regla. (#209)
+- Los hallazgos de refactorización se incluyen en las exportaciones JSON,
+  SARIF y GitLab cuando se pasa `--suggest-refactors`; el catálogo de
+  reglas SARIF se construye dinámicamente a partir de los planes
+  encontrados. (#209)
+- `compute_diff`, `has_regressions`, `DiffEntry` y `DiffStatus` ahora
+  forman parte de la API pública de Python, de modo que las herramientas de
+  CI pueden consumir los resultados del diff como objetos en lugar de
+  parsear la salida del terminal; `DiffStatus` proporciona constantes con
+  nombre como `DiffStatus.REGRESSED`. (#210)
+- `collect_removable_ignored_locations()` y `RemovableIgnore` se exportan
+  desde la API de Python. Cada ejecución informa ahora de los comentarios
+  de ignorado que ya no son necesarios (`path:line function=X complexity=N <comment>`) cuando la función suprimida vuelve a estar bajo el límite
+  permitido — el código de salida no se ve afectado, el informe se suprime
+  con `--quiet` y funciona con `--plain`. (#213)
+- Flag `--staged` para la comparación del índice git — responde "¿qué
+  complejidad estoy a punto de commitear?" en lugar de solo lo que cambió
+  en el working tree; `--staged` solo usa `HEAD` como baseline por defecto
+  y aplica el umbral, mientras que `--diff <ref> --staged` aplica contra la
+  ref. (#218)
+- Sección TOML `[tool.complexipy.diff]` para que la política de comparación
+  viva en la configuración del repositorio: `branch = "main"` hace que una
+  ejecución simple de `complexipy .` se comporte como `--diff main` (con
+  aplicación del umbral), `staged = true` habilita la comparación staged
+  por defecto y `branch = ""` la desactiva. Las flags de CLI tienen
+  precedencia sobre la sección. (#219)
+
+### Cambiado
+
+- Las estimaciones de reducción de los planes de refactorización ahora son
+  honestas: la matemática de reducción se reescribió y validó contra la
+  complejidad medida antes/después, C004 ya no sugiere dividir sentencias
+  `match`, C006 se eliminó porque su gate nunca podía dispararse y C011
+  ahora se dispara en cadenas `try` → `with` → `try`. Los planes
+  solapados se deduplican contra cada solapamiento y se limitan a 5,
+  informando los descartados como "... and N more suggestions". (#209)
+- La extracción de condiciones en las reglas de refactorización ahora
+  rastrea la profundidad de corchetes, los literales de cadena y el walrus
+  `:=` en lugar de un `rfind(':')` ingenuo. (#209)
+- `file_complexity()` ahora devuelve rutas relativas al cwd (igual que
+  `git diff --name-only`), y las invocaciones anidadas resuelven las rutas
+  git mediante una búsqueda por basename con `git ls-files` — sin esto,
+  comparar los resultados por archivo marcaba silenciosamente cada función
+  como NEW. (#210)
+- Se añadieron archivos de estándares comunitarios: `CODE_OF_CONDUCT.md`,
+  `CONTRIBUTING.md`, `SECURITY.md`, plantillas de issue y una plantilla de
+  pull request. (#201)
+
+### Corregido
+
+- Las actualizaciones de snapshot ahora se fusionan con el snapshot
+  existente en lugar de reemplazarlo: solo se tocan los archivos analizados
+  en la ejecución, de modo que las ejecuciones parciales (p. ej. hooks de
+  pre-commit que analizan solo los archivos staged) ya no borran el
+  baseline de los archivos no analizados. (#215)
+- El footer de los docs ahora renderiza sus enlaces como enlaces con estilo
+  en lugar de markdown crudo, tanto en la página de inicio en inglés como
+  en español. (#216)
+
+### Eliminado
+
+- `RefactorPlan.steps` — reemplazado por los campos concretos `suggestion`
+  / `help` del plan. (#209)
+- `CodeSnippet` de la API pública; `CodeSuggestion` se exporta en su
+  lugar. (#209)
+- `--output-json` / `-j`, `--output-csv` / `-c`, `--output-gitlab` y
+  `--output-sarif` / `-sr` — usa `--output-format` en su lugar. (#221)
+- `--ratchet` / `-R` — `--diff` aplica el umbral por defecto. (#221)
+- Las claves TOML `output-json`, `output-csv`, `output-gitlab`,
+  `output-sarif`, `staged` plana, `ratchet` plana y el alias no documentado
+  `details = "low"`. (#221)
+
+Estas eliminaciones llegan en la próxima versión mayor. Consulta la
+[guía de migración](https://rohaquinlop.github.io/complexipy/es/migracion/)
+para cada flag y clave eliminada con su reemplazo.
+
+## [6.2.0] - 2026-07-23
+
+### Añadido
+
+- `--exclude` y `--output-format` ahora aceptan valores separados por comas
+  (`--exclude tests/**,src/**`), evitando problemas de expansión del
+  shell. (#199)
+
+### Corregido
+
+- La salida ahora muestra la ruta relativa correcta desde el directorio de
+  trabajo al analizar un archivo o directorio. (#198)
+- El texto de ayuda de `--output-sarif` ahora incluye un aviso de
+  deprecación, aclarando que la salida SARIF pasa a otro mecanismo. (#199)
+
+### Cambiado
+
+- Se descompuso la función monolítica `main()` de 316 líneas en un
+  orquestador limpio (~80 líneas) con la lógica de negocio extraída en
+  módulos `utils/` específicos (`config.py`, `paths.py`, `ignored.py`). (#199)
+- Se introdujeron los dataclasses `RunConfig`, `ExitReport` y
+  `SnapshotEvaluation`, reemplazando los acumuladores mutables y el
+  desempaquetado de tuplas posicionales. (#199)
+- Se eliminaron todas las declaraciones `global console`: la instancia de
+  `console` se construye una vez y se pasa explícitamente. (#199)
+- Se refactorizó `get_arguments_value`, de una función de 20 parámetros que
+  devolvía una tupla de 15 elementos, a un enfoque basado en diccionarios.
+  (#199)
+- Se añadieron 30 tests nuevos que cubren la resolución de configuración y
+  la lógica de evaluación de snapshots. (#199)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/6.2.0)
+para más detalles.
+
+## [6.1.0] - 2026-07-21
+
+### Corregido
+
+- Se corrigió la resolución de rutas git al ejecutar `--diff` desde un
+  subdirectorio anidado dentro de un repositorio, que antes provocaba
+  errores de "not a git repository". (#196)
+- Se corrigió la configuración de lint de ruff para usar un patrón glob en
+  lugar de una exclusión de directorio para los archivos de test. (#196)
+
+### Cambiado
+
+- Se simplificó el CLI de diff — `--diff` ahora siempre aplica
+  `--max-complexity-allowed`, mientras que `--diff-only` ofrece la
+  comparación solo visual. `--ratchet` queda deprecado en favor de este
+  modelo. (#196)
+- Se integró la salida de diff en el flujo principal de análisis en lugar de
+  producirla como un paso de post-procesamiento separado. (#196)
+- Se eliminó la sección redundante de "Failed functions" — las funciones que
+  fallan ahora se muestran en línea en el resumen por archivo. (#196)
+- Se añadió `AGENTS.md` para el contexto de asistentes de IA.
+- Se añadió un workflow de CI que notifica a los repositorios downstream en
+  cada nueva versión. (#197)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/6.1.0)
+para más detalles.
+
+## [6.0.1] - 2026-07-03
+
+### Corregido
+
+- Se normalizaron las rutas de Windows para la compatibilidad con los globs
+  de wax en el manejo de exclusiones. (#194)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/6.0.1)
+para más detalles.
+
+## [6.0.0] - 2026-06-26
+
+!!! note "Migración"
+
+    Esta versión alinea el algoritmo de complejidad cognitiva con el white
+    paper de SonarSource (v1.7). Las puntuaciones cambian para archivos que
+    usan `match`, `try`/`except`, `with`, comprehensions, lambdas,
+    recursión o ternarios anidados — en la mayoría de los casos aumentan.
+    Vuelve a ejecutar `complexipy` tras actualizar y revisa las nuevas
+    puntuaciones; si usas `--max-complexity` / `--failed` en CI,
+    probablemente necesitarás subir los umbrales. Consulta la
+    [guía de migración](https://rohaquinlop.github.io/complexipy/es/migracion/)
+    para obtener orientación sobre la actualización.
+
+### Corregido
+
+- Las sentencias `match` ahora aplican un incremento estructural + de
+  anidamiento según el paper, en lugar de puntuarse como 0. (#192)
+- Los bloques `try`/`else`/`finally` ahora se recogen en el nivel de
+  anidamiento actual en lugar de `+1`, según la regla del paper. (#192)
+- Los handlers `except` ahora cobran `1 + nesting_level` en lugar de un
+  `+1` fijo. (#192)
+- Los bloques `with` ya no elevan incorrectamente el nivel de
+  anidamiento. (#192)
+- La recursión directa ahora emite `+1` por cada auto-llamada mediante un
+  `RecursionFinder` consciente del ámbito, que omite correctamente
+  definiciones anidadas de funciones/clases y lambdas. (#192)
+- Las expresiones lambda ahora se incluyen en el conteo de operadores
+  booleanos, recursando en el cuerpo con `nesting_level + 1`. (#192)
+- Las comprehensions (`ListComp`, `SetComp`, `DictComp`, `Generator`) ahora
+  cobran `1 + nesting_level` por generador y `+1` por filtro `if`. (#192)
+- Los ternarios anidados ahora recursan con `nesting_level + 1`, de modo que
+  los ternarios internos reciben el incremento correcto. (#192)
+- Las cláusulas `else` de `for`/`while` ahora se recogen en el nivel de
+  anidamiento del propio bucle, no en `+1`. (#192)
+- Las sentencias de expresión sueltas ahora cuentan operadores booleanos
+  (p. ej. `foo(a and b)`). (#192)
+- El iterable de `for` ahora cuenta operadores booleanos, en paridad con
+  `while`. (#192)
+
+### Cambiado
+
+- Se extrajo toda la orquestación de rutas (I/O de archivos, recorrido de
+  directorios, clonado de URLs) de `cognitive_complexity.rs` a un nuevo
+  módulo `src/runner.rs`, con `#[cfg(feature = "python")]`, lo que también
+  resuelve un fallo de compilación wasm preexistente. (#192)
+- Se extrajeron los helpers `push_line`, `absorb`, `absorb_with_regions`,
+  `finalize_region`, `count_line_bool_ops`, `loop_complexity`, `is_ignored`
+  y `analyze_function` para eliminar el patrón repetido de fold/push en
+  todos los brazos de sentencias. (#192)
+- Se unificó el manejo estructuralmente idéntico de `Stmt::For` y
+  `Stmt::While` en una única llamada `loop_complexity`. (#192)
+- Se colapsaron 7 brazos de sentencias casi idénticos mediante
+  `count_line_bool_ops`. (#192)
+- Se derivó `Default` en `ComplexityRegion` y `RegionKind`. (#192)
+- Se eliminó `merge_child` y su `child.regions.clone()` interno. (#192)
+- Se endureció el job de tests unitarios de release en Windows contra fallos
+  transitorios de la capa HTTP/2 de Cargo. (#189)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/6.0.0)
+para más detalles.
+
+## [5.6.1] - 2026-06-16
+
+### Corregido
+
+- Se corrigió un panic en `extract_comment_marker` cuando un carácter
+  multi-byte UTF-8 (em-dash, emoji, letras acentuadas, CJK) cruzaba el byte
+  offset 16 de un comentario, lo que antes abortaba el análisis del
+  directorio completo. El byte-slicing propenso a errores se reemplazó con
+  coincidencia basada en regex. (#187)
+
+### Eliminado
+
+- Se eliminó el workflow de auto-release `release-plz.yml` y sus archivos de
+  soporte (`CHANGELOG.md`, `cliff.toml`). Los releases manuales mediante
+  `release.yml` (tag → build → test → publish) son ahora el camino
+  estándar. (#188)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.6.1)
+para más detalles.
+
+## [5.6.0] - 2026-06-14
+
+### Añadido
+
+- Flag `--no-ignore` para ignorar los comentarios `# complexipy: ignore` y
+  `# noqa: complexipy`. (#182)
+- Flag `--report-ignored` para listar todas las funciones suprimidas, con
+  exportación JSON opcional a `complexipy-ignored.json`. (#182)
+- Tipo `IgnoredLocation` y `collect_all_ignored_locations()` en la API de
+  Python. (#182)
+
+### Corregido
+
+- Se corrigió el modo diff que mostraba todos los archivos como NEW en
+  Windows. (#177)
+
+### Cambiado
+
+- Se migró pyo3 a 0.29 y se actualizaron los runners de CI. (#185)
+- Se añadieron builds de wheels musllinux_1_2 para soporte de Alpine
+  Linux. (#180)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.6.0)
+para más detalles.
+
+## [5.5.0] - 2026-05-22
+
+### Añadido
+
+- Planes de refactorización deterministas: un algoritmo nuevo genera
+  sugerencias accionables y deterministas para reducir la complejidad
+  cognitiva. Los planes se muestran en la salida rica del CLI y se incluyen
+  en la salida JSON.
+- Globs de exclusión recursivos: los patrones de exclusión ahora admiten
+  `**` (p. ej. `tests/**`). El motor de globs se reemplazó por `wax` para un
+  emparejamiento recursivo correcto relativo al directorio de trabajo del
+  llamador.
+
+### Corregido
+
+- Se corrigió el crecimiento ilimitado de las entradas target-set en la
+  caché, que podía degradar el rendimiento en proyectos grandes.
+
+### Cambiado
+
+- Los internals de salida ahora usan dataclasses tipados `FunctionRow` /
+  `FileEntry` en lugar de estructuras `Dict` sin tipar, extraídos en
+  `complexipy/utils/dataclasses.py`.
+- Los despliegues de docs ahora se disparan solo en eventos de release, no
+  en cada push.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.5.0)
+para más detalles.
+
+## [5.4.1] - 2026-05-05
+
+### Corregido
+
+- Se estabilizó la salida de snapshots omitiendo los campos transitorios a
+  nivel de línea de las estructuras Rust serializadas hacia Python.
+- Se movieron las constantes de salida compartidas a
+  `complexipy.utils.constants` para que los nombres de archivo de salida,
+  las flags CLI heredadas y las claves TOML heredadas se definan en un solo
+  lugar.
+- Se aclaró el mensaje de deprecación de `--output-csv`, `--output-json` y
+  `--output-gitlab` para apuntar a `--output-format`.
+
+### Cambiado
+
+- Se actualizó el CI para que los pull requests ejecuten una matriz de
+  quick-test más rápida, mientras que los builds completos de wheels, sdist
+  y los jobs de test de todas las plataformas se ejecutan para tags o
+  despachos manuales.
+- Se habilitó el caching de dependencias uv en los jobs de CI.
+- Se actualizaron el README y los docs para reflejar los tipos de retorno
+  actuales de la API de Python y el formato actual de array JSON de los
+  snapshots.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.4.1)
+para más detalles.
+
+## [5.4.0] - 2026-04-25
+
+### Eliminado
+
+- Se eliminó el scoring de complejidad de comprehensions — revierte el
+  manejo de nodos AST `ListComp`/`SetComp`/`Generator`/`DictComp` en
+  `count_bool_ops()` y el helper `count_comprehension_complexity()` añadido
+  en v5.3.0. (#166)
+
+### Corregido
+
+- Se corrigió el feature gating de los builds WASM y se incluyeron los
+  metadatos de versión. (#164)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.4.0)
+para más detalles.
+
+## [5.3.0] - 2026-04-16
+
+### Añadido
+
+- Flag `--ratchet` — el CI falla solo cuando la complejidad aumenta por
+  encima del umbral; las regresiones se bloquean, las mejoras siempre
+  pasan. (#159)
+- Flag `--plain` — salida de texto plano legible por máquinas para scripting
+  y pipes. (#158)
+- Flag `--top N` — muestra las N funciones más complejas, ordenadas
+  globalmente entre todos los archivos. (#157)
+- Flags `--check-script` / `--script-strict` — analizan la complejidad a
+  nivel de módulo (script) además de las funciones. (#156)
+- Destinos de salida unificados — enrutamiento consistente de `--output-*`
+  en todos los formatos de reporte. (#155)
+- Reporte de GitLab Code Quality mediante `--output-gitlab`. (#153)
+- Salida SARIF 2.1.0 mediante `--output-sarif` para integración con IDE y
+  GitHub Advanced Security. (#141)
+- Análisis de diff git — `--diff <ref>` informa de los cambios de
+  complejidad relativos a cualquier referencia git. (#140)
+- Complejidad de comprehensions — las comprehensions de lista/dict/set y las
+  expresiones generador ahora contribuyen a las puntuaciones de complejidad
+  cognitiva. (#139)
+- `# complexipy: ignore` — nuevo comentario canónico de supresión en línea;
+  `# noqa: complexipy` queda deprecado. (#146)
+- Patrones glob en el campo `exclude` de la configuración. (#142)
+- Documentación en español. (#147)
+
+### Corregido
+
+- Los resultados de `--top` ahora preservan el orden descendente global en
+  ejecuciones multi-archivo.
+- `--top N` rechaza `N ≤ 0` con un error claro.
+- `--script-strict` ahora requiere `--check-script` correctamente.
+- Los marcadores de ignorar (`# complexipy: ignore`) ahora funcionan en
+  definiciones de función multilínea.
+- La salida JSON incluye una nueva línea final (cumplimiento POSIX). (#148)
+- Las funciones permitidas por snapshot ahora se muestran como `PASSED` en
+  la salida.
+- El watermark de snapshot ahora controla correctamente el código de salida
+  cuando está activo.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.3.0)
+para más detalles.
+
+## [5.2.0] - 2026-01-28
+
+### Corregido
+
+- Se corrigieron los comentarios `# noqa: complexipy` en funciones con
+  decoradores. (#128)
+
+### Cambiado
+
+- Se actualizó la versión de complexipy pre-commit en los docs. (#126)
+- Se actualizó la documentación. (#132)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.2.0)
+para más detalles.
+
+## [5.1.0] - 2025-12-09
+
+### Corregido
+
+- Se corrigieron las rutas de salida de resultados inválidas en
+  Windows. (#120)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.1.0)
+para más detalles.
+
+## [5.0.0] - 2025-11-26
+
+!!! note "Migración"
+
+    El scoring condicional ahora cuenta cada rama `elif`/`else` como +1 de
+    complejidad (más su test booleano), alineándose con las reglas de
+    complejidad cognitiva de Sonar. Espera puntuaciones más altas en código
+    con ramificaciones. Consulta la
+    [guía de migración](https://rohaquinlop.github.io/complexipy/es/migracion/)
+    para obtener orientación sobre la actualización.
+
+### Añadido
+
+- Snapshots: `--snapshot-create` escribe `complexipy-snapshot.json`; las
+  comparaciones bloquean regresiones, se auto-refrescan en mejoras y pueden
+  omitirse con `--snapshot-ignore`. (#111)
+- Seguimiento de cambios: una caché por target en `.complexipy_cache`
+  muestra deltas/nuevos fallos de las funciones por encima del umbral con
+  claves estables BLAKE2. (#115)
+- Controles de salida: `--failed` para mostrar solo violaciones (#114);
+  `--color auto|yes|no` (#109); resúmenes más ricos de funciones con fallos
+  y rutas inválidas.
+- Soporte de Python 3.14. (#106)
+
+### Cambiado
+
+- Exclusiones y errores: las entradas de exclusión se resuelven relativas a
+  la raíz y solo se aplican cuando coinciden con archivos/directorios
+  reales; las rutas inexistentes se informan limpiamente en lugar de
+  producir un panic. (#113)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/5.0.0)
+para más detalles.
+
+## [4.2.0] - 2025-09-21
+
+### Añadido
+
+- Excluir archivos del análisis.
+- Ignorados en línea para excluir funciones del análisis.
+
+### Corregido
+
+- Soporte de Python 3.8. (#96)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/4.2.0)
+para más detalles.
+
+## [4.1.0] - 2025-09-08
+
+### Añadido
+
+- Soporte de versión. (#93)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/4.1.0)
+para más detalles.
+
+## [4.0.2] - 2025-08-22
+
+Versión de parche; no se registraron cambios en sus notas de versión.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/4.0.2)
+para más detalles.
+
+## [4.0.1] - 2025-08-21
+
+### Corregido
+
+- Se corrigió el error del README en PyPI.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/4.0.1)
+para más detalles.
+
+## [4.0.0] - 2025-08-21
+
+!!! note "Migración"
+
+    La lógica de conteo de operadores booleanos en condiciones se actualizó
+    para alinearse con la definición del paper original. Las funciones
+    existentes pueden reportar complejidades más altas. Consulta la
+    [guía de migración](https://rohaquinlop.github.io/complexipy/es/migracion/)
+    para obtener orientación sobre la actualización.
+
+### Añadido
+
+- Soporte de configuración mediante `complexipy.toml` o `[tool.complexipy]`
+  en `pyproject.toml` — los usuarios pueden ahora definir argumentos por
+  defecto.
+
+### Corregido
+
+- Se corrigió un bucle infinito al analizar módulos con sintaxis Python
+  inválida. (#85, resuelto en #88)
+
+### Cambiado
+
+- Se mejoró el rendimiento y los detalles de implementación en Rust.
+- Se actualizó y mejoró la documentación.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/4.0.0)
+para más detalles.
+
+## [3.3.0] - 2025-07-17
+
+### Añadido
+
+- `--max-complexity-allowed` (`-mx`) — personaliza el umbral máximo de
+  complejidad cognitiva permitido por función. El valor por defecto sigue
+  siendo 15 para mantener el comportamiento existente.
+- Integración con GitHub Actions para el umbral personalizado.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/3.3.0)
+para más detalles.
+
+## [3.2.0] - 2025-07-09
+
+### Corregido
+
+- Se corrigió un error al usar complexipy en Windows, relacionado con la
+  librería `rich` usada para dibujar la salida de consola con emojis.
+- Se corrigió que el parámetro `quiet` siguiera dibujando salida no
+  manejada en el código Rust.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/3.2.0)
+para más detalles.
+
+## [3.1.1] - 2025-07-06
+
+### Cambiado
+
+- El umbral máximo de complejidad ahora es `15`, coincidiendo con el umbral
+  de Sonar para facilitar la adopción de la librería. (#78)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/3.1.1)
+para más detalles.
+
+## [3.0.0] - 2025-06-16
+
+!!! note "Migración"
+
+    `--max-complexity` se eliminó; complexipy ahora usa un umbral fijo de
+    complejidad cognitiva de 15. La herramienta sale con error cuando una
+    función alcanza o supera el umbral. Usa `--ignore-complexity` (`-i`)
+    para mostrar todas las funciones independientemente de su puntuación.
+    Consulta la
+    [guía de migración](https://rohaquinlop.github.io/complexipy/es/migracion/)
+    para obtener orientación sobre la actualización.
+
+### Añadido
+
+- Soporte de WebAssembly (WASM) — el motor de análisis central ahora puede
+  compilarse a WebAssembly, habilitando el análisis en el navegador y
+  herramientas como la extensión de VSCode. (#72)
+- Salida JSON mediante `--output-json` (`-j`) para resultados legibles por
+  máquinas. (#74)
+- Flag `--ignore-complexity` (`-i`) para mostrar todas las funciones
+  independientemente de si superan el umbral de complejidad. (#73)
+- `--details` (`-d`) ahora afecta también a las salidas CSV y JSON. (#73)
+- Ordenar resultados por puntuación de complejidad (`asc`, `desc`) o por
+  `name`. (#73)
+- Soporte de pre-commit hook con documentación para una configuración
+  sencilla. (#75)
+
+### Eliminado
+
+- El argumento `--max-complexity`. (#73)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/3.0.0)
+para más detalles.
+
+## [2.1.1] - 2025-04-24
+
+### Corregido
+
+- Se corrigió la compatibilidad con Python 3.8. (#66)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/2.1.1)
+para más detalles.
+
+## [2.1.0] - 2025-04-23
+
+### Corregido
+
+- Se corrigió el conteo de operadores booleanos en expresiones de
+  diccionario. (#64)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/2.1.0)
+para más detalles.
+
+## [2.0.0] - 2025-04-18
+
+### Cambiado
+
+- Se cambió el parser de `rustpython` a `ruff_python_parser`. (#62)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/2.0.0)
+para más detalles.
+
+## [1.2.0] - 2024-12-15
+
+### Corregido
+
+- Se corrigió la llamada a `output_summary`, a la que faltaba el argumento
+  `files_complexities`. (#58)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/1.2.0)
+para más detalles.
+
+## [1.1.0] - 2024-12-14
+
+### Añadido
+
+- Soporte de múltiples rutas — pasa varios paths para analizar a la
+  vez. (#56)
+
+### Eliminado
+
+- La opción deprecada `-l`, simplificando la interfaz de línea de
+  comandos. (#56)
+- El análisis a nivel de archivo, para centrarse en las funciones en lugar
+  de todo el archivo. (#56)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/1.1.0)
+para más detalles.
+
+## [0.5.0] - 2024-10-28
+
+### Añadido
+
+- API de Python — llama a complexipy desde tu propio código Python con
+  `file_complexity()` y `code_complexity()`. (#45)
+- Uso de la librería documentado en el README. (#49)
+- Usabilidad del paquete mejorada. (#53)
+- Documentación actualizada. (#54)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.5.0)
+para más detalles.
+
+## [0.4.0] - 2024-06-21
+
+### Añadido
+
+- La complejidad cognitiva ahora considera el `If Expression` usado en el
+  código, incluido dentro de un `Call Expression`, etc. (#44)
+
+### Corregido
+
+- Se corrigió un edge case que podía causar un desbordamiento de memoria,
+  filtrando la complejidad cognitiva de los valores `orelse` en un `If Statement` y manteniendo la propagación de la resta del nivel de
+  anidamiento. (#44)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.4.0)
+para más detalles.
+
+## [0.3.3] - 2024-04-27
+
+### Cambiado
+
+- Se actualizó el CI y se eliminaron dependencias sin uso. (#43)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.3.3)
+para más detalles.
+
+## [0.3.2] - 2024-03-22
+
+### Cambiado
+
+- Al usar `--details low`, ya no se imprime una tabla de resumen vacía; se
+  muestra un mensaje informativo. (#38)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.3.2)
+para más detalles.
+
+## [0.3.1] - 2024-03-13
+
+### Añadido
+
+- Parámetro opcional `-s` / `--sort` para ordenar la salida. (#30)
+- Requisito de Python >= 3.8. (#35)
+
+### Corregido
+
+- Se corrigió la lógica usada para calcular la complejidad cognitiva: las
+  sentencias de asignación solo añaden complejidad cuando se usa `IfExp`, y
+  `BinOp` por sí solo no añade complejidad. (#34)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.3.1)
+para más detalles.
+
+## [0.3.0] - 2024-03-07
+
+### Añadido
+
+- Análisis de complejidad a nivel de función por defecto — la complejidad
+  máxima se evalúa para cada función dentro de los archivos Python; la
+  complejidad cognitiva por archivo sigue disponible. (#21)
+- Nuevos parámetros. (#14)
+- Barras de progreso. (#24)
+- Opción `--quiet`. (#26)
+- Tests unitarios. (#20)
+- Explicación de la complejidad cognitiva en los docs. (#22)
+
+### Cambiado
+
+- Se mejoró el algoritmo de medición de la complejidad cognitiva — los
+  resultados se acercan más a la implementación de Sonar. (#18)
+- Se redujo la verbosidad, con más información sobre las etapas al ejecutar
+  `complexipy` sobre repositorios git (usando la URL).
+- La generación del reporte CSV ahora está implementada en Rust en lugar de
+  Python, mejorando el rendimiento.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.3.0)
+para más detalles.
+
+## [0.2.2] - 2024-02-27
+
+Versión de parche; no se registraron cambios en sus notas de versión.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.2.2)
+para más detalles.
+
+## [0.2.1] - 2024-02-27
+
+### Cambiado
+
+- Se actualizó el README.
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.2.1)
+para más detalles.
+
+## [0.2.0] - 2024-02-27
+
+### Añadido
+
+- Soporte de rutas a ignorar. (#6)
+- Soporte de URLs de repositorios git. (#7)
+- Formato de salida CSV. (#8)
+- Correcciones del algoritmo de complejidad cognitiva. (#10)
+- README actualizado. (#9)
+
+Consulta las [notas de la versión](https://github.com/rohaquinlop/complexipy/releases/tag/0.2.0)
+para más detalles.

--- a/mkdocs.es.yml
+++ b/mkdocs.es.yml
@@ -14,6 +14,7 @@ nav:
   - Primeros Pasos:
       - Guía de Uso: usage-guide.md
       - Guía de Migración: migracion.md
+  - Registro de Cambios: changelog.md
   - Entendiendo la Complejidad:
       - Qué Significan las Puntuaciones: understanding-scores.md
       - Comparación con Ruff: comparison-with-ruff.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Getting Started:
       - Usage Guide: usage-guide.md
       - Migration Guide: migration.md
+  - Changelog: changelog.md
   - Understanding Complexity:
       - What Scores Mean: understanding-scores.md
       - Comparison with Ruff: comparison-with-ruff.md
@@ -94,7 +95,8 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.snippets
+  - pymdownx.snippets:
+      check_paths: true
   - admonition
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
## What

Adds a centralized changelog to the documentation site, with the full per-release history curated from the GitHub release notes, plus an Unreleased section that tracks pending changes.

## Why

Issue #222: the documentation had no single place showing what changed between releases. Users had to dig through git history, GitHub releases, or the migration page. A changelog page gives everyone — users and contributors — the features, fixes, and breaking changes of every release in one place.

## Changes

- **`CHANGELOG.md`** (repo root) — single source of truth: `## Unreleased` on top, then one dated section per release (0.2.0 → 6.2.0, all 36 releases), newest first, in Keep a Changelog shape (Added / Changed / Fixed / Removed) with Migration callouts on the breaking majors (3.0.0, 4.0.0, 5.0.0, 6.0.0) linking to the migration guide
- **Unreleased section** — seeded with the removals merged in PR #221, then expanded to cover all 9 PRs merged since 6.2.0 (clippy-style `--suggest-refactors`, public diff API, `--staged`, `[tool.complexipy.diff]`, removable-ignore reporting, snapshot partial-run fix, and more)
- **`docs/changelog.md`** — embeds the root file via the pymdownx.snippets include (`--8<-- "CHANGELOG.md"`), so the docs page can never drift; `check_paths: true` makes a missing include fail the build
- **`docs/es/changelog.md`** — full Spanish mirror, same sections, dates, and PR references
- **Nav + README** — Changelog entry added to `mkdocs.yml` and `mkdocs.es.yml` (Registro de Cambios); README header links to the page
- **`release-notes` skill** — updated so creating release notes keeps the changelog in sync: fill Unreleased from merged PRs, move it into a dated section at release time, mirror in Spanish, plus changelog conventions documented

Closes #222
