### PR TITLE
fix(snapshot): keep analyzed entries in place on partial runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ release section links to its GitHub release notes for the full details.
 
 ## Unreleased
 
+### Fixed
+
+- Snapshot entries for analyzed files are updated in place instead of
+  being moved to the end of the file: partial runs (e.g. pre-commit hooks
+  analyzing only staged files) no longer reorder the snapshot, so the
+  snapshot stays byte-identical across commits that do not change
+  complexity. ([#226](https://github.com/rohaquinlop/complexipy/issues/226))
+
 ## [7.0.0] - 2026-08-10
 
 !!! note "Migration"

--- a/complexipy/utils/snapshot.py
+++ b/complexipy/utils/snapshot.py
@@ -41,17 +41,26 @@ def merge_snapshot_files(
     snapshot_files: List[FileComplexity],
     files_complexities: List[FileComplexity],
 ) -> List[FileComplexity]:
-    analyzed_keys = {
-        (file_complexity.path, file_complexity.file_name)
+    current_entries = {
+        (file_complexity.path, file_complexity.file_name): file_complexity
         for file_complexity in files_complexities
     }
-    preserved = [
-        file_complexity
-        for file_complexity in snapshot_files
-        if (file_complexity.path, file_complexity.file_name)
-        not in analyzed_keys
-    ]
-    return [*preserved, *files_complexities]
+    merged = []
+    merged_keys = set()
+    for file_complexity in snapshot_files:
+        key = (file_complexity.path, file_complexity.file_name)
+        if key in current_entries:
+            if key not in merged_keys:
+                merged.append(current_entries[key])
+                merged_keys.add(key)
+        else:
+            merged.append(file_complexity)
+    for file_complexity in files_complexities:
+        key = (file_complexity.path, file_complexity.file_name)
+        if key not in merged_keys:
+            merged.append(file_complexity)
+            merged_keys.add(key)
+    return merged
 
 
 def handle_snapshot_watermark(

--- a/docs/es/changelog.md
+++ b/docs/es/changelog.md
@@ -6,6 +6,14 @@ GitHub con todos los detalles.
 
 ## Sin publicar
 
+### Corregido
+
+- Las entradas de snapshot de los archivos analizados se actualizan en su
+  posición en lugar de moverse al final del archivo: las ejecuciones
+  parciales (p. ej. hooks de pre-commit que analizan solo los archivos
+  staged) ya no reordenan el snapshot, por lo que el snapshot permanece
+  byte-idéntico entre commits que no cambian la complejidad. ([#226](https://github.com/rohaquinlop/complexipy/issues/226))
+
 ## [7.0.0] - 2026-08-10
 
 !!! note "Migración"

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -113,10 +113,142 @@ class TestEvaluateSnapshot:
 
         assert result.watermark_success is True
         snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
-        assert {entry.file_name for entry in snapshot_files} == {
+        assert [entry.file_name for entry in snapshot_files] == [
             "tracked_a.py",
             "tracked_b.py",
-        }
+        ]
+
+    def test_partial_run_keeps_analyzed_file_position(self, tmp_path: Path):
+        tracked_a = tmp_path / "tracked_a.py"
+        tracked_a.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_b = tmp_path / "tracked_b.py"
+        tracked_b.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_c = tmp_path / "tracked_c.py"
+        tracked_c.write_text(*self.tracked_function_body, encoding="utf-8")
+        files, _ = self._analyze_paths([tracked_a, tracked_b, tracked_c])
+        snapshot_path = tmp_path / self.complexipy_snapshot_file
+
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files)
+
+        tracked_b.write_text(
+            "def tracked(value):\n"
+            "    if value:\n"
+            "        if value > 1:\n"
+            "            return 1\n"
+            "    return 0\n",
+            encoding="utf-8",
+        )
+        files_b, _ = self._analyze_paths([tracked_b])
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files_b)
+
+        snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
+        assert [entry.file_name for entry in snapshot_files] == [
+            "tracked_a.py",
+            "tracked_b.py",
+            "tracked_c.py",
+        ]
+        assert (
+            snapshot_files[1].functions[0].complexity
+            == files_b[0].functions[0].complexity
+        )
+
+    def test_repeated_partial_runs_keep_snapshot_byte_identical(
+        self, tmp_path: Path
+    ):
+        tracked_a = tmp_path / "tracked_a.py"
+        tracked_a.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_b = tmp_path / "tracked_b.py"
+        tracked_b.write_text(*self.tracked_function_body, encoding="utf-8")
+        files, _ = self._analyze_paths([tracked_a, tracked_b])
+        snapshot_path = tmp_path / self.complexipy_snapshot_file
+
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files)
+
+        files_b, _ = self._analyze_paths([tracked_b])
+        evaluate_snapshot(False, False, str(snapshot_path), 0, files_b)
+        first_content = snapshot_path.read_text(encoding="utf-8")
+
+        evaluate_snapshot(False, False, str(snapshot_path), 0, files_b)
+
+        assert snapshot_path.read_text(encoding="utf-8") == first_content
+
+    def test_new_file_appends_at_end(self, tmp_path: Path):
+        tracked_a = tmp_path / "tracked_a.py"
+        tracked_a.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_b = tmp_path / "tracked_b.py"
+        tracked_b.write_text(*self.tracked_function_body, encoding="utf-8")
+        files, _ = self._analyze_paths([tracked_a, tracked_b])
+        snapshot_path = tmp_path / self.complexipy_snapshot_file
+
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files)
+
+        tracked_c = tmp_path / "tracked_c.py"
+        tracked_c.write_text(*self.tracked_function_body, encoding="utf-8")
+        files_ac, _ = self._analyze_paths([tracked_a, tracked_c])
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files_ac)
+
+        snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
+        assert [entry.file_name for entry in snapshot_files] == [
+            "tracked_a.py",
+            "tracked_b.py",
+            "tracked_c.py",
+        ]
+
+    def test_duplicate_snapshot_entries_collapse_in_place(self, tmp_path: Path):
+        tracked_a = tmp_path / "tracked_a.py"
+        tracked_a.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_b = tmp_path / "tracked_b.py"
+        tracked_b.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_c = tmp_path / "tracked_c.py"
+        tracked_c.write_text(*self.tracked_function_body, encoding="utf-8")
+        files, _ = self._analyze_paths([tracked_a, tracked_b, tracked_c])
+        snapshot_path = tmp_path / self.complexipy_snapshot_file
+
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files)
+
+        snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
+        duplicated = [
+            snapshot_files[0],
+            snapshot_files[1],
+            snapshot_files[1],
+            snapshot_files[2],
+        ]
+        _complexipy.create_snapshot_file(str(snapshot_path), 0, duplicated)
+
+        files_b, _ = self._analyze_paths([tracked_b])
+        evaluate_snapshot(False, False, str(snapshot_path), 0, files_b)
+
+        snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
+        assert [entry.file_name for entry in snapshot_files] == [
+            "tracked_a.py",
+            "tracked_b.py",
+            "tracked_c.py",
+        ]
+        assert (
+            snapshot_files[1].functions[0].complexity
+            == files_b[0].functions[0].complexity
+        )
+
+    def test_snapshot_create_partial_run_preserves_positions(
+        self, tmp_path: Path
+    ):
+        tracked_a = tmp_path / "tracked_a.py"
+        tracked_a.write_text(*self.tracked_function_body, encoding="utf-8")
+        tracked_b = tmp_path / "tracked_b.py"
+        tracked_b.write_text(*self.tracked_function_body, encoding="utf-8")
+        files, _ = self._analyze_paths([tracked_a, tracked_b])
+        snapshot_path = tmp_path / self.complexipy_snapshot_file
+
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files)
+
+        files_b, _ = self._analyze_paths([tracked_b])
+        evaluate_snapshot(True, False, str(snapshot_path), 0, files_b)
+
+        snapshot_files = _complexipy.load_snapshot_file(str(snapshot_path))
+        assert [entry.file_name for entry in snapshot_files] == [
+            "tracked_a.py",
+            "tracked_b.py",
+        ]
 
     def test_partial_run_removes_improved_function(self, tmp_path: Path):
         tracked_a = tmp_path / "tracked_a.py"


### PR DESCRIPTION
## What

Snapshot entries for analyzed files are updated in place instead of being appended at the end, so partial runs no longer reorder complexipy-snapshot.json on every commit.

## Why

Since 7.0.0, the snapshot merge appended analyzed files at the end of the file. The pre-commit hook passes only changed files, so every commit rewrote the snapshot with those files moved to the end, which made the hook fail and left a modified snapshot file in the working tree. Fixes #226.

## Changes

- Rework `merge_snapshot_files` in `complexipy/utils/snapshot.py` to replace analyzed entries at their existing positions, collapse duplicate keys, and append only files missing from the snapshot
- Add tests for position stability on partial runs (`--snapshot-create` and `--snapshot-watermark`), byte-identical repeated partial runs, new-file appending, and duplicate-key collapse
- Strengthen `test_partial_run_preserves_unanalyzed_files` to assert order, not only membership
- Add changelog entries in `CHANGELOG.md` and `docs/es/changelog.md` referencing #226