### PR TITLE
feat: add configurable cache directory location

### DIFF
--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -224,7 +224,7 @@ def main(
         "--cache-dir",
         help="Directory to use for storing complexipy cache between runs. Defaults to "
         ".complexipy_cache in the invocation directory. Can also be set via the "
-        "cache-dir key in TOML config files."
+        "cache-dir key in TOML config files.",
     ),
     version: bool = typer.Option(
         False,

--- a/complexipy/main.py
+++ b/complexipy/main.py
@@ -219,6 +219,13 @@ def main(
         "--report-ignored",
         help="List every file:line where a '# complexipy: ignore' or '# noqa: complexipy' comment exists.",
     ),
+    cache_dir: Optional[str] = typer.Option(
+        None,
+        "--cache-dir",
+        help="Directory to use for storing complexipy cache between runs. Defaults to "
+        ".complexipy_cache in the invocation directory. Can also be set via the "
+        "cache-dir key in TOML config files."
+    ),
     version: bool = typer.Option(
         False,
         "--version",
@@ -250,6 +257,7 @@ def main(
         check_script,
         no_ignore,
         report_ignored,
+        cache_dir,
     )
 
     console = handle_console_settings(cfg.color, cfg.quiet, cfg.plain)
@@ -302,6 +310,7 @@ def main(
         cfg.quiet,
         cfg.plain,
         INVOCATION_PATH,
+        cfg.cache_dir,
         cfg.top,
         cfg.suggest_refactors,
     )

--- a/complexipy/types.py
+++ b/complexipy/types.py
@@ -70,6 +70,7 @@ class RunConfig:
     diff: Optional[str]
     diff_only: Optional[str]
     staged: bool
+    cache_dir: Optional[str]
 
 
 @dataclass

--- a/complexipy/utils/cache.py
+++ b/complexipy/utils/cache.py
@@ -56,6 +56,9 @@ def remember_previous_functions(
         return None
 
     cache_dir_path = _resolve_cache_dir(invocation_path, cache_dir)
+    is_default_cache_location = (
+        cache_dir_path == Path(invocation_path) / CACHE_DIR_NAME
+    )
     cache_file = _cache_value_path(cache_dir_path, FUNCTIONS_CACHE_KEY)
     try:
         _ensure_cache_dir_and_supporting_files(cache_dir_path)
@@ -63,7 +66,8 @@ def remember_previous_functions(
         return None
 
     cache_store = _load_cache_store(cache_file)
-    _migrate_legacy_cache_entry(cache_dir_path, cache_store, cache_key)
+    if is_default_cache_location:
+        _migrate_legacy_cache_entry(cache_dir_path, cache_store, cache_key)
     previous_map = _load_previous_map_from_store(cache_store, cache_key)
 
     cache_store.setdefault("entries", {})[cache_key] = {
@@ -73,7 +77,8 @@ def remember_previous_functions(
     }
     _prune_cache_store(cache_store)
     if _persist_cache(cache_file, cache_store):
-        _remove_legacy_cache_files(cache_dir_path)
+        if is_default_cache_location:
+            _remove_legacy_cache_files(cache_dir_path)
     return previous_map
 
 

--- a/complexipy/utils/cache.py
+++ b/complexipy/utils/cache.py
@@ -32,10 +32,17 @@ complexity results so future runs can compare per-function complexity changes.
 """
 
 
+def _resolve_cache_dir(invocation_path: str, cache_dir: Optional[str]) -> Path:
+    if cache_dir:
+        return Path(cache_dir)
+    return Path(invocation_path) / CACHE_DIR_NAME
+
+
 def remember_previous_functions(
     invocation_path: str,
     targets: List[str],
     files_complexities: List[FileComplexity],
+    cache_dir: Optional[str] = None,
 ) -> Optional[dict[tuple[str, str, str], int]]:
     """Store per-function results for the target set and return previous map.
 
@@ -47,15 +54,15 @@ def remember_previous_functions(
     if cache_key is None:
         return None
 
-    cache_dir = Path(invocation_path) / CACHE_DIR_NAME
-    cache_file = _cache_value_path(cache_dir, FUNCTIONS_CACHE_KEY)
+    cache_dir_path = _resolve_cache_dir(invocation_path, cache_dir)
+    cache_file = _cache_value_path(cache_dir_path, FUNCTIONS_CACHE_KEY)
     try:
-        _ensure_cache_dir_and_supporting_files(cache_dir)
+        _ensure_cache_dir_and_supporting_files(cache_dir_path)
     except OSError:
         return None
 
     cache_store = _load_cache_store(cache_file)
-    _migrate_legacy_cache_entry(cache_dir, cache_store, cache_key)
+    _migrate_legacy_cache_entry(cache_dir_path, cache_store, cache_key)
     previous_map = _load_previous_map_from_store(cache_store, cache_key)
 
     cache_store.setdefault("entries", {})[cache_key] = {
@@ -65,7 +72,7 @@ def remember_previous_functions(
     }
     _prune_cache_store(cache_store)
     if _persist_cache(cache_file, cache_store):
-        _remove_legacy_cache_files(cache_dir)
+        _remove_legacy_cache_files(cache_dir_path)
     return previous_map
 
 
@@ -287,7 +294,7 @@ def _remove_legacy_cache_files(cache_dir: Path) -> None:
 
 def _ensure_cache_dir_and_supporting_files(cache_dir: Path) -> None:
     """Create the cache directory and support files used by cache tools."""
-    cache_dir.mkdir(exist_ok=True)
+    cache_dir.mkdir(parents=True, exist_ok=True)
     _write_support_file(cache_dir / ".gitignore", "*\n")
     _write_support_file(cache_dir / "CACHEDIR.TAG", CACHEDIR_TAG_CONTENT)
     _write_support_file(cache_dir / "README.md", README_CONTENT)

--- a/complexipy/utils/cache.py
+++ b/complexipy/utils/cache.py
@@ -30,6 +30,7 @@ complexity results so future runs can compare per-function complexity changes.
 
 **Do not** commit this to version control.
 """
+LEGACY_CACHE_FILE_PATTERN = re.compile(r"^[0-9a-f]{32}\.json$")
 
 
 def _resolve_cache_dir(invocation_path: str, cache_dir: Optional[str]) -> Path:
@@ -286,6 +287,8 @@ def _persist_cache(cache_file: Path, payload: dict) -> bool:
 
 def _remove_legacy_cache_files(cache_dir: Path) -> None:
     for legacy_cache_file in cache_dir.glob("*.json"):
+        if not LEGACY_CACHE_FILE_PATTERN.match(legacy_cache_file.name):
+            continue
         try:
             legacy_cache_file.unlink()
         except OSError:

--- a/complexipy/utils/config.py
+++ b/complexipy/utils/config.py
@@ -63,6 +63,7 @@ def resolve_config(
     check_script: Optional[bool],
     no_ignore: Optional[bool],
     report_ignored: Optional[bool],
+    cache_dir: Optional[str],
 ) -> RunConfig:
     cli_args = {
         "paths": paths,
@@ -80,6 +81,7 @@ def resolve_config(
         "check_script": check_script,
         "no_ignore": no_ignore,
         "report_ignored": report_ignored,
+        "cache_dir": cache_dir,
     }
 
     resolved = get_arguments_value(toml_config, cli_args)
@@ -107,6 +109,7 @@ def resolve_config(
     report_ignored = bool(report_ignored)
     cli_staged = staged
     staged = bool(staged)
+    cache_dir = resolved["cache_dir"]
 
     diff_section = (
         cast(Optional[TOMLDiffSection], toml_config.get("diff"))
@@ -146,6 +149,7 @@ def resolve_config(
         diff=diff,
         diff_only=diff_only,
         staged=staged,
+        cache_dir=cache_dir,
     )
 
 

--- a/complexipy/utils/output.py
+++ b/complexipy/utils/output.py
@@ -68,12 +68,13 @@ def handle_display(
     quiet: bool,
     plain: bool,
     invocation_path: str,
+    cache_dir: Optional[str] = None,
     top: Optional[int] = None,
     suggest_refactors: bool = False,
 ) -> bool:
     if files_complexities:
         previous_functions = remember_previous_functions(
-            invocation_path, paths, files_complexities
+            invocation_path, paths, files_complexities, cache_dir
         )
     else:
         previous_functions = None

--- a/complexipy/utils/toml.py
+++ b/complexipy/utils/toml.py
@@ -279,4 +279,8 @@ def get_arguments_value(
         toml_config, "exclude", cli_args.get("exclude"), []
     )
 
+    result["cache_dir"] = cli_args.get("cache_dir")
+    if result["cache_dir"] is None and toml_config is not None:
+        result["cache_dir"] = cast(Optional[str], toml_config.get("cache-dir"))
+
     return result

--- a/complexipy/utils/toml.py
+++ b/complexipy/utils/toml.py
@@ -287,6 +287,11 @@ def get_arguments_value(
             "The 'cache-dir' option must be a string in the TOML config file"
         )
         raise Exit(code=1)
+    if cache_dir is not None and not cache_dir.strip():
+        typer.echo(
+            "The 'cache-dir' option cannot be an empty string in the TOML config file"
+        )
+        raise Exit(code=1)
     result["cache_dir"] = cache_dir
 
     return result

--- a/complexipy/utils/toml.py
+++ b/complexipy/utils/toml.py
@@ -279,8 +279,14 @@ def get_arguments_value(
         toml_config, "exclude", cli_args.get("exclude"), []
     )
 
-    result["cache_dir"] = cli_args.get("cache_dir")
-    if result["cache_dir"] is None and toml_config is not None:
-        result["cache_dir"] = cast(Optional[str], toml_config.get("cache-dir"))
+    cache_dir = cli_args.get("cache_dir")
+    if cache_dir is None and toml_config is not None:
+        cache_dir = toml_config.get("cache-dir")
+    if cache_dir is not None and not isinstance(cache_dir, str):
+        typer.echo(
+            "The 'cache-dir' option must be a string in the TOML config file"
+        )
+        raise Exit(code=1)
+    result["cache_dir"] = cache_dir
 
     return result

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -319,6 +319,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     check-script = false
     no-ignore = false
     report-ignored = false
+    cache-dir = ".complexipy_cache"
     ```
 
 === "pyproject.toml"
@@ -331,6 +332,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     failed = true
     sort = "desc"
     check-script = true
+    cache-dir = ".complexipy_cache"
     ```
 
 === ".complexipy.toml"
@@ -339,6 +341,7 @@ complexipy carga la configuración en este orden (de mayor a menor prioridad):
     # Archivo de configuración oculto para ajustes específicos del equipo
     max-complexity-allowed = 15
     exclude = ["venv/**", ".venv/**", "node_modules/**"]
+    cache-dir = ".complexipy_cache"
     ```
 
 `check-script` está soportado en TOML. `--top` y `--plain` son flags solo de CLI.
@@ -379,6 +382,41 @@ en lugar de pasar los mismos flags en cada llamada. Añade una sección
   clon recién hecho o shallow), cada función se reporta como `NEW` y la
   aplicación del umbral sigue activa. Haz fetch de la rama o pasa
   `--diff <ref>` con una referencia existente.
+
+## Configuración de la caché
+
+complexipy almacena los datos de complejidad de cada función entre ejecuciones
+para permitir comparaciones de cambios/diferencias (delta/diff). De forma
+predeterminada, esta caché se encuentra en .complexipy_cache/ dentro del directorio
+desde el que se ejecuta la herramienta. En lugar de utilizar la ubicación
+predeterminada, puedes redirigir la caché a cualquier directorio. Esto resulta útil
+para CI, directorios de caché compartidos o para evitar añadir archivos innecesarios
+al árbol del proyecto.
+
+```bash
+# Opción de CLI (máxima prioridad)
+complexipy . --cache-dir .cache/complexipy
+```
+
+O decláralo una vez en un archivo de configuración:
+
+=== "complexipy.toml"
+
+    ```toml
+    cache-dir = ".cache/complexipy"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    cache-dir = ".cache/complexipy"
+    ```
+
+=== ".complexipy.toml"
+
+    ```toml
+    cache-dir = ".cache/complexipy"
+    ```
 
 ## API de Python
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -387,18 +387,18 @@ en lugar de pasar los mismos flags en cada llamada. Añade una sección
 
 complexipy almacena los datos de complejidad de cada función entre ejecuciones
 para permitir comparaciones de cambios/diferencias (delta/diff). De forma
-predeterminada, esta caché se encuentra en .complexipy_cache/ dentro del directorio
+predeterminada, esta caché se encuentra en `.complexipy_cache/` dentro del directorio
 desde el que se ejecuta la herramienta. En lugar de utilizar la ubicación
 predeterminada, puedes redirigir la caché a cualquier directorio. Esto resulta útil
 para CI, directorios de caché compartidos o para evitar añadir archivos innecesarios
 al árbol del proyecto.
 
 ```bash
-# Opción de CLI (máxima prioridad)
+# Flag de CLI (mayor prioridad)
 complexipy . --cache-dir .cache/complexipy
 ```
 
-O decláralo una vez en un archivo de configuración:
+O declárala una vez en un archivo de configuración:
 
 === "complexipy.toml"
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -323,6 +323,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     check-script = false
     no-ignore = false
     report-ignored = false
+    cache-dir = ".complexipy_cache"
     ```
 
 === "pyproject.toml"
@@ -335,6 +336,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     failed = true
     sort = "desc"
     check-script = true
+    cache-dir = ".complexipy_cache"
     ```
 
 === ".complexipy.toml"
@@ -343,6 +345,7 @@ complexipy loads configuration in this order (highest to lowest priority):
     # Hidden config file for team-specific settings
     max-complexity-allowed = 15
     exclude = ["venv/**", ".venv/**", "node_modules/**"]
+    cache-dir = ".complexipy_cache"
     ```
 
 `check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
@@ -382,6 +385,40 @@ section to the same configuration file:
   example a fresh or shallow clone), every function reports as `NEW` and
   the enforcement still applies. Fetch the branch or pass `--diff <ref>`
   with an existing reference instead.
+
+## Cache Configuration
+
+complexipy stores per-function complexity data between runs to power
+delta/diff comparisons. By default this cache lives in
+`.complexipy_cache/` inside your invocation directory. Instead of the
+default location you can redirect it to any directory which is useful
+for CI, chared cache directories or avoiding polluting the project
+tree.
+
+```bash
+# CLI flag (highest priority)
+complexipy . --cache-dir .cache/complexipy
+```
+
+Or declare it once in a configuration file:
+
+=== "complexipy.toml"
+
+    ```toml
+    cache-dir = ".cache/complexipy"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    cache-dir = ".cache/complexipy"
+    ```
+
+=== ".complexipy.toml"
+
+    ```toml
+    cache-dir = ".cache/complexipy
+    ```
 
 ## Python API
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -392,7 +392,7 @@ complexipy stores per-function complexity data between runs to power
 delta/diff comparisons. By default this cache lives in
 `.complexipy_cache/` inside your invocation directory. Instead of the
 default location you can redirect it to any directory which is useful
-for CI, chared cache directories or avoiding polluting the project
+for CI, shared cache directories or avoiding polluting the project
 tree.
 
 ```bash
@@ -417,7 +417,7 @@ Or declare it once in a configuration file:
 === ".complexipy.toml"
 
     ```toml
-    cache-dir = ".cache/complexipy
+    cache-dir = ".cache/complexipy"
     ```
 
 ## Python API

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -169,6 +169,51 @@ class TestCache:
         assert not legacy_file.exists()
         assert cache_file.exists()
 
+    def test_cache_skips_migration_and_removal_when_cache_dir_is_not_default(
+        self, tmp_path: Path
+    ):
+        """Legacy cache entries should not be migrated when a custom cache_dir is used."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("def example():\n    return 1\n", encoding="utf-8")
+        files, _ = _complexipy.main([str(test_file)], False, [])
+
+        custom_cache_dir = str(tmp_path / "custom_cache")
+
+        remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(test_file)],
+            files_complexities=files,
+            cache_dir=custom_cache_dir,
+        )
+
+        cache_file = (
+            Path(custom_cache_dir) / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        )
+        cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+        [cache_key] = cache_payload["entries"].keys()
+        cache_file.unlink()
+
+        # Plant a legacy file inside the custom cache dir
+        legacy_file = Path(custom_cache_dir) / f"{cache_key}.json"
+        legacy_file.write_text(
+            json.dumps(next(iter(cache_payload["entries"].values()))),
+            encoding="utf-8",
+        )
+
+        previous = remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(test_file)],
+            files_complexities=files,
+            cache_dir=custom_cache_dir,
+        )
+
+        # Legacy file should survive untouched — migration never ran
+        assert previous is None, (
+            "Previous map should be None since migration and removal never ran"
+        )
+        assert legacy_file.exists(), "Legacy file should exist"
+        assert cache_file.exists(), "Cache file should exist"
+
     def test_cache_prunes_old_target_set_entries(self, tmp_path: Path):
         """Test that the single value file does not grow unbounded."""
         files = []
@@ -232,6 +277,21 @@ class TestCache:
             targets=[str(test_file)],
             files_complexities=files,
             cache_dir=str(custom_cache_dir),
+        )
+
+        files_again, _ = _complexipy.main([str(test_file)], False, [])
+        previous = remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(test_file)],
+            files_complexities=files_again,
+            cache_dir=str(custom_cache_dir),
+        )
+
+        assert previous is not None, (
+            "Subsequent runs should read the previous map from the custom cache directory"
+        )
+        assert len(previous) == 1, (
+            "The number of previous maps cached should only be 1"
         )
 
         assert custom_cache_dir.exists(), "Custom cache directory should exist"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -220,7 +220,7 @@ class TestCache:
         """Test that a custom cache directory is used when provided."""
         test_file = tmp_path / "test.py"
         test_file.write_text(
-            "def example():\n   if True\n       return 1\n  return 0\n",
+            "def example():\n    if True:\n        return 1\n    return 0\n",
             encoding="utf-8",
         )
 
@@ -251,7 +251,7 @@ class TestCache:
         """Test that the default cache location is used when cache_dir is None."""
         test_file = tmp_path / "test.py"
         test_file.write_text(
-            "def example():\n   if True\n       return 1\n  return 0\n",
+            "def example():\n    if True:\n        return 1\n    return 0\n",
             encoding="utf-8",
         )
 
@@ -284,7 +284,7 @@ class TestCache:
         """Test that nested cache directories (ex. .cache/complexipy) are created and work as expected."""
         test_file = tmp_path / "test.py"
         test_file.write_text(
-            "def example():\n   if True\n       return 1\n  return 0\n",
+            "def example():\n    if True:\n        return 1\n    return 0\n",
             encoding="utf-8",
         )
 
@@ -295,7 +295,7 @@ class TestCache:
             invocation_path=str(tmp_path),
             targets=[str(test_file)],
             files_complexities=files,
-            cache_dir=custom_cache_dir,
+            cache_dir=str(custom_cache_dir),
         )
 
         assert custom_cache_dir.exists(), (

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -235,11 +235,17 @@ class TestCache:
         )
 
         assert custom_cache_dir.exists(), "Custom cache directory should exist"
-        assert custom_cache_dir.is_dir(), "Custom cache directory should be a directory"
+        assert custom_cache_dir.is_dir(), (
+            "Custom cache directory should be a directory"
+        )
 
         cache_file = custom_cache_dir / "v" / "cache" / FUNCTIONS_CACHE_KEY
-        assert cache_file.exists(), "Cache file should exist in custom cache directory"
-        assert cache_file.is_file(), "Cache file should be a file in the custom cache directory"
+        assert cache_file.exists(), (
+            "Cache file should exist in custom cache directory"
+        )
+        assert cache_file.is_file(), (
+            "Cache file should be a file in the custom cache directory"
+        )
 
     def test_default_cache_dir_when_none_provided(self, tmp_path: Path):
         """Test that the default cache location is used when cache_dir is None."""
@@ -259,12 +265,20 @@ class TestCache:
         )
 
         default_cache_dir = tmp_path / CACHE_DIR_NAME
-        assert default_cache_dir.exists(), "Default cache directory should exist"
-        assert default_cache_dir.is_dir(), "Default cache directory should be a directory"
+        assert default_cache_dir.exists(), (
+            "Default cache directory should exist"
+        )
+        assert default_cache_dir.is_dir(), (
+            "Default cache directory should be a directory"
+        )
 
         cache_file = default_cache_dir / "v" / "cache" / FUNCTIONS_CACHE_KEY
-        assert cache_file.exists(), "Cache file should exist in default cache directory"
-        assert cache_file.is_file(), "Cache file should be a file in the default cache directory"
+        assert cache_file.exists(), (
+            "Cache file should exist in default cache directory"
+        )
+        assert cache_file.is_file(), (
+            "Cache file should be a file in the default cache directory"
+        )
 
     def test_nested_cache_dir(self, tmp_path: Path):
         """Test that nested cache directories (ex. .cache/complexipy) are created and work as expected."""
@@ -284,9 +298,17 @@ class TestCache:
             cache_dir=custom_cache_dir,
         )
 
-        assert custom_cache_dir.exists(), "Nested custom cache directory should exist"
-        assert custom_cache_dir.is_dir(), "Nested custom cache directory should be a directory"
+        assert custom_cache_dir.exists(), (
+            "Nested custom cache directory should exist"
+        )
+        assert custom_cache_dir.is_dir(), (
+            "Nested custom cache directory should be a directory"
+        )
 
         cache_file = custom_cache_dir / "v" / "cache" / FUNCTIONS_CACHE_KEY
-        assert cache_file.exists(), "Cache file should exist in nested custom cache directory"
-        assert cache_file.is_file(), "Cache file should be a file in the nested custom cache directory"
+        assert cache_file.exists(), (
+            "Cache file should exist in nested custom cache directory"
+        )
+        assert cache_file.is_file(), (
+            "Cache file should be a file in the nested custom cache directory"
+        )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -215,3 +215,78 @@ class TestCache:
 
         # Should return None gracefully without raising exceptions
         assert result is None
+
+    def test_custom_cache_dir(self, tmp_path: Path):
+        """Test that a custom cache directory is used when provided."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text(
+            "def example():\n   if True\n       return 1\n  return 0\n",
+            encoding="utf-8",
+        )
+
+        files, _ = _complexipy.main([str(test_file)], False, [])
+
+        custom_cache_dir = tmp_path / "custom_cache"
+        remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(test_file)],
+            files_complexities=files,
+            cache_dir=str(custom_cache_dir),
+        )
+
+        assert custom_cache_dir.exists(), "Custom cache directory should exist"
+        assert custom_cache_dir.is_dir(), "Custom cache directory should be a directory"
+
+        cache_file = custom_cache_dir / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        assert cache_file.exists(), "Cache file should exist in custom cache directory"
+        assert cache_file.is_file(), "Cache file should be a file in the custom cache directory"
+
+    def test_default_cache_dir_when_none_provided(self, tmp_path: Path):
+        """Test that the default cache location is used when cache_dir is None."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text(
+            "def example():\n   if True\n       return 1\n  return 0\n",
+            encoding="utf-8",
+        )
+
+        files, _ = _complexipy.main([str(test_file)], False, [])
+
+        remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(test_file)],
+            files_complexities=files,
+            cache_dir=None,
+        )
+
+        default_cache_dir = tmp_path / CACHE_DIR_NAME
+        assert default_cache_dir.exists(), "Default cache directory should exist"
+        assert default_cache_dir.is_dir(), "Default cache directory should be a directory"
+
+        cache_file = default_cache_dir / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        assert cache_file.exists(), "Cache file should exist in default cache directory"
+        assert cache_file.is_file(), "Cache file should be a file in the default cache directory"
+
+    def test_nested_cache_dir(self, tmp_path: Path):
+        """Test that nested cache directories (ex. .cache/complexipy) are created and work as expected."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text(
+            "def example():\n   if True\n       return 1\n  return 0\n",
+            encoding="utf-8",
+        )
+
+        files, _ = _complexipy.main([str(test_file)], False, [])
+
+        custom_cache_dir = tmp_path / ".cache" / "complexipy"
+        remember_previous_functions(
+            invocation_path=str(tmp_path),
+            targets=[str(test_file)],
+            files_complexities=files,
+            cache_dir=custom_cache_dir,
+        )
+
+        assert custom_cache_dir.exists(), "Nested custom cache directory should exist"
+        assert custom_cache_dir.is_dir(), "Nested custom cache directory should be a directory"
+
+        cache_file = custom_cache_dir / "v" / "cache" / FUNCTIONS_CACHE_KEY
+        assert cache_file.exists(), "Cache file should exist in nested custom cache directory"
+        assert cache_file.is_file(), "Cache file should be a file in the nested custom cache directory"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -651,6 +651,62 @@ class TestPlainAndSuggestRefactors:
         )
         assert cfg.cache_dir == "/tmp/cli"
 
+    def test_non_string_toml_cache_dir_raises(self):
+        with pytest.raises(Exception):
+            resolve_config(
+                {"cache-dir": 123},
+                paths=["."],
+                max_complexity_allowed=None,
+                snapshot_create=None,
+                snapshot_ignore=None,
+                quiet=None,
+                ignore_complexity=None,
+                failed=None,
+                color=None,
+                sort=None,
+                output_format=None,
+                output=None,
+                diff=None,
+                diff_only=None,
+                staged=None,
+                top=None,
+                plain=None,
+                suggest_refactors=None,
+                exclude=None,
+                check_script=None,
+                no_ignore=None,
+                report_ignored=None,
+                cache_dir=None,
+            )
+
+    def test_empty_string_toml_cache_dir_raises(self):
+        with pytest.raises(Exception):
+            resolve_config(
+                {"cache-dir": ""},
+                paths=["."],
+                max_complexity_allowed=None,
+                snapshot_create=None,
+                snapshot_ignore=None,
+                quiet=None,
+                ignore_complexity=None,
+                failed=None,
+                color=None,
+                sort=None,
+                output_format=None,
+                output=None,
+                diff=None,
+                diff_only=None,
+                staged=None,
+                top=None,
+                plain=None,
+                suggest_refactors=None,
+                exclude=None,
+                check_script=None,
+                no_ignore=None,
+                report_ignored=None,
+                cache_dir=None,
+            )
+
 
 class TestDiffFlagResolution:
     def test_diff_only_when_both_set(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,7 @@ class TestRunConfigDefaults:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.max_complexity_allowed == 15
 
@@ -64,6 +65,7 @@ class TestRunConfigDefaults:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.snapshot_create is False
         assert cfg.snapshot_ignore is False
@@ -98,6 +100,7 @@ class TestRunConfigDefaults:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.color == ColorTypes.auto
         assert cfg.sort == Sort.asc
@@ -126,6 +129,7 @@ class TestRunConfigDefaults:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.output is None
         assert cfg.diff is None
@@ -156,6 +160,7 @@ class TestRunConfigDefaults:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.output_format == []
         assert cfg.exclude == []
@@ -184,6 +189,7 @@ class TestRunConfigDefaults:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.plain is False
         assert cfg.suggest_refactors is False
@@ -214,6 +220,7 @@ class TestResolveConfigOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.max_complexity_allowed == 25
 
@@ -241,6 +248,7 @@ class TestResolveConfigOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.quiet is True
 
@@ -268,6 +276,7 @@ class TestResolveConfigOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.color == ColorTypes.yes
 
@@ -295,6 +304,7 @@ class TestResolveConfigOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.sort == Sort.desc
 
@@ -322,6 +332,7 @@ class TestResolveConfigOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.exclude == ["tests/**"]
 
@@ -349,6 +360,7 @@ class TestResolveConfigOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.output_format == ["csv", "json"]
 
@@ -376,6 +388,7 @@ class TestResolveConfigOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.diff == "main"
         assert cfg.diff_only is None
@@ -404,6 +417,7 @@ class TestResolveConfigOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.top == 10
 
@@ -433,6 +447,7 @@ class TestBooleanNormalization:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert isinstance(cfg.no_ignore, bool)
         assert cfg.no_ignore is False
@@ -461,6 +476,7 @@ class TestBooleanNormalization:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert isinstance(cfg.report_ignored, bool)
         assert cfg.report_ignored is False
@@ -491,6 +507,7 @@ class TestPlainAndSuggestRefactors:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.plain is False
 
@@ -518,6 +535,7 @@ class TestPlainAndSuggestRefactors:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.suggest_refactors is False
 
@@ -545,6 +563,7 @@ class TestPlainAndSuggestRefactors:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.plain is True
 
@@ -573,6 +592,7 @@ class TestPlainAndSuggestRefactors:
                 check_script=None,
                 no_ignore=None,
                 report_ignored=None,
+                cache_dir=None,
             )
 
 
@@ -606,6 +626,7 @@ class TestDiffFlagResolution:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.diff == "main"
         assert cfg.diff_only is None
@@ -636,6 +657,7 @@ class TestCheckScriptAndNoIgnore:
             check_script=True,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.check_script is True
 
@@ -663,6 +685,7 @@ class TestCheckScriptAndNoIgnore:
             check_script=None,
             no_ignore=True,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.no_ignore is True
 
@@ -692,6 +715,7 @@ class TestOutputDir:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.output == "/tmp/results"
 
@@ -721,6 +745,7 @@ class TestTomlOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.max_complexity_allowed == 30
 
@@ -748,6 +773,7 @@ class TestTomlOverrides:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
         assert cfg.max_complexity_allowed == 10
 
@@ -778,6 +804,7 @@ class TestDiffSectionFromToml:
             check_script=None,
             no_ignore=None,
             report_ignored=None,
+            cache_dir=None,
         )
 
     def test_branch_from_section_sets_diff(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -595,6 +595,62 @@ class TestPlainAndSuggestRefactors:
                 cache_dir=None,
             )
 
+    def test_toml_cache_dir(self):
+        cfg = resolve_config(
+            {"cache-dir": "/tmp/cache"},
+            paths=["."],
+            max_complexity_allowed=None,
+            snapshot_create=None,
+            snapshot_ignore=None,
+            quiet=None,
+            ignore_complexity=None,
+            failed=None,
+            color=None,
+            sort=None,
+            output_format=None,
+            output=None,
+            diff=None,
+            diff_only=None,
+            staged=None,
+            top=None,
+            plain=None,
+            suggest_refactors=None,
+            exclude=None,
+            check_script=None,
+            no_ignore=None,
+            report_ignored=None,
+            cache_dir=None,
+        )
+        assert cfg.cache_dir == "/tmp/cache"
+
+    def test_cli_cache_dir_overrides_toml(self):
+        cfg = resolve_config(
+            {"cache-dir": "/tmp/cache"},
+            paths=["."],
+            max_complexity_allowed=None,
+            snapshot_create=None,
+            snapshot_ignore=None,
+            quiet=None,
+            ignore_complexity=None,
+            failed=None,
+            color=None,
+            sort=None,
+            output_format=None,
+            output=None,
+            diff=None,
+            diff_only=None,
+            staged=None,
+            top=None,
+            plain=None,
+            suggest_refactors=None,
+            exclude=None,
+            check_script=None,
+            no_ignore=None,
+            report_ignored=None,
+            cache_dir="/tmp/cli",
+        )
+        assert cfg.cache_dir == "/tmp/cli"
+
 
 class TestDiffFlagResolution:
     def test_diff_only_when_both_set(self):


### PR DESCRIPTION
## What

Adds support for a custom cache directory location, allowing users to override the default cache path via cli option or toml configuration.

## Why

complexipy stores per-function complexity data between runs to power delta/diff comparisons. By default this cache lives in `.complexipy_cache/` inside your invocation directory. Instead of the default location you can redirect it to any directory which is useful for CI, chared cache directories or avoiding polluting the project tree.

## Changes

- Introduced functionality allowing users to modify the cache directory location. a4232786ed4cef03933138f4a85a789b4bcef481 
- Included documentation on configuring the custom cache directory location feature. 844809c72566023ed11ce9280ea7df4729ba32b9
- Wrote unit tests for feature coverage. 4372e7bdf2a7a2419314cad65d7f8d0a2fb5fbde & 21ac528bdae78572013db099d4e1e206249076e7

## Checklist

- [x] Tests pass (`uv run pytest tests/`)
- [x] Code is formatted (`uv run ruff check .` and `uv run ruff format .`)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): description`
