### PR TITLE
feat(cli): port config stack to rust (steps 1-3)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,3 +87,21 @@ jobs:
         run: |-
           uv run -p ${{ matrix.python-version }} complexipy tests/src --exclude "exclude_dir/**" --ignore-complexity
           uv run -p ${{ matrix.python-version }} complexipy tests/src --exclude "**/test_exclude*.py" --ignore-complexity
+
+  rust-tests:
+    name: Rust Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+      - name: cargo test
+        run: cargo test --features python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "tempfile",
+ "toml",
  "wasm-bindgen",
  "wax",
  "web-sys",
@@ -958,6 +959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,6 +1049,45 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "unicode-ident"
@@ -1333,6 +1382,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -142,6 +142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -154,6 +155,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -311,7 +324,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -362,7 +375,7 @@ checksum = "b5a443e77201a230c25f0c11574e9b20e5705f749520e0f30ab0d0974fb1a794"
 dependencies = [
  "attribute-derive",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -506,7 +519,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -588,7 +601,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -711,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -776,7 +789,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -788,7 +801,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -819,7 +832,7 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1038,7 +1051,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1099,6 +1112,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,7 +1158,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1312,7 +1336,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1527,7 +1551,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1543,7 +1567,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1602,7 +1626,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,10 +136,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "collection_literals"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -109,6 +192,7 @@ dependencies = [
 name = "complexipy"
 version = "7.0.1"
 dependencies = [
+ "clap",
  "console_error_panic_hook",
  "csv",
  "globset",
@@ -426,6 +510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +635,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "phf"
@@ -986,6 +1082,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1239,12 @@ dependencies = [
  "phf_codegen",
  "rand",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ name = "complexipy"
 crate-type = ["cdylib"]
 
 [features]
-default = ["python"]
+default = ["python", "cli"]
+cli = ["dep:clap", "dep:toml", "serde"]
 python = [
     "serde",
     "pyo3",
@@ -70,8 +71,8 @@ serde-wasm-bindgen = { version = "0.4", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 web-sys = { version = "0.3", features = ["console"], optional = true }
 wax = "0.7.0"
-toml = "1.1.4"
-clap = { version = "4.6.6", features = ["derive"] }
+toml = { version = "1.1.4", optional = true }
+clap = { version = "4.6.6", features = ["derive"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ serde-wasm-bindgen = { version = "0.4", optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 web-sys = { version = "0.3", features = ["console"], optional = true }
 wax = "0.7.0"
+toml = "1.1.4"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 web-sys = { version = "0.3", features = ["console"], optional = true }
 wax = "0.7.0"
 toml = "1.1.4"
+clap = {version = "4.6.6", features = ["derive"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 web-sys = { version = "0.3", features = ["console"], optional = true }
 wax = "0.7.0"
 toml = "1.1.4"
-clap = {version = "4.6.6", features = ["derive"]}
+clap = { version = "4.6.6", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,1 +1,2 @@
 pub mod types;
+pub mod utils;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,2 +1,3 @@
+pub mod args;
 pub mod types;
 pub mod utils;

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,10 +1,69 @@
 use clap::Parser;
 
-#[derive(Parser)]
+use crate::cli::types::{Color, OutputFormat, Sort};
+
+#[derive(Parser, Debug, Clone, PartialEq)]
 #[command(name = "complexipy", version)]
 pub struct CliArgs {
     pub paths: Vec<String>,
 
     #[arg(short, long, value_delimiter = ',')]
     pub exclude: Vec<String>,
+
+    #[arg(long)]
+    pub max_complexity_allowed: Option<u64>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub snapshot_create: Option<bool>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub snapshot_ignore: Option<bool>,
+
+    #[arg(short, long, num_args = 0..=1, default_missing_value = "true")]
+    pub quiet: Option<bool>,
+
+    #[arg(short, long, num_args = 0..=1, default_missing_value = "true")]
+    pub ignore_complexity: Option<bool>,
+
+    #[arg(short, long, num_args = 0..=1, default_missing_value = "true")]
+    pub failed: Option<bool>,
+
+    #[arg(short = 'C', long)]
+    pub color: Option<Color>,
+
+    #[arg(short, long)]
+    pub sort: Option<Sort>,
+
+    #[arg(long)]
+    pub output: Option<String>,
+
+    #[arg(long, value_delimiter = ',')]
+    pub output_format: Option<Vec<OutputFormat>>,
+
+    #[arg(short, long)]
+    pub diff: Option<String>,
+
+    #[arg(long)]
+    pub diff_only: Option<String>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub staged: Option<bool>,
+
+    #[arg(short, long, value_parser = clap::value_parser!(u64).range(1..))]
+    pub top: Option<u64>,
+
+    #[arg(long, conflicts_with = "quiet", num_args = 0..=1, default_missing_value = "true")]
+    pub plain: Option<bool>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub suggest_refactors: Option<bool>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub check_script: Option<bool>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub no_ignore: Option<bool>,
+
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub report_ignored: Option<bool>,
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,0 +1,10 @@
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "complexipy", version)]
+pub struct CliArgs {
+    pub paths: Vec<String>,
+
+    #[arg(short, long, value_delimiter = ',')]
+    pub exclude: Vec<String>,
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -37,6 +37,9 @@ pub struct CliArgs {
     #[arg(long)]
     pub output: Option<String>,
 
+    #[arg(long)]
+    pub cache_dir: Option<String>,
+
     #[arg(long, value_delimiter = ',')]
     pub output_format: Option<Vec<OutputFormat>>,
 

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -2,27 +2,50 @@ pub use crate::classes::RefactorPlan;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-pub struct RunConfig {
+pub struct Config {
     paths: Vec<String>,
-    max_complexity_allowed: u64,
-    snapshot_create: bool,
-    snapshot_ignore: bool,
-    quiet: bool,
-    ignore_complexity: bool,
-    failed: bool,
-    color: Color,
-    sort: Sort,
-    output_format: Vec<OutputFormat>,
+    #[serde(default)]
     exclude: Vec<String>,
-    check_script: bool,
-    no_ignore: bool,
-    report_ignored: bool,
-    plain: bool,
+    #[serde(default = "default_max_complexity")]
+    max_complexity_allowed: u64,
+    #[serde(default)]
+    snapshot_create: bool,
+    #[serde(default)]
+    snapshot_ignore: bool,
+    #[serde(default)]
+    failed: bool,
+    #[serde(default)]
     suggest_refactors: bool,
+    #[serde(default)]
+    color: Color,
+    #[serde(default)]
+    sort: Sort,
+    #[serde(default)]
+    quiet: bool,
+    #[serde(default)]
+    ignore_complexity: bool,
+    #[serde(default)]
+    version: bool,
     top: Option<u64>,
+    #[serde(default)]
+    plain: bool,
+    #[serde(default)]
+    output_format: Vec<OutputFormat>,
+    output: Option<String>,
     diff: Option<String>,
     diff_only: Option<String>,
+    #[serde(default)]
     staged: bool,
+    #[serde(default)]
+    check_script: bool,
+    #[serde(default)]
+    no_ignore: bool,
+    #[serde(default)]
+    report_ignored: bool,
+}
+
+fn default_max_complexity() -> u64 {
+    15
 }
 
 #[derive(Deserialize)]
@@ -33,12 +56,24 @@ pub enum Color {
     no,
 }
 
+impl Default for Color {
+    fn default() -> Self {
+        Self::auto
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Sort {
     asc,
     desc,
     file_name,
+}
+
+impl Default for Sort {
+    fn default() -> Self {
+        Self::asc
+    }
 }
 
 #[derive(Deserialize)]

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub output: Option<String>,
     pub diff: Option<DiffSection>,
     #[serde(default)]
+    pub cache_dir: Option<toml::Value>,
+    #[serde(default)]
     pub check_script: bool,
     #[serde(default)]
     pub no_ignore: bool,
@@ -83,6 +85,7 @@ pub struct RunConfig {
     pub output_format: Vec<OutputFormat>,
     pub output: Option<String>,
     pub exclude: Vec<String>,
+    pub cache_dir: Option<String>,
     pub check_script: bool,
     pub no_ignore: bool,
     pub report_ignored: bool,

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,0 +1,122 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct RunConfig {
+    paths: Vec<String>,
+    max_complexity_allowed: u64,
+    snapshot_create: bool,
+    snapshot_ignore: bool,
+    quiet: bool,
+    ignore_complexity: bool,
+    failed: bool,
+    color: Color,
+    sort: Sort,
+    output_format: Vec<OutputFormat>,
+    exclude: Vec<String>,
+    check_script: bool,
+    no_ignore: bool,
+    report_ignored: bool,
+    plain: bool,
+    suggest_refactors: bool,
+    top: Option<u64>,
+    diff: Option<String>,
+    diff_only: Option<String>,
+    staged: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Color {
+    auto,
+    yes,
+    no,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Sort {
+    asc,
+    desc,
+    file_name,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputFormat {
+    csv,
+    json,
+    gitlab,
+    sarif,
+}
+
+impl OutputFormat {
+    pub fn default_output_filename(&self) -> String {
+        let file_name = "complexipy-results";
+        let extension = match self {
+            Self::csv => "csv",
+            Self::json => "json",
+            Self::gitlab => "gitlab.json",
+            Self::sarif => "sarif",
+        };
+        format!("{}.{}", file_name, extension)
+    }
+}
+
+pub struct ExitReport {
+    display_ok: bool,
+    snapshot_ok: bool,
+    paths_ok: bool,
+    diff_ok: bool,
+    enforce_diff: bool,
+}
+
+impl ExitReport {
+    pub fn success(&self) -> bool {
+        if self.enforce_diff {
+            self.diff_ok && self.paths_ok && self.snapshot_ok
+        } else {
+            self.display_ok && self.snapshot_ok && self.paths_ok
+        }
+    }
+}
+
+pub enum DiffStatus {
+    REGRESSED,
+    IMPROVED,
+    UNCHANGED,
+    NEW,
+    REMOVED,
+}
+
+pub struct DiffEntry {
+    file_path: String,
+    func_name: String,
+    old_complexity: Option<u64>,
+    new_complexity: Option<u64>,
+}
+
+impl DiffEntry {
+    pub fn status(&self) -> DiffStatus {
+        match (self.old_complexity, self.new_complexity) {
+            (None, ..) => DiffStatus::NEW,
+            (.., None) => DiffStatus::REMOVED,
+            (Some(old), Some(new)) => {
+                if new > old {
+                    DiffStatus::REGRESSED
+                } else if new < old {
+                    DiffStatus::IMPROVED
+                } else {
+                    DiffStatus::UNCHANGED
+                }
+            }
+        }
+    }
+
+    pub fn delta(&self) -> Option<u64> {
+        match (self.old_complexity, self.new_complexity) {
+            (None, ..) => None,
+            (.., None) => None,
+            (Some(old), Some(new)) => Some(new - old),
+        }
+    }
+}

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -2,54 +2,99 @@ pub use crate::classes::RefactorPlan;
 use clap::ValueEnum;
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
 pub struct Config {
-    paths: Vec<String>,
     #[serde(default)]
-    exclude: Vec<String>,
+    pub paths: StringOrList<String>,
+    #[serde(default)]
+    pub exclude: StringOrList<String>,
     #[serde(default = "default_max_complexity")]
-    max_complexity_allowed: u64,
+    pub max_complexity_allowed: u64,
     #[serde(default)]
-    snapshot_create: bool,
+    pub snapshot_create: bool,
     #[serde(default)]
-    snapshot_ignore: bool,
+    pub snapshot_ignore: bool,
     #[serde(default)]
-    failed: bool,
+    pub quiet: bool,
     #[serde(default)]
-    suggest_refactors: bool,
+    pub ignore_complexity: bool,
     #[serde(default)]
-    color: Color,
+    pub failed: bool,
     #[serde(default)]
-    sort: Sort,
+    pub color: Color,
     #[serde(default)]
-    quiet: bool,
+    pub sort: Sort,
     #[serde(default)]
-    ignore_complexity: bool,
+    pub output_format: StringOrList<OutputFormat>,
+    pub output: Option<String>,
+    pub diff: Option<DiffSection>,
     #[serde(default)]
-    version: bool,
-    top: Option<u64>,
+    pub check_script: bool,
     #[serde(default)]
-    plain: bool,
+    pub no_ignore: bool,
     #[serde(default)]
-    output_format: Vec<OutputFormat>,
-    output: Option<String>,
-    diff: Option<String>,
-    diff_only: Option<String>,
-    #[serde(default)]
-    staged: bool,
-    #[serde(default)]
-    check_script: bool,
-    #[serde(default)]
-    no_ignore: bool,
-    #[serde(default)]
-    report_ignored: bool,
+    pub report_ignored: bool,
 }
 
 fn default_max_complexity() -> u64 {
     15
 }
 
-#[derive(Deserialize, Clone, ValueEnum)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct DiffSection {
+    pub branch: Option<String>,
+    pub staged: Option<bool>,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum StringOrList<T> {
+    One(T),
+    Many(Vec<T>),
+}
+
+impl<T> Default for StringOrList<T> {
+    fn default() -> Self {
+        Self::Many(Vec::new())
+    }
+}
+
+impl<T> StringOrList<T> {
+    pub fn into_vec(self) -> Vec<T> {
+        match self {
+            Self::One(value) => vec![value],
+            Self::Many(values) => values,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RunConfig {
+    pub paths: Vec<String>,
+    pub max_complexity_allowed: u64,
+    pub snapshot_create: bool,
+    pub snapshot_ignore: bool,
+    pub quiet: bool,
+    pub ignore_complexity: bool,
+    pub failed: bool,
+    pub color: Color,
+    pub sort: Sort,
+    pub output_format: Vec<OutputFormat>,
+    pub output: Option<String>,
+    pub exclude: Vec<String>,
+    pub check_script: bool,
+    pub no_ignore: bool,
+    pub report_ignored: bool,
+    pub plain: bool,
+    pub suggest_refactors: bool,
+    pub top: Option<u64>,
+    pub diff: Option<String>,
+    pub diff_only: Option<String>,
+    pub staged: bool,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum Color {
     Auto,
@@ -63,7 +108,7 @@ impl Default for Color {
     }
 }
 
-#[derive(Deserialize, Clone, ValueEnum)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum Sort {
     Asc,
@@ -77,7 +122,7 @@ impl Default for Sort {
     }
 }
 
-#[derive(Deserialize, Clone, ValueEnum)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum OutputFormat {
     Csv,

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,3 +1,4 @@
+pub use crate::classes::RefactorPlan;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -119,4 +120,19 @@ impl DiffEntry {
             (Some(old), Some(new)) => Some(new - old),
         }
     }
+}
+
+pub struct FunctionRow {
+    name: String,
+    complexity: u64,
+    passed: bool,
+    path: String,
+    file_name: String,
+    refactor_plans: Vec<RefactorPlan>,
+    additional_refactor_plans: u64,
+}
+
+pub struct FileEntry {
+    path: String,
+    functions: Vec<FunctionRow>,
 }

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,4 +1,5 @@
 pub use crate::classes::RefactorPlan;
+use clap::ValueEnum;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -48,51 +49,51 @@ fn default_max_complexity() -> u64 {
     15
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum Color {
-    auto,
-    yes,
-    no,
+    Auto,
+    Yes,
+    No,
 }
 
 impl Default for Color {
     fn default() -> Self {
-        Self::auto
+        Self::Auto
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum Sort {
-    asc,
-    desc,
-    file_name,
+    Asc,
+    Desc,
+    File_name,
 }
 
 impl Default for Sort {
     fn default() -> Self {
-        Self::asc
+        Self::Asc
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone, ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum OutputFormat {
-    csv,
-    json,
-    gitlab,
-    sarif,
+    Csv,
+    Json,
+    Gitlab,
+    Sarif,
 }
 
 impl OutputFormat {
     pub fn default_output_filename(&self) -> String {
         let file_name = "complexipy-results";
         let extension = match self {
-            Self::csv => "csv",
-            Self::json => "json",
-            Self::gitlab => "gitlab.json",
-            Self::sarif => "sarif",
+            Self::Csv => "csv",
+            Self::Json => "json",
+            Self::Gitlab => "gitlab.json",
+            Self::Sarif => "sarif",
         };
         format!("{}.{}", file_name, extension)
     }

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,0 +1,1 @@
+pub mod toml;

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,1 +1,2 @@
+pub mod config;
 pub mod toml;

--- a/src/cli/utils/config.rs
+++ b/src/cli/utils/config.rs
@@ -6,6 +6,8 @@ use crate::cli::types::{Color, Config, OutputFormat, RunConfig, Sort};
 #[derive(Debug, PartialEq)]
 pub enum ConfigError {
     MissingPaths,
+    CacheDirNotAString,
+    CacheDirEmpty,
 }
 
 impl fmt::Display for ConfigError {
@@ -15,11 +17,42 @@ impl fmt::Display for ConfigError {
                 f,
                 "You need to define paths in the CLI call arguments or in complexipy.toml file"
             ),
+            Self::CacheDirNotAString => write!(
+                f,
+                "The 'cache-dir' option must be a string in the TOML config file"
+            ),
+            Self::CacheDirEmpty => write!(
+                f,
+                "The 'cache-dir' option cannot be an empty string in the TOML config file"
+            ),
         }
     }
 }
 
 impl std::error::Error for ConfigError {}
+
+fn resolve_cache_dir(
+    cli_value: Option<String>,
+    toml_value: Option<&toml::Value>,
+) -> Result<Option<String>, ConfigError> {
+    if let Some(value) = cli_value {
+        if value.trim().is_empty() {
+            return Err(ConfigError::CacheDirEmpty);
+        }
+        return Ok(Some(value));
+    }
+    match toml_value {
+        Some(toml::Value::String(value)) => {
+            if value.trim().is_empty() {
+                Err(ConfigError::CacheDirEmpty)
+            } else {
+                Ok(Some(value.clone()))
+            }
+        }
+        Some(_) => Err(ConfigError::CacheDirNotAString),
+        None => Ok(None),
+    }
+}
 
 pub fn resolve_config(toml_config: Option<Config>, cli: CliArgs) -> Result<RunConfig, ConfigError> {
     let toml = toml_config.as_ref();
@@ -104,6 +137,8 @@ pub fn resolve_config(toml_config: Option<Config>, cli: CliArgs) -> Result<RunCo
     let plain = cli.plain.unwrap_or(false);
     let suggest_refactors = cli.suggest_refactors.unwrap_or(false);
     let top = cli.top;
+    let cache_dir =
+        resolve_cache_dir(cli.cache_dir, toml.and_then(|toml| toml.cache_dir.as_ref()))?;
 
     let mut diff = cli.diff;
     let diff_only = cli.diff_only;
@@ -140,6 +175,7 @@ pub fn resolve_config(toml_config: Option<Config>, cli: CliArgs) -> Result<RunCo
         plain,
         suggest_refactors,
         top,
+        cache_dir,
         diff,
         diff_only,
         staged,

--- a/src/cli/utils/config.rs
+++ b/src/cli/utils/config.rs
@@ -1,0 +1,5 @@
+use crate::cli::types::Config;
+
+pub fn resolve_config(toml_config: Config, cli_config: Config) -> Config {
+    todo!()
+}

--- a/src/cli/utils/config.rs
+++ b/src/cli/utils/config.rs
@@ -1,5 +1,151 @@
-use crate::cli::types::Config;
+use std::fmt;
 
-pub fn resolve_config(toml_config: Config, cli_config: Config) -> Config {
-    todo!()
+use crate::cli::args::CliArgs;
+use crate::cli::types::{Color, Config, OutputFormat, RunConfig, Sort};
+
+#[derive(Debug, PartialEq)]
+pub enum ConfigError {
+    MissingPaths,
 }
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingPaths => write!(
+                f,
+                "You need to define paths in the CLI call arguments or in complexipy.toml file"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+pub fn resolve_config(toml_config: Option<Config>, cli: CliArgs) -> Result<RunConfig, ConfigError> {
+    let toml = toml_config.as_ref();
+
+    let paths = if !cli.paths.is_empty() {
+        cli.paths
+    } else if let Some(toml) = toml {
+        toml.paths.clone().into_vec()
+    } else {
+        return Err(ConfigError::MissingPaths);
+    };
+
+    let max_complexity_allowed = cli
+        .max_complexity_allowed
+        .or_else(|| toml.map(|toml| toml.max_complexity_allowed))
+        .unwrap_or(15);
+
+    let snapshot_create = cli
+        .snapshot_create
+        .or_else(|| toml.map(|toml| toml.snapshot_create))
+        .unwrap_or(false);
+
+    let snapshot_ignore = cli
+        .snapshot_ignore
+        .or_else(|| toml.map(|toml| toml.snapshot_ignore))
+        .unwrap_or(false);
+
+    let quiet = cli
+        .quiet
+        .or_else(|| toml.map(|toml| toml.quiet))
+        .unwrap_or(false);
+
+    let ignore_complexity = cli
+        .ignore_complexity
+        .or_else(|| toml.map(|toml| toml.ignore_complexity))
+        .unwrap_or(false);
+
+    let failed = cli
+        .failed
+        .or_else(|| toml.map(|toml| toml.failed))
+        .unwrap_or(false);
+
+    let color = cli.color.or_else(|| toml.map(|toml| toml.color.clone()));
+    let color = color.unwrap_or(Color::Auto);
+
+    let sort = cli.sort.or_else(|| toml.map(|toml| toml.sort.clone()));
+    let sort = sort.unwrap_or(Sort::Asc);
+
+    let output_format = match cli.output_format {
+        Some(formats) => formats,
+        None => toml
+            .map(|toml| toml.output_format.clone().into_vec())
+            .unwrap_or_default(),
+    };
+
+    let output = cli
+        .output
+        .or_else(|| toml.and_then(|toml| toml.output.clone()));
+
+    let exclude = if !cli.exclude.is_empty() {
+        cli.exclude
+    } else {
+        toml.map(|toml| toml.exclude.clone().into_vec())
+            .unwrap_or_default()
+    };
+
+    let check_script = cli
+        .check_script
+        .or_else(|| toml.map(|toml| toml.check_script))
+        .unwrap_or(false);
+
+    let no_ignore = cli
+        .no_ignore
+        .or_else(|| toml.map(|toml| toml.no_ignore))
+        .unwrap_or(false);
+
+    let report_ignored = cli
+        .report_ignored
+        .or_else(|| toml.map(|toml| toml.report_ignored))
+        .unwrap_or(false);
+
+    let plain = cli.plain.unwrap_or(false);
+    let suggest_refactors = cli.suggest_refactors.unwrap_or(false);
+    let top = cli.top;
+
+    let mut diff = cli.diff;
+    let diff_only = cli.diff_only;
+    let mut staged = cli.staged.unwrap_or(false);
+    if let Some(section) = toml.and_then(|toml| toml.diff.as_ref()) {
+        if diff.is_none() && diff_only.is_none() {
+            if let Some(branch) = &section.branch {
+                diff = Some(branch.clone());
+            }
+        }
+        if cli.staged.is_none() {
+            if let Some(section_staged) = section.staged {
+                staged = section_staged;
+            }
+        }
+    }
+
+    Ok(RunConfig {
+        paths,
+        max_complexity_allowed,
+        snapshot_create,
+        snapshot_ignore,
+        quiet,
+        ignore_complexity,
+        failed,
+        color,
+        sort,
+        output_format,
+        output,
+        exclude,
+        check_script,
+        no_ignore,
+        report_ignored,
+        plain,
+        suggest_refactors,
+        top,
+        diff,
+        diff_only,
+        staged,
+    })
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/config.rs"]
+mod tests;

--- a/src/cli/utils/toml.rs
+++ b/src/cli/utils/toml.rs
@@ -1,0 +1,62 @@
+use std::{fs, path::Path};
+
+use toml;
+
+use crate::cli::types::Config;
+
+pub fn get_complexipy_toml_config(invocation_path: &str) -> Option<Config> {
+    let invocation_path = Path::new(invocation_path);
+
+    if let Some(toml) = load_toml_config(invocation_path, "complexipy.toml") {
+        return Some(toml);
+    } else if let Some(toml) = load_toml_config(invocation_path, ".complexipy.toml") {
+        return Some(toml);
+    }
+    load_pyproject_config(invocation_path)
+}
+
+fn load_toml_config(invocation_path: &Path, file_name: &str) -> Option<Config> {
+    let config_file_path = invocation_path.join(file_name);
+
+    if !config_file_path.exists() {
+        return None;
+    }
+
+    let content = fs::read_to_string(&config_file_path).ok()?;
+
+    match toml::from_str(&content) {
+        Ok(config) => Some(config),
+        Err(e) => {
+            eprintln!("Failed to parse {}: {}", config_file_path.display(), e);
+            None
+        }
+    }
+}
+
+fn load_pyproject_config(invocation_path: &Path) -> Option<Config> {
+    let config_file_path = invocation_path.join("pyproject.toml");
+
+    if !config_file_path.exists() {
+        return None;
+    }
+
+    let content = fs::read_to_string(&config_file_path).ok()?;
+
+    let value: toml::Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to parse {}: {}", config_file_path.display(), e);
+            return None;
+        }
+    };
+
+    let section = value.get("tool")?.get("complexipy")?;
+
+    match section.clone().try_into() {
+        Ok(config) => Some(config),
+        Err(e) => {
+            eprintln!("Invalid config in {}: {}", config_file_path.display(), e);
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 mod classes;
+#[cfg(feature = "python")]
+mod cli;
 pub(crate) mod cognitive_complexity;
 mod helpers;
 mod refactor_plans;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod classes;
-#[cfg(feature = "python")]
+#[cfg(feature = "cli")]
 mod cli;
 pub(crate) mod cognitive_complexity;
 mod helpers;

--- a/src/tests/cli/config.rs
+++ b/src/tests/cli/config.rs
@@ -36,6 +36,7 @@ fn defaults_with_only_paths() {
     assert_eq!(config.plain, false);
     assert_eq!(config.suggest_refactors, false);
     assert_eq!(config.top, None);
+    assert_eq!(config.cache_dir, None);
     assert_eq!(config.diff, None);
     assert_eq!(config.diff_only, None);
     assert_eq!(config.staged, false);
@@ -173,6 +174,47 @@ fn staged_from_toml_when_cli_absent() {
     let config = resolve(&["src"], Some("[diff]\nstaged = true")).expect("resolve should succeed");
 
     assert_eq!(config.staged, true);
+}
+
+#[test]
+fn cache_dir_from_cli() {
+    let config = resolve(&["src", "--cache-dir", ".cache"], None).expect("resolve should succeed");
+
+    assert_eq!(config.cache_dir, Some(".cache".to_string()));
+}
+
+#[test]
+fn cache_dir_from_toml_when_cli_absent() {
+    let config = resolve(&["src"], Some("cache-dir = \".cache\"")).expect("resolve should succeed");
+
+    assert_eq!(config.cache_dir, Some(".cache".to_string()));
+}
+
+#[test]
+fn cli_cache_dir_wins_over_toml() {
+    let config = resolve(
+        &["src", "--cache-dir", "cli-cache"],
+        Some("cache-dir = \".cache\""),
+    )
+    .expect("resolve should succeed");
+
+    assert_eq!(config.cache_dir, Some("cli-cache".to_string()));
+}
+
+#[test]
+fn cache_dir_must_be_a_string_in_toml() {
+    let result = resolve(&["src"], Some("cache-dir = 123"));
+
+    assert_eq!(result, Err(ConfigError::CacheDirNotAString));
+}
+
+#[test]
+fn cache_dir_cannot_be_empty() {
+    let from_toml = resolve(&["src"], Some("cache-dir = \"\""));
+    assert_eq!(from_toml, Err(ConfigError::CacheDirEmpty));
+
+    let from_cli = resolve(&["src", "--cache-dir", ""], None);
+    assert_eq!(from_cli, Err(ConfigError::CacheDirEmpty));
 }
 
 #[test]

--- a/src/tests/cli/config.rs
+++ b/src/tests/cli/config.rs
@@ -1,0 +1,286 @@
+//! Wired in from `src/cli/utils/config.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use clap::Parser;
+
+use crate::cli::args::CliArgs;
+use crate::cli::types::{Color, Config, OutputFormat, RunConfig, Sort};
+use crate::cli::utils::config::{resolve_config, ConfigError};
+
+fn resolve(cli_args: &[&str], toml_source: Option<&str>) -> Result<RunConfig, ConfigError> {
+    let mut argv = vec!["complexipy"];
+    argv.extend_from_slice(cli_args);
+    let cli = CliArgs::try_parse_from(argv).expect("cli args should parse");
+    let toml = toml_source.map(|source| toml::from_str(source).expect("toml should parse"));
+    resolve_config(toml, cli)
+}
+
+#[test]
+fn defaults_with_only_paths() {
+    let config = resolve(&["src"], None).expect("resolve should succeed");
+
+    assert_eq!(config.paths, vec!["src"]);
+    assert_eq!(config.max_complexity_allowed, 15);
+    assert_eq!(config.snapshot_create, false);
+    assert_eq!(config.snapshot_ignore, false);
+    assert_eq!(config.quiet, false);
+    assert_eq!(config.ignore_complexity, false);
+    assert_eq!(config.failed, false);
+    assert_eq!(config.color, Color::Auto);
+    assert_eq!(config.sort, Sort::Asc);
+    assert_eq!(config.output_format, Vec::<OutputFormat>::new());
+    assert_eq!(config.output, None);
+    assert_eq!(config.exclude, Vec::<String>::new());
+    assert_eq!(config.check_script, false);
+    assert_eq!(config.no_ignore, false);
+    assert_eq!(config.report_ignored, false);
+    assert_eq!(config.plain, false);
+    assert_eq!(config.suggest_refactors, false);
+    assert_eq!(config.top, None);
+    assert_eq!(config.diff, None);
+    assert_eq!(config.diff_only, None);
+    assert_eq!(config.staged, false);
+}
+
+#[test]
+fn missing_paths_without_toml() {
+    let result = resolve(&[], None);
+
+    assert_eq!(result, Err(ConfigError::MissingPaths));
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "You need to define paths in the CLI call arguments or in complexipy.toml file"
+    );
+}
+
+#[test]
+fn toml_paths_used_when_cli_absent() {
+    let config = resolve(&[], Some("paths = [\"src\"]")).expect("resolve should succeed");
+
+    assert_eq!(config.paths, vec!["src"]);
+}
+
+#[test]
+fn toml_without_paths_allows_empty() {
+    let config = resolve(&[], Some("max-complexity-allowed = 10")).expect("resolve should succeed");
+
+    assert_eq!(config.paths, Vec::<String>::new());
+}
+
+#[test]
+fn cli_overrides_toml() {
+    let config = resolve(
+        &["--max-complexity-allowed", "20"],
+        Some("max-complexity-allowed = 10"),
+    )
+    .expect("resolve should succeed");
+
+    assert_eq!(config.max_complexity_allowed, 20);
+}
+
+#[test]
+fn toml_value_used_when_cli_absent() {
+    let config =
+        resolve(&["src"], Some("max-complexity-allowed = 10")).expect("resolve should succeed");
+
+    assert_eq!(config.max_complexity_allowed, 10);
+}
+
+#[test]
+fn toml_boolean_used_when_cli_absent() {
+    let config = resolve(
+        &["src"],
+        Some("quiet = true\nno-ignore = true\nreport-ignored = true"),
+    )
+    .expect("resolve should succeed");
+
+    assert_eq!(config.quiet, true);
+    assert_eq!(config.no_ignore, true);
+    assert_eq!(config.report_ignored, true);
+}
+
+#[test]
+fn cli_boolean_overrides_toml() {
+    let config =
+        resolve(&["src", "--quiet=false"], Some("quiet = true")).expect("resolve should succeed");
+
+    assert_eq!(config.quiet, false);
+}
+
+#[test]
+fn output_format_falls_back_to_toml_then_empty() {
+    let from_toml = resolve(&["src"], Some("output-format = [\"csv\", \"json\"]"))
+        .expect("resolve should succeed");
+    assert_eq!(
+        from_toml.output_format,
+        vec![OutputFormat::Csv, OutputFormat::Json]
+    );
+
+    let without_toml = resolve(&["src"], None).expect("resolve should succeed");
+    assert_eq!(without_toml.output_format, Vec::<OutputFormat>::new());
+}
+
+#[test]
+fn cli_output_format_overrides_toml() {
+    let config = resolve(
+        &["src", "--output-format", "json"],
+        Some("output-format = [\"csv\"]"),
+    )
+    .expect("resolve should succeed");
+
+    assert_eq!(config.output_format, vec![OutputFormat::Json]);
+}
+
+#[test]
+fn exclude_flattened_from_toml() {
+    let config = resolve(&["src"], Some("exclude = \"tests\"")).expect("resolve should succeed");
+
+    assert_eq!(config.exclude, vec!["tests"]);
+}
+
+#[test]
+fn diff_branch_from_toml() {
+    let config =
+        resolve(&["src"], Some("[diff]\nbranch = \"main\"")).expect("resolve should succeed");
+
+    assert_eq!(config.diff, Some("main".to_string()));
+}
+
+#[test]
+fn cli_diff_wins_over_toml_branch() {
+    let config = resolve(
+        &["src", "--diff", "develop"],
+        Some("[diff]\nbranch = \"main\""),
+    )
+    .expect("resolve should succeed");
+
+    assert_eq!(config.diff, Some("develop".to_string()));
+}
+
+#[test]
+fn diff_only_blocks_toml_branch() {
+    let config = resolve(
+        &["src", "--diff-only", "develop"],
+        Some("[diff]\nbranch = \"main\""),
+    )
+    .expect("resolve should succeed");
+
+    assert_eq!(config.diff, None);
+    assert_eq!(config.diff_only, Some("develop".to_string()));
+}
+
+#[test]
+fn staged_from_toml_when_cli_absent() {
+    let config = resolve(&["src"], Some("[diff]\nstaged = true")).expect("resolve should succeed");
+
+    assert_eq!(config.staged, true);
+}
+
+#[test]
+fn cli_staged_wins_over_toml() {
+    let config = resolve(&["src", "--staged"], Some("[diff]\nstaged = false"))
+        .expect("resolve should succeed");
+
+    assert_eq!(config.staged, true);
+}
+
+#[test]
+fn kebab_case_keys_deserialize() {
+    let source = "max-complexity-allowed = 12
+check-script = true
+no-ignore = true
+report-ignored = true
+snapshot-create = true
+snapshot-ignore = true
+ignore-complexity = true
+color = \"no\"
+sort = \"desc\"
+failed = true
+output = \"results.json\"";
+    let config: Config = toml::from_str(source).expect("toml should parse");
+
+    assert_eq!(config.max_complexity_allowed, 12);
+    assert_eq!(config.check_script, true);
+    assert_eq!(config.no_ignore, true);
+    assert_eq!(config.report_ignored, true);
+    assert_eq!(config.snapshot_create, true);
+    assert_eq!(config.snapshot_ignore, true);
+    assert_eq!(config.ignore_complexity, true);
+    assert_eq!(config.color, Color::No);
+    assert_eq!(config.sort, Sort::Desc);
+    assert_eq!(config.failed, true);
+    assert_eq!(config.output, Some("results.json".to_string()));
+}
+
+#[test]
+fn single_string_values_accepted() {
+    let source = "paths = \"src\"
+exclude = \"tests\"
+output-format = \"csv\"";
+    let config: Config = toml::from_str(source).expect("toml should parse");
+
+    assert_eq!(config.paths.into_vec(), vec!["src".to_string()]);
+    assert_eq!(config.exclude.into_vec(), vec!["tests".to_string()]);
+    assert_eq!(config.output_format.into_vec(), vec![OutputFormat::Csv]);
+}
+
+#[test]
+fn diff_section_deserializes() {
+    let config: Config =
+        toml::from_str("[diff]\nbranch = \"main\"\nstaged = true").expect("toml should parse");
+
+    let section = config.diff.expect("diff section should exist");
+    assert_eq!(section.branch, Some("main".to_string()));
+    assert_eq!(section.staged, Some(true));
+}
+
+#[test]
+fn top_and_version_ignored_in_toml() {
+    let config =
+        resolve(&["src"], Some("top = 5\nversion = true")).expect("resolve should succeed");
+
+    assert_eq!(config.top, None);
+}
+
+#[test]
+fn plain_and_suggest_refactors_default_false() {
+    let config = resolve(&["src"], None).expect("resolve should succeed");
+
+    assert_eq!(config.plain, false);
+    assert_eq!(config.suggest_refactors, false);
+}
+
+#[test]
+fn plain_conflicts_with_quiet() {
+    let result = CliArgs::try_parse_from(["complexipy", "src", "--plain", "--quiet"]);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn top_must_be_positive() {
+    assert!(CliArgs::try_parse_from(["complexipy", "src", "--top", "0"]).is_err());
+    assert!(CliArgs::try_parse_from(["complexipy", "src", "--top", "-1"]).is_err());
+
+    let parsed =
+        CliArgs::try_parse_from(["complexipy", "src", "--top", "1"]).expect("top 1 should parse");
+    assert_eq!(parsed.top, Some(1));
+}
+
+#[test]
+fn comma_separated_values_parse() {
+    let parsed = CliArgs::try_parse_from([
+        "complexipy",
+        "src",
+        "--exclude",
+        "tests/**,docs/**",
+        "--output-format",
+        "csv,json",
+    ])
+    .expect("comma separated values should parse");
+
+    assert_eq!(parsed.exclude, vec!["tests/**", "docs/**"]);
+    assert_eq!(
+        parsed.output_format,
+        Some(vec![OutputFormat::Csv, OutputFormat::Json])
+    );
+}


### PR DESCRIPTION
## What

Ports the CLI configuration stack — types, TOML loading, and config resolution — from Python to Rust, as steps 1–3 of the CLI migration tracked in issue #224.

## Why

This is the foundation of the CLI migration: every later step (paths, cache, output, diff, main) consumes the resolved `RunConfig`. The Rust port replaces typer's merge and validation logic with a serde + clap equivalent, and gates the whole CLI scaffold behind a new `cli` cargo feature so the WASM target stays clean.

## Changes

- `feat(cargo)` — add `cli` feature; clap/toml become optional deps; default features = `python, cli`
- `src/cli/types.rs` — `Config` (TOML, kebab-case serde, string-or-list coercion, `DiffSection`) and `RunConfig` (resolved) split; `Color`/`Sort`/`OutputFormat` enums with clap `ValueEnum`
- `src/cli/utils/toml.rs` — port of `utils/toml.py` (`complexipy.toml`, `.complexipy.toml`, `[tool.complexipy]`)
- `src/cli/args.rs` — full clap `CliArgs` with all flags, typer flag semantics for booleans, plain×quiet conflict, `--top` range validation
- `src/cli/utils/config.rs` — `resolve_config` with CLI > TOML > default precedence, `[diff]` branch/staged rules, `cache-dir` validation (type + empty-string), `ConfigError`
- `feat(cli)` — `--cache-dir` support merged from main (PR #229)
- `src/tests/cli/config.rs` — 30 Rust unit tests mirroring the Python `test_config.py` contract plus the cache-dir cases
- `ci` — new `rust-tests` job running `cargo test --features python`
- Python CLI untouched — it remains the behavioral oracle until the final integration step

Issue: #224