### PR TITLE
feat(cli): port output path resolution to rust (step 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ vscode/complexipy/.vscode-test/**
 
 # ES doc
 site-es/
+
+# Pi extension state (baselines, last report)
+.pi/rust-validate/

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -97,32 +97,23 @@ pub struct RunConfig {
     pub staged: bool,
 }
 
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq, ValueEnum)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, ValueEnum, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Color {
+    #[default]
     Auto,
     Yes,
     No,
 }
 
-impl Default for Color {
-    fn default() -> Self {
-        Self::Auto
-    }
-}
-
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq, ValueEnum)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, ValueEnum, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum Sort {
+    #[default]
     Asc,
     Desc,
-    File_name,
-}
-
-impl Default for Sort {
-    fn default() -> Self {
-        Self::Asc
-    }
+    #[value(name = "file_name")]
+    FileName,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq, ValueEnum)]
@@ -166,11 +157,11 @@ impl ExitReport {
 }
 
 pub enum DiffStatus {
-    REGRESSED,
-    IMPROVED,
-    UNCHANGED,
-    NEW,
-    REMOVED,
+    Regressed,
+    Improved,
+    Unchanged,
+    New,
+    Removed,
 }
 
 pub struct DiffEntry {
@@ -183,15 +174,15 @@ pub struct DiffEntry {
 impl DiffEntry {
     pub fn status(&self) -> DiffStatus {
         match (self.old_complexity, self.new_complexity) {
-            (None, ..) => DiffStatus::NEW,
-            (.., None) => DiffStatus::REMOVED,
+            (None, ..) => DiffStatus::New,
+            (.., None) => DiffStatus::Removed,
             (Some(old), Some(new)) => {
                 if new > old {
-                    DiffStatus::REGRESSED
+                    DiffStatus::Regressed
                 } else if new < old {
-                    DiffStatus::IMPROVED
+                    DiffStatus::Improved
                 } else {
-                    DiffStatus::UNCHANGED
+                    DiffStatus::Unchanged
                 }
             }
         }

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,2 +1,3 @@
 pub mod config;
+pub mod paths;
 pub mod toml;

--- a/src/cli/utils/config.rs
+++ b/src/cli/utils/config.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::cli::args::CliArgs;
-use crate::cli::types::{Color, Config, OutputFormat, RunConfig, Sort};
+use crate::cli::types::{Color, Config, RunConfig, Sort};
 
 #[derive(Debug, PartialEq)]
 pub enum ConfigError {
@@ -144,15 +144,16 @@ pub fn resolve_config(toml_config: Option<Config>, cli: CliArgs) -> Result<RunCo
     let diff_only = cli.diff_only;
     let mut staged = cli.staged.unwrap_or(false);
     if let Some(section) = toml.and_then(|toml| toml.diff.as_ref()) {
-        if diff.is_none() && diff_only.is_none() {
-            if let Some(branch) = &section.branch {
-                diff = Some(branch.clone());
-            }
+        if diff.is_none()
+            && diff_only.is_none()
+            && let Some(branch) = &section.branch
+        {
+            diff = Some(branch.clone());
         }
-        if cli.staged.is_none() {
-            if let Some(section_staged) = section.staged {
-                staged = section_staged;
-            }
+        if cli.staged.is_none()
+            && let Some(section_staged) = section.staged
+        {
+            staged = section_staged;
         }
     }
 

--- a/src/cli/utils/paths.rs
+++ b/src/cli/utils/paths.rs
@@ -1,0 +1,118 @@
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+use crate::cli::types::OutputFormat;
+
+#[derive(Debug, PartialEq)]
+pub enum PathsError {
+    StdoutNotSupported,
+    MultiFormatNotDirectory,
+    MultiFormatNoTrailingSeparator,
+    Io(String),
+}
+
+impl fmt::Display for PathsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StdoutNotSupported => write!(
+                f,
+                "Writing machine-readable output to stdout is not supported."
+            ),
+            Self::MultiFormatNotDirectory => write!(
+                f,
+                "When multiple output formats are selected, --output must point to a directory."
+            ),
+            Self::MultiFormatNoTrailingSeparator => write!(
+                f,
+                "When multiple output formats are selected, --output must point to a directory or end with a path separator."
+            ),
+            Self::Io(message) => write!(f, "{}", message),
+        }
+    }
+}
+
+impl std::error::Error for PathsError {}
+
+pub fn resolve_output_paths(
+    output_formats: &[OutputFormat],
+    output: Option<&str>,
+    invocation_path: &Path,
+) -> Result<Vec<(OutputFormat, String)>, PathsError> {
+    if output_formats.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let Some(output) = output else {
+        return Ok(build_output_paths(invocation_path, output_formats));
+    };
+
+    if output == "-" {
+        return Err(PathsError::StdoutNotSupported);
+    }
+
+    let destination = std::path::absolute(output).map_err(|e| PathsError::Io(e.to_string()))?;
+    let is_directory_hint = is_directory_output_hint(output);
+
+    if output_formats.len() > 1 {
+        ensure_directory_destination(&destination, is_directory_hint)?;
+        return Ok(build_output_paths(&destination, output_formats));
+    }
+
+    let output_format = &output_formats[0];
+    if destination.is_dir() || is_directory_hint {
+        fs::create_dir_all(&destination).map_err(|e| PathsError::Io(e.to_string()))?;
+        return Ok(build_output_paths(&destination, output_formats));
+    }
+
+    if let Some(parent) = destination
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|e| PathsError::Io(e.to_string()))?;
+    }
+
+    Ok(vec![(
+        output_format.clone(),
+        destination.to_string_lossy().into_owned(),
+    )])
+}
+
+pub fn build_output_paths(
+    destination: &Path,
+    output_formats: &[OutputFormat],
+) -> Vec<(OutputFormat, String)> {
+    output_formats
+        .iter()
+        .map(|output_format| {
+            (
+                output_format.clone(),
+                destination
+                    .join(output_format.default_output_filename())
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        })
+        .collect()
+}
+
+pub fn is_directory_output_hint(output: &str) -> bool {
+    output.ends_with('/') || (cfg!(windows) && output.ends_with('\\'))
+}
+
+pub fn ensure_directory_destination(
+    destination: &Path,
+    is_directory_hint: bool,
+) -> Result<(), PathsError> {
+    if destination.exists() && !destination.is_dir() {
+        return Err(PathsError::MultiFormatNotDirectory);
+    } else if !is_directory_hint {
+        return Err(PathsError::MultiFormatNoTrailingSeparator);
+    }
+
+    fs::create_dir_all(destination).map_err(|e| PathsError::Io(e.to_string()))
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/paths.rs"]
+mod tests;

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -44,13 +44,8 @@ pub fn code_complexity(
         }
     };
     let ast_body = parsed.into_suite();
-    let (functions, complexity) = function_level_cognitive_complexity_shared(
-        &ast_body,
-        code,
-        check_script,
-        no_ignore,
-        true,
-    );
+    let (functions, complexity) =
+        function_level_cognitive_complexity_shared(&ast_body, code, check_script, no_ignore, true);
     Ok(CodeComplexity {
         functions,
         complexity,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod classes;
 #[cfg(feature = "cli")]
+#[allow(dead_code)]
 mod cli;
 pub(crate) mod cognitive_complexity;
 mod helpers;

--- a/src/rules/complexity.rs
+++ b/src/rules/complexity.rs
@@ -649,9 +649,7 @@ fn generate_loop_guard_suggestion(
     // dangling `else` inside the body. A first chain member with its own
     // `else`/`elif` cannot become a guard either — the guard would skip the
     // `else` branch entirely.
-    if has_else_branch(region, &lines)
-        || guards.is_empty()
-        || has_else_branch(guards[0].0, &lines)
+    if has_else_branch(region, &lines) || guards.is_empty() || has_else_branch(guards[0].0, &lines)
     {
         return None;
     }

--- a/src/rules/registry.rs
+++ b/src/rules/registry.rs
@@ -88,9 +88,7 @@ impl RuleRegistry {
                 continue;
             };
             plan.estimated_reduction = measured;
-            plan.estimated_complexity_after = plan
-                .current_complexity
-                .saturating_sub(measured);
+            plan.estimated_complexity_after = plan.current_complexity.saturating_sub(measured);
             plan.reduction_is_measured = true;
         }
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -482,13 +482,8 @@ fn collect_removable_ignores_from_file(
     let parsed = parse_module(&code)
         .map_err(|e| PyValueError::new_err(format!("Failed to parse code: {}", e)))?;
     let ast_body = parsed.into_suite();
-    let (functions, _) = function_level_cognitive_complexity_shared(
-        &ast_body,
-        &code,
-        false,
-        true,
-        false,
-    );
+    let (functions, _) =
+        function_level_cognitive_complexity_shared(&ast_body, &code, false, true, false);
     let removable = filter_removable_ignores(&locations, &functions, max_complexity_allowed);
     Ok(removable
         .into_iter()

--- a/src/tests/cli/config.rs
+++ b/src/tests/cli/config.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 
 use crate::cli::args::CliArgs;
 use crate::cli::types::{Color, Config, OutputFormat, RunConfig, Sort};
-use crate::cli::utils::config::{resolve_config, ConfigError};
+use crate::cli::utils::config::{ConfigError, resolve_config};
 
 fn resolve(cli_args: &[&str], toml_source: Option<&str>) -> Result<RunConfig, ConfigError> {
     let mut argv = vec!["complexipy"];
@@ -20,26 +20,26 @@ fn defaults_with_only_paths() {
 
     assert_eq!(config.paths, vec!["src"]);
     assert_eq!(config.max_complexity_allowed, 15);
-    assert_eq!(config.snapshot_create, false);
-    assert_eq!(config.snapshot_ignore, false);
-    assert_eq!(config.quiet, false);
-    assert_eq!(config.ignore_complexity, false);
-    assert_eq!(config.failed, false);
+    assert!(!config.snapshot_create);
+    assert!(!config.snapshot_ignore);
+    assert!(!config.quiet);
+    assert!(!config.ignore_complexity);
+    assert!(!config.failed);
     assert_eq!(config.color, Color::Auto);
     assert_eq!(config.sort, Sort::Asc);
     assert_eq!(config.output_format, Vec::<OutputFormat>::new());
     assert_eq!(config.output, None);
     assert_eq!(config.exclude, Vec::<String>::new());
-    assert_eq!(config.check_script, false);
-    assert_eq!(config.no_ignore, false);
-    assert_eq!(config.report_ignored, false);
-    assert_eq!(config.plain, false);
-    assert_eq!(config.suggest_refactors, false);
+    assert!(!config.check_script);
+    assert!(!config.no_ignore);
+    assert!(!config.report_ignored);
+    assert!(!config.plain);
+    assert!(!config.suggest_refactors);
     assert_eq!(config.top, None);
     assert_eq!(config.cache_dir, None);
     assert_eq!(config.diff, None);
     assert_eq!(config.diff_only, None);
-    assert_eq!(config.staged, false);
+    assert!(!config.staged);
 }
 
 #[test]
@@ -94,9 +94,9 @@ fn toml_boolean_used_when_cli_absent() {
     )
     .expect("resolve should succeed");
 
-    assert_eq!(config.quiet, true);
-    assert_eq!(config.no_ignore, true);
-    assert_eq!(config.report_ignored, true);
+    assert!(config.quiet);
+    assert!(config.no_ignore);
+    assert!(config.report_ignored);
 }
 
 #[test]
@@ -104,7 +104,7 @@ fn cli_boolean_overrides_toml() {
     let config =
         resolve(&["src", "--quiet=false"], Some("quiet = true")).expect("resolve should succeed");
 
-    assert_eq!(config.quiet, false);
+    assert!(!config.quiet);
 }
 
 #[test]
@@ -173,7 +173,7 @@ fn diff_only_blocks_toml_branch() {
 fn staged_from_toml_when_cli_absent() {
     let config = resolve(&["src"], Some("[diff]\nstaged = true")).expect("resolve should succeed");
 
-    assert_eq!(config.staged, true);
+    assert!(config.staged);
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn cli_staged_wins_over_toml() {
     let config = resolve(&["src", "--staged"], Some("[diff]\nstaged = false"))
         .expect("resolve should succeed");
 
-    assert_eq!(config.staged, true);
+    assert!(config.staged);
 }
 
 #[test]
@@ -241,15 +241,15 @@ output = \"results.json\"";
     let config: Config = toml::from_str(source).expect("toml should parse");
 
     assert_eq!(config.max_complexity_allowed, 12);
-    assert_eq!(config.check_script, true);
-    assert_eq!(config.no_ignore, true);
-    assert_eq!(config.report_ignored, true);
-    assert_eq!(config.snapshot_create, true);
-    assert_eq!(config.snapshot_ignore, true);
-    assert_eq!(config.ignore_complexity, true);
+    assert!(config.check_script);
+    assert!(config.no_ignore);
+    assert!(config.report_ignored);
+    assert!(config.snapshot_create);
+    assert!(config.snapshot_ignore);
+    assert!(config.ignore_complexity);
     assert_eq!(config.color, Color::No);
     assert_eq!(config.sort, Sort::Desc);
-    assert_eq!(config.failed, true);
+    assert!(config.failed);
     assert_eq!(config.output, Some("results.json".to_string()));
 }
 
@@ -287,8 +287,8 @@ fn top_and_version_ignored_in_toml() {
 fn plain_and_suggest_refactors_default_false() {
     let config = resolve(&["src"], None).expect("resolve should succeed");
 
-    assert_eq!(config.plain, false);
-    assert_eq!(config.suggest_refactors, false);
+    assert!(!config.plain);
+    assert!(!config.suggest_refactors);
 }
 
 #[test]

--- a/src/tests/cli/paths.rs
+++ b/src/tests/cli/paths.rs
@@ -1,0 +1,322 @@
+//! Wired in from `src/cli/utils/paths.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::tempdir;
+
+use crate::cli::types::OutputFormat;
+use crate::cli::utils::paths::{
+    PathsError, build_output_paths, ensure_directory_destination, is_directory_output_hint,
+    resolve_output_paths,
+};
+
+fn default_paths(destination: &Path) -> Vec<(OutputFormat, PathBuf)> {
+    [
+        OutputFormat::Csv,
+        OutputFormat::Json,
+        OutputFormat::Gitlab,
+        OutputFormat::Sarif,
+    ]
+    .into_iter()
+    .map(|format| {
+        let filename = format.default_output_filename();
+        (format, destination.join(filename))
+    })
+    .collect()
+}
+
+#[test]
+fn empty_formats_returns_empty() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = resolve_output_paths(&[], None, dir.path()).expect("should succeed");
+
+    assert!(result.is_empty());
+    assert_eq!(fs::read_dir(dir.path()).expect("should read").count(), 0);
+}
+
+#[test]
+fn no_output_uses_invocation_path_with_default_filenames() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result =
+        resolve_output_paths(&[OutputFormat::Csv], None, dir.path()).expect("should succeed");
+
+    assert_eq!(
+        result,
+        vec![(
+            OutputFormat::Csv,
+            dir.path()
+                .join("complexipy-results.csv")
+                .to_string_lossy()
+                .into_owned()
+        )]
+    );
+}
+
+#[test]
+fn stdout_destination_rejected() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = resolve_output_paths(&[OutputFormat::Csv], Some("-"), dir.path());
+
+    assert_eq!(result, Err(PathsError::StdoutNotSupported));
+}
+
+#[test]
+fn single_format_existing_directory() {
+    let dir = tempdir().expect("tempdir should work");
+    let sub = dir.path().join("sub");
+    fs::create_dir(&sub).expect("should create");
+
+    let result = resolve_output_paths(
+        &[OutputFormat::Csv],
+        Some(sub.to_str().unwrap()),
+        dir.path(),
+    )
+    .expect("should succeed");
+
+    assert_eq!(
+        result,
+        vec![(
+            OutputFormat::Csv,
+            sub.join("complexipy-results.csv")
+                .to_string_lossy()
+                .into_owned()
+        )]
+    );
+}
+
+#[test]
+fn single_format_trailing_separator_hint() {
+    let dir = tempdir().expect("tempdir should work");
+    let out = dir.path().join("out");
+    let output = format!("{}{}", out.to_str().unwrap(), std::path::MAIN_SEPARATOR);
+
+    let result = resolve_output_paths(&[OutputFormat::Json], Some(&output), dir.path())
+        .expect("should succeed");
+
+    assert!(out.is_dir());
+    assert_eq!(
+        result,
+        vec![(
+            OutputFormat::Json,
+            out.join("complexipy-results.json")
+                .to_string_lossy()
+                .into_owned()
+        )]
+    );
+}
+
+#[test]
+fn single_format_plain_file_path() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("results.csv");
+
+    let result = resolve_output_paths(
+        &[OutputFormat::Csv],
+        Some(file.to_str().unwrap()),
+        dir.path(),
+    )
+    .expect("should succeed");
+
+    assert_eq!(
+        result,
+        vec![(OutputFormat::Csv, file.to_string_lossy().into_owned())]
+    );
+}
+
+#[test]
+fn single_format_creates_parent_directories() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("nested").join("deep").join("results.json");
+
+    let result = resolve_output_paths(
+        &[OutputFormat::Json],
+        Some(file.to_str().unwrap()),
+        dir.path(),
+    )
+    .expect("should succeed");
+
+    assert!(file.parent().expect("parent").is_dir());
+    assert_eq!(
+        result,
+        vec![(OutputFormat::Json, file.to_string_lossy().into_owned())]
+    );
+}
+
+#[test]
+fn relative_output_is_absolutized() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = "rel-out/";
+
+    let result = resolve_output_paths(&[OutputFormat::Csv], Some(output), dir.path())
+        .expect("should succeed");
+
+    let expected = std::env::current_dir()
+        .expect("cwd")
+        .join("rel-out")
+        .join("complexipy-results.csv");
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].1, expected.to_string_lossy().into_owned());
+    assert!(expected.parent().expect("parent").is_dir());
+}
+
+#[test]
+fn multi_format_existing_file_rejected() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("results.txt");
+    fs::write(&file, "x").expect("should write");
+
+    let result = resolve_output_paths(
+        &[OutputFormat::Csv, OutputFormat::Json],
+        Some(file.to_str().unwrap()),
+        dir.path(),
+    );
+
+    assert_eq!(result, Err(PathsError::MultiFormatNotDirectory));
+}
+
+#[test]
+fn multi_format_plain_path_rejected() {
+    let dir = tempdir().expect("tempdir should work");
+    let out = dir.path().join("out");
+
+    let result = resolve_output_paths(
+        &[OutputFormat::Csv, OutputFormat::Json],
+        Some(out.to_str().unwrap()),
+        dir.path(),
+    );
+
+    assert_eq!(result, Err(PathsError::MultiFormatNoTrailingSeparator));
+}
+
+#[test]
+fn multi_format_trailing_separator_creates_directory() {
+    let dir = tempdir().expect("tempdir should work");
+    let out = dir.path().join("out");
+    let output = format!("{}{}", out.to_str().unwrap(), std::path::MAIN_SEPARATOR);
+
+    let result = resolve_output_paths(
+        &[OutputFormat::Csv, OutputFormat::Json],
+        Some(&output),
+        dir.path(),
+    )
+    .expect("should succeed");
+
+    assert!(out.is_dir());
+    assert_eq!(
+        result,
+        vec![
+            (
+                OutputFormat::Csv,
+                out.join("complexipy-results.csv")
+                    .to_string_lossy()
+                    .into_owned()
+            ),
+            (
+                OutputFormat::Json,
+                out.join("complexipy-results.json")
+                    .to_string_lossy()
+                    .into_owned()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn multi_format_existing_directory_without_hint_rejected() {
+    let dir = tempdir().expect("tempdir should work");
+    let sub = dir.path().join("sub");
+    fs::create_dir(&sub).expect("should create");
+
+    let result = resolve_output_paths(
+        &[OutputFormat::Csv, OutputFormat::Json],
+        Some(sub.to_str().unwrap()),
+        dir.path(),
+    );
+
+    assert_eq!(result, Err(PathsError::MultiFormatNoTrailingSeparator));
+}
+
+#[test]
+fn multi_format_existing_directory_with_hint() {
+    let dir = tempdir().expect("tempdir should work");
+    let sub = dir.path().join("sub");
+    fs::create_dir(&sub).expect("should create");
+    let output = format!("{}{}", sub.to_str().unwrap(), std::path::MAIN_SEPARATOR);
+
+    let result = resolve_output_paths(
+        &[OutputFormat::Csv, OutputFormat::Sarif],
+        Some(&output),
+        dir.path(),
+    )
+    .expect("should succeed");
+
+    assert_eq!(
+        result,
+        vec![
+            (
+                OutputFormat::Csv,
+                sub.join("complexipy-results.csv")
+                    .to_string_lossy()
+                    .into_owned()
+            ),
+            (
+                OutputFormat::Sarif,
+                sub.join("complexipy-results.sarif")
+                    .to_string_lossy()
+                    .into_owned()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn build_output_paths_uses_default_filenames() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = build_output_paths(
+        dir.path(),
+        &[
+            OutputFormat::Csv,
+            OutputFormat::Json,
+            OutputFormat::Gitlab,
+            OutputFormat::Sarif,
+        ],
+    );
+
+    assert_eq!(
+        result,
+        default_paths(dir.path())
+            .into_iter()
+            .map(|(format, path)| (format, path.to_string_lossy().into_owned()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn directory_hint_detects_trailing_separators() {
+    assert!(is_directory_output_hint("out/"));
+    assert!(!is_directory_output_hint("out"));
+    assert!(!is_directory_output_hint(""));
+}
+
+#[test]
+fn ensure_directory_destination_validates() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("results.txt");
+    fs::write(&file, "x").expect("should write");
+
+    assert_eq!(
+        ensure_directory_destination(&file, false),
+        Err(PathsError::MultiFormatNotDirectory)
+    );
+    assert_eq!(
+        ensure_directory_destination(&dir.path().join("new"), false),
+        Err(PathsError::MultiFormatNoTrailingSeparator)
+    );
+    assert!(ensure_directory_destination(&dir.path().join("new"), true).is_ok());
+    assert!(dir.path().join("new").is_dir());
+}

--- a/src/tests/rules/complexity.rs
+++ b/src/tests/rules/complexity.rs
@@ -384,7 +384,8 @@ fn loop_guard_suggestion_refuses_a_first_member_with_its_own_else() {
 
 #[test]
 fn loop_guard_suggestion_refuses_a_loop_level_else() {
-    let source = "def f():\n    for x in y:\n        if a:\n            pass\n    else:\n        pass\n";
+    let source =
+        "def f():\n    for x in y:\n        if a:\n            pass\n    else:\n        pass\n";
     let region = ComplexityRegion {
         kind: RegionKind::Loop,
         line_start: 2,

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -25,13 +25,8 @@ fn get_code_complexity(code: &str) -> Result<CodeComplexity, String> {
         Err(e) => return Err(format!("Parse error: {}", e)),
     };
 
-    let (functions, complexity) = function_level_cognitive_complexity_shared(
-        parsed.suite(),
-        code,
-        false,
-        false,
-        true,
-    );
+    let (functions, complexity) =
+        function_level_cognitive_complexity_shared(parsed.suite(), code, false, false, true);
 
     Ok(CodeComplexity {
         complexity,


### PR DESCRIPTION
## What

Ports `utils/paths.py` — output path resolution for export formats — to Rust, as step 4 of the CLI migration in issue #224.

## Why

Each migration step is merged to main directly once validated. This step stands alone: no Rust consumer yet (Steps 12–13 use it), mirroring how the toml port preceded the config port.

## Changes

- `src/cli/utils/paths.rs` — `resolve_output_paths`, `build_output_paths`, `is_directory_output_hint`, `ensure_directory_destination`, `PathsError` (verbatim Python messages, `Io` variant for fs failures)
- Faithful port details: `std::path::absolute` for `os.path.abspath`, directory-hint with `os.sep`/`os.altsep` semantics, multi-format existing-directory-without-separator quirk preserved
- `src/tests/cli/paths.rs` — 16 tests covering every Python branch
- `refactor(cli): fix clippy warnings` — `Color`/`Sort` derived defaults, `FileName`/`DiffStatus` naming, let-chains, module-level `#[allow(dead_code)]` for the unreachable scaffolding, 26 test asserts converted
- `format: format rust sources` — rustfmt line-wrapping only
- `chore: ignore pi extension state` — `.gitignore`

Issue: #224