### PR TITLE
feat(rules): measure refactor reductions instead of estimating them

### DIFF
--- a/complexipy/_complexipy.pyi
+++ b/complexipy/_complexipy.pyi
@@ -43,8 +43,15 @@ class CodeSuggestion:
     description: str
     """Description of what this suggestion does."""
 
+    spliceable: bool
+    """Whether the replacement is a faithful source splice that can be measured."""
+
     def __init__(
-        self, replacement: str, applicability: Applicability, description: str
+        self,
+        replacement: str,
+        applicability: Applicability,
+        description: str,
+        spliceable: bool,
     ) -> None: ...
 
 class LineComplexity:
@@ -107,10 +114,17 @@ class RefactorPlan:
     """Current cognitive complexity of the function."""
 
     estimated_reduction: int
-    """Estimated complexity reduction from applying this refactoring."""
+    """Complexity reduction from applying this refactoring — measured when
+    `reduction_is_measured` is true, formula-estimated otherwise."""
 
     estimated_complexity_after: int
-    """Estimated complexity after applying this refactoring."""
+    """Complexity after applying this refactoring — measured when
+    `reduction_is_measured` is true, formula-estimated otherwise."""
+
+    reduction_is_measured: bool
+    """True when the reduction was measured by splicing the suggestion into
+    the source and re-scoring it; false for formula estimates (help-only
+    rules and measurement fallbacks)."""
 
     rule_id: str
     """Unique identifier for the rule (e.g., 'C001', 'C007')."""
@@ -149,6 +163,7 @@ class RefactorPlan:
         current_complexity: int,
         estimated_reduction: int,
         estimated_complexity_after: int,
+        reduction_is_measured: bool,
         rule_id: str,
         category: RuleCategory,
         applicability: Applicability,

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -362,9 +362,13 @@ def _output_single_plan(
         f"          Category: {category_icon} {category_name} "
         f"| Applicability: {applicability_icon} {applicability_name}"
     )
+    reduction_label = (
+        "Reduction" if plan.reduction_is_measured else "Estimated reduction"
+    )
+    qualifier = "" if plan.reduction_is_measured else "~"
     console.print(
         f"          Lines {plan.line_start}-{plan.line_end} "
-        f"-> Estimated reduction: [green]-{plan.estimated_reduction}[/green] complexity "
+        f"-> {reduction_label}: [green]-{qualifier}{plan.estimated_reduction}[/green] complexity "
         f"({plan.current_complexity} -> {plan.estimated_complexity_after})"
     )
 

--- a/docs/es/refactoring-rules.md
+++ b/docs/es/refactoring-rules.md
@@ -445,9 +445,11 @@ La salida JSON incluye todos los metadatos de las reglas para consumo programát
   "current_complexity": 4,
   "estimated_reduction": 1,
   "estimated_complexity_after": 3,
+  "reduction_is_measured": true,
   "suggestion": {
     "replacement": "    if data and data.is_valid():\n        return process(data)",
     "applicability": "MachineApplicable",
+    "spliceable": true,
     "description": "Merge nested conditions into `if data and data.is_valid():`"
   },
   "help": null,
@@ -456,6 +458,26 @@ La salida JSON incluye todos los metadatos de las reglas para consumo programát
   "doc_url": "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c007-collapsible-if"
 }
 ```
+
+### Reducciones medidas vs estimadas
+
+Cada plan informa cuánto reduce la complejidad al aplicarlo
+(`estimated_reduction` / `estimated_complexity_after`) junto con un
+indicador de confianza, `reduction_is_measured`:
+
+- **Medida** (`true`): la regla insertó su sugerencia en el código real, lo
+  re-analizó y volvió a ejecutar el puntuador. El número es la respuesta
+  literal a "aplica esto y vuelve a puntuar" — exactamente lo que
+  reportan C002 y C007, que llevan reemplazos aplicables por máquina. La
+  CLI los muestra sin calificador: `Reduction: -2 complexity (7 -> 5)`.
+- **Estimada** (`false`): el número proviene de la fórmula manual de la
+  regla (reglas solo con ayuda C001, C003, C004, C011, y el fragmento
+  C005, además de cualquier respaldo cuando una inserción no se puede
+  re-analizar). La CLI los muestra con una tilde:
+  `Estimated reduction: ~-2 complexity (7 -> 5)`.
+
+Una reducción medida de 0 significa que la sugerencia no reduce la
+complejidad realmente; el plan se descarta en lugar de mostrarse.
 
 ______________________________________________________________________
 

--- a/docs/refactoring-rules.md
+++ b/docs/refactoring-rules.md
@@ -445,9 +445,11 @@ The JSON output includes all rule metadata for programmatic consumption:
   "current_complexity": 4,
   "estimated_reduction": 1,
   "estimated_complexity_after": 3,
+  "reduction_is_measured": true,
   "suggestion": {
     "replacement": "    if data and data.is_valid():\n        return process(data)",
     "applicability": "MachineApplicable",
+    "spliceable": true,
     "description": "Merge nested conditions into `if data and data.is_valid():`"
   },
   "help": null,
@@ -456,6 +458,25 @@ The JSON output includes all rule metadata for programmatic consumption:
   "doc_url": "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c007-collapsible-if"
 }
 ```
+
+### Measured vs estimated reductions
+
+Every plan reports how much applying it lowers the complexity
+(`estimated_reduction` / `estimated_complexity_after`) together with a
+confidence flag, `reduction_is_measured`:
+
+- **Measured** (`true`): the rule spliced its suggestion into the real
+  source, re-parsed it, and re-ran the scorer. The number is the literal
+  answer to "apply this and re-score" — exactly what C002 and C007
+  report, since they carry machine-applicable replacements. The CLI shows
+  these without a qualifier: `Reduction: -2 complexity (7 -> 5)`.
+- **Estimated** (`false`): the number comes from the rule's hand-derived
+  formula (help-only rules C001, C003, C004, C011, and the C005 snippet,
+  plus any fallback when a splice cannot be re-parsed). The CLI renders
+  these with a tilde: `Estimated reduction: ~-2 complexity (7 -> 5)`.
+
+A measured reduction of 0 means the suggestion does not actually lower
+complexity; the plan is dropped rather than shown.
 
 ______________________________________________________________________
 

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -31,6 +31,7 @@ pub struct CodeSuggestion {
     pub replacement: String,
     pub applicability: Applicability,
     pub description: String,
+    pub spliceable: bool,
 }
 
 #[cfg_attr(
@@ -80,6 +81,7 @@ pub struct RefactorPlan {
     pub current_complexity: u64,
     pub estimated_reduction: u64,
     pub estimated_complexity_after: u64,
+    pub reduction_is_measured: bool,
 
     pub rule_id: String,
     pub category: RuleCategory,

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -44,8 +44,13 @@ pub fn code_complexity(
         }
     };
     let ast_body = parsed.into_suite();
-    let (functions, complexity) =
-        function_level_cognitive_complexity_shared(&ast_body, code, check_script, no_ignore);
+    let (functions, complexity) = function_level_cognitive_complexity_shared(
+        &ast_body,
+        code,
+        check_script,
+        no_ignore,
+        true,
+    );
     Ok(CodeComplexity {
         functions,
         complexity,
@@ -60,6 +65,7 @@ pub fn function_level_cognitive_complexity_shared(
     code: &str,
     check_script: bool,
     no_ignore: bool,
+    with_plans: bool,
 ) -> (Vec<FunctionComplexity>, u64) {
     let mut functions: Vec<FunctionComplexity> = Vec::new();
     let mut complexity: u64 = 0;
@@ -71,7 +77,13 @@ pub fn function_level_cognitive_complexity_shared(
         match node {
             Stmt::FunctionDef(f) => {
                 if !is_ignored(f, code, no_ignore) {
-                    functions.push(analyze_function(node, f, f.name.to_string(), code));
+                    functions.push(analyze_function(
+                        node,
+                        f,
+                        f.name.to_string(),
+                        code,
+                        with_plans,
+                    ));
                 }
             }
             Stmt::ClassDef(c) => {
@@ -84,6 +96,7 @@ pub fn function_level_cognitive_complexity_shared(
                             f,
                             format!("{}::{}", c.name, f.name),
                             code,
+                            with_plans,
                         ));
                     }
                 }
@@ -103,8 +116,11 @@ pub fn function_level_cognitive_complexity_shared(
 
     if check_script {
         let total_lines = code.lines().count() as u64;
-        let (refactor_plans, additional_refactor_plans) =
-            build_refactor_plans(module_complexity, &module_regions, code);
+        let (refactor_plans, additional_refactor_plans) = if with_plans {
+            build_refactor_plans(module_complexity, &module_regions, code, true)
+        } else {
+            (Vec::new(), 0)
+        };
         functions.push(FunctionComplexity {
             name: "<module>".to_string(),
             complexity: module_complexity,
@@ -134,14 +150,18 @@ fn analyze_function(
     f: &ast::StmtFunctionDef,
     name: String,
     code: &str,
+    with_plans: bool,
 ) -> FunctionComplexity {
     let mut result = statement_cognitive_complexity_shared(node, 0, code);
     if let Some(line) = detect_direct_recursion(&f.body, f.name.as_str(), code) {
         result.complexity += 1;
         push_line(&mut result, line, 1);
     }
-    let (refactor_plans, additional_refactor_plans) =
-        build_refactor_plans(result.complexity, &result.regions, code);
+    let (refactor_plans, additional_refactor_plans) = if with_plans {
+        build_refactor_plans(result.complexity, &result.regions, code, false)
+    } else {
+        (Vec::new(), 0)
+    };
     FunctionComplexity {
         name,
         complexity: result.complexity,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod classes;
-mod cognitive_complexity;
+pub(crate) mod cognitive_complexity;
 mod helpers;
 mod refactor_plans;
 mod rules;

--- a/src/refactor_plans.rs
+++ b/src/refactor_plans.rs
@@ -45,8 +45,9 @@ pub fn build_refactor_plans(
     function_complexity: u64,
     regions: &[ComplexityRegion],
     source: &str,
+    is_module: bool,
 ) -> (Vec<RefactorPlan>, u64) {
     static REGISTRY: OnceLock<RuleRegistry> = OnceLock::new();
     let registry = REGISTRY.get_or_init(RuleRegistry::new);
-    registry.analyze(regions, source, function_complexity)
+    registry.analyze(regions, source, function_complexity, is_module)
 }

--- a/src/rules/complexity.rs
+++ b/src/rules/complexity.rs
@@ -596,7 +596,8 @@ impl RefactorRule for CollapsibleIfRule {
 
 /// Generate a concrete suggestion for loop guards by inverting nested if
 /// conditions and using continue. Uses the region tree to collect guards,
-/// similar to how C007 uses `collect_if_chain`.
+/// similar to how C007 uses `collect_if_chain`. Returns `None` when the body
+/// holds no guardable chain — callers fall back to `help` text then.
 fn generate_loop_guard_suggestion(
     region: &ComplexityRegion,
     source: &str,
@@ -610,8 +611,6 @@ fn generate_loop_guard_suggestion(
     }
 
     let base_indent = get_indentation_from_str(lines[start]);
-    let indent_step = detect_indent_step(&lines[start..end]);
-    let loop_body_indent = base_indent + indent_step;
 
     let mut guards = Vec::new();
     let mut current_region: Option<&ComplexityRegion> = None;
@@ -645,15 +644,37 @@ fn generate_loop_guard_suggestion(
         break;
     }
 
-    if guards.is_empty() {
+    // A loop-level `else` (for/while-else, aligned with the loop header)
+    // cannot survive the guard transformation: re-emitted as-is it becomes a
+    // dangling `else` inside the body. A first chain member with its own
+    // `else`/`elif` cannot become a guard either — the guard would skip the
+    // `else` branch entirely.
+    if has_else_branch(region, &lines)
+        || guards.is_empty()
+        || has_else_branch(guards[0].0, &lines)
+    {
         return None;
     }
 
     let innermost = guards.last().unwrap().0;
     let innermost_line_idx = (innermost.line_start.saturating_sub(1)) as usize;
+    let innermost_end = (innermost.line_end as usize).min(lines.len());
+    let chain_start_idx = (guards[0].0.line_start.saturating_sub(1)) as usize;
+
+    // The body indent and step come from the first chain member's own line:
+    // the header may span several lines, so its continuation lines cannot be
+    // trusted to reveal the step. Header continuation lines fall into the
+    // leading range below and pass through unchanged.
+    let loop_body_indent = get_indentation_from_str(lines[chain_start_idx]);
+    let indent_step = loop_body_indent.saturating_sub(base_indent);
 
     let mut result = Vec::new();
     result.push(lines[start].to_string());
+    result.extend(
+        lines[(start + 1)..chain_start_idx]
+            .iter()
+            .map(|line| (*line).to_string()),
+    );
 
     for (_, guard) in &guards {
         result.push(format!("{}if not {}:", " ".repeat(loop_body_indent), guard));
@@ -663,8 +684,7 @@ fn generate_loop_guard_suggestion(
         ));
     }
 
-    let body_start = innermost_line_idx + 1;
-    for line in &lines[body_start..end] {
+    for line in &lines[(innermost_line_idx + 1)..innermost_end] {
         let trimmed = line.trim_start();
         if trimmed.is_empty() {
             result.push(String::new());
@@ -675,10 +695,16 @@ fn generate_loop_guard_suggestion(
         let padding = " ".repeat(shifted);
         result.push(format!("{}{}", padding, trimmed));
     }
+    result.extend(
+        lines[innermost_end..end]
+            .iter()
+            .map(|line| (*line).to_string()),
+    );
 
     Some(CodeSuggestion {
         replacement: result.join("\n"),
         applicability: Applicability::MachineApplicable,
+        spliceable: true,
         description: format!(
             "Convert {} nested conditions to continue guards",
             guards.len()
@@ -733,6 +759,7 @@ fn generate_predicate_suggestion(
     Some(CodeSuggestion {
         replacement,
         applicability: Applicability::MachineApplicable,
+        spliceable: false,
         description: format!("Extract condition into named predicate function `{func_name}`"),
     })
 }
@@ -903,6 +930,7 @@ fn generate_collapsible_if_suggestion_chain(
     CodeSuggestion {
         replacement,
         applicability: Applicability::MachineApplicable,
+        spliceable: true,
         description: format!("Merge nested conditions into `if {}:`", combined),
     }
 }

--- a/src/rules/registry.rs
+++ b/src/rules/registry.rs
@@ -1,6 +1,8 @@
 use super::types::RefactorRule;
-use crate::classes::RefactorPlan;
+use crate::classes::{CodeSuggestion, RefactorPlan};
+use crate::cognitive_complexity::function_level_cognitive_complexity_shared;
 use crate::refactor_plans::ComplexityRegion;
+use ruff_python_parser::parse_module;
 use std::collections::HashMap;
 
 pub struct RuleRegistry {
@@ -58,15 +60,39 @@ impl RuleRegistry {
         regions: &[ComplexityRegion],
         source: &str,
         function_complexity: u64,
+        is_module: bool,
     ) -> (Vec<RefactorPlan>, u64) {
         let mut plans = Vec::new();
 
         self.collect_plans(regions, source, function_complexity, &mut plans);
+        self.measure_plans(&mut plans, source, is_module);
 
         plans.retain(|plan| plan.estimated_reduction >= 1);
 
         let effectiveness = self.effectiveness_by_rule_id();
         select_non_overlapping(plans, &effectiveness)
+    }
+
+    /// Plans whose measurement fails keep their formula estimate with
+    /// `reduction_is_measured = false` — never a panic, never a fabricated
+    /// measured number.
+    fn measure_plans(&self, plans: &mut [RefactorPlan], source: &str, is_module: bool) {
+        for plan in plans.iter_mut() {
+            let Some(suggestion) = &plan.suggestion else {
+                continue;
+            };
+            if !suggestion.spliceable {
+                continue;
+            }
+            let Some(measured) = measure_reduction(plan, suggestion, source, is_module) else {
+                continue;
+            };
+            plan.estimated_reduction = measured;
+            plan.estimated_complexity_after = plan
+                .current_complexity
+                .saturating_sub(measured);
+            plan.reduction_is_measured = true;
+        }
     }
 
     fn collect_plans(
@@ -92,6 +118,57 @@ impl Default for RuleRegistry {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn splice_plan(plan: &RefactorPlan, suggestion: &CodeSuggestion, source: &str) -> Option<String> {
+    let start: usize = plan.line_start.saturating_sub(1) as usize;
+    let end: usize = plan.line_end as usize;
+    let lines: Vec<&str> = source.lines().collect();
+    if start > end || end > lines.len() {
+        return None;
+    }
+    let mut spliced = Vec::with_capacity(lines.len() + 1);
+    spliced.extend(lines[..start].iter().copied());
+    spliced.push(suggestion.replacement.as_str());
+    spliced.extend(lines[end..].iter().copied());
+    Some(spliced.join("\n"))
+}
+
+/// The target is `<module>` for script-mode plans (module-level regions
+/// only reach the registry through the `is_module` call); otherwise it is
+/// the function with the greatest `line_start` still before the plan's
+/// region — the splice only shifts lines after the region, so the
+/// containing function's start is unchanged between the two parses.
+///
+/// Returns `None` when the spliced source cannot be parsed or the target
+/// cannot be located; the caller keeps the formula estimate then.
+fn measure_reduction(
+    plan: &RefactorPlan,
+    suggestion: &CodeSuggestion,
+    source: &str,
+    is_module: bool,
+) -> Option<u64> {
+    let spliced = splice_plan(plan, suggestion, source)?;
+    let parsed = parse_module(&spliced).ok()?;
+    let (functions, _) = function_level_cognitive_complexity_shared(
+        &parsed.into_suite(),
+        &spliced,
+        true,
+        true,
+        false,
+    );
+
+    let new_complexity = if is_module {
+        functions.iter().find(|f| f.name == "<module>")?.complexity
+    } else {
+        let containing = functions
+            .iter()
+            .filter(|f| f.name != "<module>" && f.line_start <= plan.line_start)
+            .max_by_key(|f| f.line_start)?;
+        containing.complexity
+    };
+
+    Some(plan.current_complexity.saturating_sub(new_complexity))
 }
 
 /// Sorts by effectiveness/reduction/line, then keeps only non-overlapping

--- a/src/rules/types.rs
+++ b/src/rules/types.rs
@@ -41,6 +41,7 @@ impl RuleMetadata {
             current_complexity: 0,
             estimated_reduction: 0,
             estimated_complexity_after: 0,
+            reduction_is_measured: false,
             rule_id: self.id.clone(),
             category: self.category.clone(),
             applicability: self.applicability.clone(),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -482,7 +482,13 @@ fn collect_removable_ignores_from_file(
     let parsed = parse_module(&code)
         .map_err(|e| PyValueError::new_err(format!("Failed to parse code: {}", e)))?;
     let ast_body = parsed.into_suite();
-    let (functions, _) = function_level_cognitive_complexity_shared(&ast_body, &code, false, true);
+    let (functions, _) = function_level_cognitive_complexity_shared(
+        &ast_body,
+        &code,
+        false,
+        true,
+        false,
+    );
     let removable = filter_removable_ignores(&locations, &functions, max_complexity_allowed);
     Ok(removable
         .into_iter()

--- a/src/tests/rules/complexity.rs
+++ b/src/tests/rules/complexity.rs
@@ -6,7 +6,7 @@
 
 use super::{
     collect_loop_if_chain, combine_conditions_chain, extract_condition_from_line,
-    fallback_boolean_count, needs_parens_for_and,
+    fallback_boolean_count, generate_loop_guard_suggestion, needs_parens_for_and,
 };
 use crate::refactor_plans::{ComplexityRegion, RegionKind};
 
@@ -153,6 +153,8 @@ fn returns_none_when_condition_spans_multiple_lines_via_unclosed_paren() {
 #[test]
 fn returns_none_for_unrecognized_leading_keyword() {
     assert_eq!(extract_condition_from_line("for x in items:"), None);
+    assert_eq!(extract_condition_from_line("match x:"), None);
+    assert_eq!(extract_condition_from_line("with open(f) as fh:"), None);
 }
 
 #[test]
@@ -265,4 +267,166 @@ fn fallback_boolean_count_sums_known_booleans_plus_one_join_per_merge() {
 
     // 1 + 2 + 0 known booleans, plus (3 - 1) joins from merging 3 conditions.
     assert_eq!(fallback_boolean_count(&refs), 5);
+}
+
+fn loop_region(children: Vec<ComplexityRegion>, line_end: u64) -> ComplexityRegion {
+    ComplexityRegion {
+        kind: RegionKind::Loop,
+        line_start: 1,
+        line_end,
+        children,
+        ..Default::default()
+    }
+}
+
+fn if_stmt(line_start: u64, line_end: u64, nesting: u64) -> ComplexityRegion {
+    ComplexityRegion {
+        kind: RegionKind::If,
+        line_start,
+        line_end,
+        nesting,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn loop_guard_suggestion_is_faithful_for_a_pure_chain() {
+    let source = "for x in y:\n    if a:\n        if b:\n            pass\n";
+    let region = loop_region(
+        vec![ComplexityRegion {
+            kind: RegionKind::If,
+            line_start: 2,
+            line_end: 4,
+            nesting: 1,
+            children: vec![if_stmt(3, 4, 2)],
+            ..Default::default()
+        }],
+        4,
+    );
+
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert!(suggestion.spliceable);
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    if not a:\n        continue\n    if not b:\n        continue\n    pass"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_keeps_leading_statements() {
+    let source = "for x in y:\n    total += x\n    if a:\n        pass\n";
+    let region = loop_region(vec![if_stmt(3, 4, 1)], 4);
+
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    total += x\n    if not a:\n        continue\n    pass"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_keeps_trailing_statements_at_loop_indent() {
+    let source = "for x in y:\n    if a:\n        pass\n    total += 1\n";
+    let region = loop_region(vec![if_stmt(2, 3, 1)], 4);
+
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    if not a:\n        continue\n    pass\n    total += 1"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_keeps_an_else_on_the_last_chain_member() {
+    let source = "for x in y:\n    if a:\n        if b:\n            pass\n        else:\n            pass\n";
+    let region = loop_region(
+        vec![ComplexityRegion {
+            kind: RegionKind::If,
+            line_start: 2,
+            line_end: 6,
+            nesting: 1,
+            children: vec![if_stmt(3, 6, 2)],
+            ..Default::default()
+        }],
+        6,
+    );
+
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    if not a:\n        continue\n    if b:\n        pass\n    else:\n        pass"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_preserves_a_multiline_header() {
+    let source = "for x in (\n    items):\n    if a:\n        pass\n";
+    let region = loop_region(vec![if_stmt(3, 4, 1)], 4);
+
+    // The header continuation lines pass through unchanged; only the body
+    // is transformed.
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert!(suggestion.spliceable);
+    assert_eq!(
+        suggestion.replacement,
+        "for x in (\n    items):\n    if not a:\n        continue\n    pass"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_refuses_a_first_member_with_its_own_else() {
+    let source = "for x in y:\n    if a:\n        pass\n    else:\n        pass\n";
+    let region = loop_region(vec![if_stmt(2, 4, 1)], 4);
+
+    // The guard `if not a: continue` would skip the `else` branch entirely.
+    assert!(generate_loop_guard_suggestion(&region, source).is_none());
+}
+
+#[test]
+fn loop_guard_suggestion_refuses_a_loop_level_else() {
+    let source = "def f():\n    for x in y:\n        if a:\n            pass\n    else:\n        pass\n";
+    let region = ComplexityRegion {
+        kind: RegionKind::Loop,
+        line_start: 2,
+        line_end: 5,
+        children: vec![if_stmt(3, 4, 1)],
+        ..Default::default()
+    };
+
+    // The loop's own `else` would dangle after the guards.
+    assert!(generate_loop_guard_suggestion(&region, source).is_none());
+}
+
+#[test]
+fn loop_guard_suggestion_refuses_an_unextractable_condition() {
+    let source = "for x in y:\n    if (a and\n            b):\n        pass\n";
+    let region = loop_region(vec![if_stmt(2, 4, 1)], 4);
+
+    // The first chain member's condition spans lines; no guard text exists.
+    assert!(generate_loop_guard_suggestion(&region, source).is_none());
+}
+
+#[test]
+fn loop_guard_suggestion_keeps_unextractable_members_in_the_survivor() {
+    let source =
+        "for x in y:\n    if a:\n        if (b and\n                c):\n            pass\n";
+    let region = loop_region(
+        vec![ComplexityRegion {
+            kind: RegionKind::If,
+            line_start: 2,
+            line_end: 5,
+            nesting: 1,
+            children: vec![if_stmt(3, 5, 2)],
+            ..Default::default()
+        }],
+        5,
+    );
+
+    // The first member becomes a guard; the unextractable member stays in
+    // the survivor block, dedented with it, unchanged.
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    if not a:\n        continue\n    if (b and\n            c):\n        pass"
+    );
 }

--- a/src/tests/rules/registry.rs
+++ b/src/tests/rules/registry.rs
@@ -4,9 +4,11 @@
 //! so this stays a child module of the code it tests and can reach the private
 //! `RuleRegistry.rules` field through `super::` without widening its visibility.
 
-use super::{RuleRegistry, select_non_overlapping};
-use crate::classes::{Applicability, RefactorPlan, RuleCategory};
+use super::{RuleRegistry, measure_reduction, select_non_overlapping, splice_plan};
+use crate::classes::{Applicability, CodeSuggestion, RefactorPlan, RuleCategory};
+use crate::cognitive_complexity::function_level_cognitive_complexity_shared;
 use crate::refactor_plans::{ComplexityRegion, RegionKind};
+use ruff_python_parser::parse_module;
 use std::collections::HashMap;
 
 fn plan(rule_id: &str, line_start: u64, line_end: u64, estimated_reduction: u64) -> RefactorPlan {
@@ -19,6 +21,7 @@ fn plan(rule_id: &str, line_start: u64, line_end: u64, estimated_reduction: u64)
         current_complexity: 10,
         estimated_reduction,
         estimated_complexity_after: 10u64.saturating_sub(estimated_reduction),
+        reduction_is_measured: false,
         rule_id: rule_id.to_string(),
         category: RuleCategory::Complexity,
         applicability: Applicability::Informational,
@@ -284,4 +287,120 @@ fn effectiveness_matches_documented_tiers() {
             "effectiveness mismatch for {rule_id}"
         );
     }
+}
+
+fn module_complexity(source: &str) -> u64 {
+    let parsed = parse_module(source).unwrap();
+    let (functions, _) =
+        function_level_cognitive_complexity_shared(&parsed.into_suite(), source, true, true, false);
+    functions
+        .iter()
+        .find(|f| f.name == "<module>")
+        .unwrap()
+        .complexity
+}
+
+/// A loop whose first if has two children (one plain statement, one nested
+/// if): C007 cannot collapse it (multi-child chain), so C002 is the only
+/// rule that fires.
+fn loop_guard_regions() -> (Vec<ComplexityRegion>, String) {
+    let source =
+        "for x in y:\n    if a:\n        total += x\n        if b:\n            pass\n".to_string();
+    let regions = vec![ComplexityRegion {
+        kind: RegionKind::Loop,
+        line_start: 1,
+        line_end: 5,
+        total: 6,
+        children: vec![ComplexityRegion {
+            kind: RegionKind::If,
+            line_start: 2,
+            line_end: 5,
+            nesting: 1,
+            total: 5,
+            children: vec![
+                ComplexityRegion {
+                    kind: RegionKind::If,
+                    line_start: 3,
+                    line_end: 3,
+                    ..Default::default()
+                },
+                ComplexityRegion {
+                    kind: RegionKind::If,
+                    line_start: 4,
+                    line_end: 5,
+                    nesting: 2,
+                    total: 1,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }],
+        ..Default::default()
+    }];
+    (regions, source)
+}
+
+/// The whole point of this change: a spliceable plan's `estimated_reduction`
+/// is the literal measured delta of applying its suggestion, and the
+/// independent ground truth (splice by hand, re-score) must match exactly.
+#[test]
+fn spliceable_plan_reports_the_measured_reduction() {
+    let (regions, source) = loop_guard_regions();
+    let complexity = module_complexity(&source);
+    let registry = RuleRegistry::new();
+
+    let (plans, _) = registry.analyze(&regions, &source, complexity, true);
+
+    assert_eq!(plans.len(), 1);
+    let plan = &plans[0];
+    assert_eq!(plan.rule_id, "C002");
+    assert!(plan.reduction_is_measured);
+
+    let spliced = splice_plan(plan, plan.suggestion.as_ref().unwrap(), &source).unwrap();
+    let measured_after = module_complexity(&spliced);
+    assert_eq!(
+        plan.estimated_reduction,
+        complexity.saturating_sub(measured_after)
+    );
+    assert_eq!(plan.estimated_complexity_after, measured_after);
+}
+
+/// A suggestion whose splice cannot be parsed must yield `None` from
+/// `measure_reduction` — the caller keeps the formula estimate and never
+/// panics and never prints a fabricated measured number.
+#[test]
+fn unparseable_splice_measures_to_none() {
+    let source = "for x in y:\n    pass\n";
+    let mut plan = plan("C002", 1, 2, 3);
+    plan.current_complexity = 5;
+    plan.suggestion = Some(CodeSuggestion {
+        replacement: "for x in y: ((".to_string(),
+        applicability: Applicability::MachineApplicable,
+        description: String::new(),
+        spliceable: true,
+    });
+
+    let measured = measure_reduction(&plan, plan.suggestion.as_ref().unwrap(), source, true);
+    assert!(measured.is_none());
+}
+
+/// A suggestion whose splice changes nothing measures 0 — the value the
+/// noise filter drops. Real rules rarely produce this (their formulas
+/// understate, so measured >= formula >= 1), which is exactly why the
+/// behavior is proven at the unit level rather than through a contrived
+/// rule shape.
+#[test]
+fn no_op_splice_measures_zero() {
+    let source = "def f():\n    pass\n";
+    let mut plan = plan("C002", 1, 2, 3);
+    plan.current_complexity = 0;
+    plan.suggestion = Some(CodeSuggestion {
+        replacement: "def f():\n    pass".to_string(),
+        applicability: Applicability::MachineApplicable,
+        description: String::new(),
+        spliceable: true,
+    });
+
+    let measured = measure_reduction(&plan, plan.suggestion.as_ref().unwrap(), source, false);
+    assert_eq!(measured, Some(0));
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -25,8 +25,13 @@ fn get_code_complexity(code: &str) -> Result<CodeComplexity, String> {
         Err(e) => return Err(format!("Parse error: {}", e)),
     };
 
-    let (functions, complexity) =
-        function_level_cognitive_complexity_shared(parsed.suite(), code, false, false);
+    let (functions, complexity) = function_level_cognitive_complexity_shared(
+        parsed.suite(),
+        code,
+        false,
+        false,
+        true,
+    );
 
     Ok(CodeComplexity {
         complexity,

--- a/tests/fixtures/refactor_plans/loop_guard_leading.py
+++ b/tests/fixtures/refactor_plans/loop_guard_leading.py
@@ -1,0 +1,10 @@
+def sample(items):
+    total = 0
+    for item in items:
+        total += item.value
+        if item.active:
+            with lock:
+                total += 1
+            if item.ready:
+                total += 2
+    return total

--- a/tests/fixtures/refactor_plans/loop_guard_multiline_header.py
+++ b/tests/fixtures/refactor_plans/loop_guard_multiline_header.py
@@ -1,0 +1,11 @@
+def sample(items):
+    total = 0
+    for item in (
+        items
+    ):
+        if item.active:
+            try:
+                total += item.value
+            except Exception:
+                pass
+    return total

--- a/tests/fixtures/refactor_plans/loop_guard_trailing.py
+++ b/tests/fixtures/refactor_plans/loop_guard_trailing.py
@@ -1,0 +1,10 @@
+def sample(items):
+    total = 0
+    for item in items:
+        if item.active:
+            with lock:
+                total += 1
+            if item.ready:
+                total += 2
+        total += 3
+    return total

--- a/tests/test_output_cli.py
+++ b/tests/test_output_cli.py
@@ -335,9 +335,10 @@ class TestSuggestRefactorsOutput:
         # The exact reduction magnitude is intentionally NOT asserted here --
         # dedicated reduction-math tests in test_refactor_plans.py cover the
         # magnitude against measured ground truth; this test only guards the
-        # output *format*.
+        # output *format*. C007 is machine-applicable, so its reduction is
+        # measured and rendered without the "Estimated" label.
         assert re.search(
-            r"Estimated reduction: -\d+ complexity \(\d+ -> \d+\)",
+            r"Reduction: -\d+ complexity \(\d+ -> \d+\)",
             result.output,
         )
 

--- a/tests/test_refactor_plans.py
+++ b/tests/test_refactor_plans.py
@@ -633,3 +633,81 @@ def test_loop_guard_with_else_reduction_matches_measured_delta() -> None:
     )
     assert real_reduction == 1
     assert plan.estimated_reduction == real_reduction
+
+
+def splice_and_measure(source: str, plan: RefactorPlan) -> int:
+    """Apply a plan's suggestion by hand and re-score the result.
+
+    Independent Python-side ground truth for the Rust measurement pass: the
+    plan's numbers must equal what splicing and re-scoring actually produce.
+    """
+    lines = source.split("\n")
+    spliced = "\n".join(
+        lines[: plan.line_start - 1]
+        + [plan.suggestion.replacement]  # type: ignore[union-attr]
+        + lines[plan.line_end :]
+    )
+    return code_complexity(spliced).functions[0].complexity
+
+
+def test_loop_guard_leading_suggestion_is_faithful_and_measured() -> None:
+    func = first_func(load_source("loop_guard_leading.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+
+    assert plan.suggestion is not None
+    assert plan.suggestion.spliceable
+    assert plan.reduction_is_measured
+    assert plan.estimated_reduction == func.complexity - splice_and_measure(
+        load_source("loop_guard_leading.py"), plan
+    )
+
+
+def test_loop_guard_trailing_suggestion_is_faithful_and_measured() -> None:
+    func = first_func(load_source("loop_guard_trailing.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+
+    assert plan.suggestion is not None
+    assert plan.suggestion.spliceable
+    assert plan.reduction_is_measured
+    assert plan.estimated_complexity_after == splice_and_measure(
+        load_source("loop_guard_trailing.py"), plan
+    )
+
+
+def test_loop_guard_multiline_header_suggestion_is_faithful_and_measured() -> (
+    None
+):
+    func = first_func(load_source("loop_guard_multiline_header.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+
+    assert plan.suggestion is not None
+    assert plan.suggestion.spliceable
+    assert plan.reduction_is_measured
+    assert plan.estimated_complexity_after == splice_and_measure(
+        load_source("loop_guard_multiline_header.py"), plan
+    )
+
+
+def test_reduction_is_measured_flag_marks_spliced_and_estimated_plans() -> None:
+    # Machine-applicable spliceable rules measure their reduction.
+    func = first_func(load_source("collapsible_if_simple.py"))
+    collapsible = next(
+        p for p in func.refactor_plans if p.kind == "collapsible_if"
+    )
+    assert collapsible.reduction_is_measured
+
+    # Help-only rules keep a formula estimate.
+    func = first_func(load_source("flatten_try_with_nested.py"))
+    flatten = next(p for p in func.refactor_plans if p.kind == "flatten_try")
+    assert not flatten.reduction_is_measured
+    assert flatten.suggestion is None
+
+    # C005 carries a suggestion but it is a snippet with a placeholder body,
+    # not a faithful splice -- it stays estimated.
+    func = first_func(load_source("extract_predicate_boolean.py"))
+    predicate = next(
+        p for p in func.refactor_plans if p.kind == "extract_predicate"
+    )
+    assert predicate.suggestion is not None
+    assert not predicate.suggestion.spliceable
+    assert not predicate.reduction_is_measured


### PR DESCRIPTION
## What

Refactor-plan reductions for machine-applicable suggestions are now measured by splicing the suggestion into the source, re-parsing, and re-scoring — the reported number is the literal delta of applying the suggestion, not a formula estimate.

## Why

Closes #203. Every rule previously computed `estimated_reduction` from a hand-derived formula over region metadata, never from running the scorer on the code the suggestion produces. The formulas were validated against measured deltas in tests, but at runtime the number was math, not measurement. The review also uncovered that the C002 loop-guard suggestion was not a faithful source replacement: loops with statements before or after the if-chain produced splices that dropped or over-dedented code (silently moving statements out of the loop).

## Changes

- **Measured reductions**: the registry splices each spliceable suggestion into the source, re-parses it, and re-scores the target function (`<module>` for script runs); `estimated_reduction` / `estimated_complexity_after` become the measured delta, and ranking, overlap resolution, and the noise filter all operate on measured values
- **Confidence flag**: new `reduction_is_measured` on `RefactorPlan` and `spliceable` on `CodeSuggestion` (FFI: `classes.rs` → `_complexipy.pyi`); help-only rules keep formula estimates, now rendered with a `~` qualifier (`Estimated reduction: ~-2`) while measured plans render plain (`Reduction: -2`)
- **C002 generator rewrite**: faithful splices for loops with leading or trailing statements, `else` branches, and multi-line headers (body indent derived from the first chain member); loops with a loop-level `else` or a first member with its own `else`/`elif` fall back to help text instead of emitting broken code
- **Fallback**: unparseable splices or missing targets keep the formula estimate with the flag set to false — never a panic, never a fabricated measured number; plans measuring 0 are dropped
- **Recursion fix**: measurement re-walks no longer rebuild plans (`with_plans` flag through `function_level_cognitive_complexity_shared`) — the first implementation segfaulted on large files
- **Tests**: Rust unit tests for the generator shapes, measurement equality against an independent splice-and-rescore, and the parse-failure fallback; Python tests assert measured equality and the flag semantics
- **Docs**: measured vs estimated reductions documented in `docs/refactoring-rules.md` (EN + ES)
- **Benchmark**: `django/django` (908 files) — 125.24s with suggestions vs 125.49s without; 184 measured re-parses across the tree; verdict: negligible

## Notes

- `C005` (extract predicate) keeps its snippet suggestion — it contains a placeholder body and is not spliceable by design