### PR TITLE
feat(cli): port cache store to rust (step 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +223,7 @@ dependencies = [
 name = "complexipy"
 version = "7.0.1"
 dependencies = [
+ "blake2",
  "clap",
  "console_error_panic_hook",
  "csv",
@@ -296,6 +315,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +354,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -366,6 +406,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "get-size-derive2"
@@ -1101,6 +1151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1272,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1331,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2"]
 python = [
     "serde",
     "pyo3",
@@ -73,6 +73,7 @@ web-sys = { version = "0.3", features = ["console"], optional = true }
 wax = "0.7.0"
 toml = { version = "1.1.4", optional = true }
 clap = { version = "4.6.6", features = ["derive"], optional = true }
+blake2 = { version = "0.10", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,3 +1,4 @@
+pub mod cache;
 pub mod config;
 pub mod paths;
 pub mod toml;

--- a/src/cli/utils/cache.rs
+++ b/src/cli/utils/cache.rs
@@ -1,0 +1,425 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use blake2::Blake2bVar;
+use blake2::digest::{Update, VariableOutput};
+use serde_json::{Value, json};
+
+use crate::classes::FileComplexity;
+
+const CACHE_DIR_NAME: &str = ".complexipy_cache";
+const CACHE_VALUES_DIR: &str = "v/cache";
+const FUNCTIONS_CACHE_KEY: &str = "functions";
+const MAX_CACHE_ENTRIES: usize = 64;
+const CACHEDIR_TAG_CONTENT: &str = "Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag created by complexipy.
+# For information about cache directory tags, see:
+#\thttps://bford.info/cachedir/spec.html
+";
+const README_CONTENT: &str = "# complexipy cache directory #
+
+This directory contains data from complexipy's cache, which stores previous
+complexity results so future runs can compare per-function complexity changes.
+
+**Do not** commit this to version control.
+";
+
+pub fn remember_previous_functions(
+    invocation_path: &str,
+    targets: &[String],
+    files_complexities: &[FileComplexity],
+    cache_dir: Option<&str>,
+) -> Option<HashMap<(String, String, String), u64>> {
+    let cache_key = build_cache_key(invocation_path, targets)?;
+
+    let cache_dir_path = resolve_cache_dir(invocation_path, cache_dir);
+    let is_default_cache_location =
+        cache_dir_path == Path::new(invocation_path).join(CACHE_DIR_NAME);
+    let cache_file = cache_value_path(&cache_dir_path, FUNCTIONS_CACHE_KEY);
+
+    ensure_cache_dir_and_supporting_files(&cache_dir_path)?;
+
+    let mut cache_store = load_cache_store(&cache_file);
+    if is_default_cache_location {
+        migrate_legacy_cache_entry(&cache_dir_path, &mut cache_store, &cache_key);
+    }
+    let previous_map = load_previous_map_from_store(&cache_store, &cache_key);
+
+    cache_store["entries"][cache_key.as_str()] = json!({
+        "targets": normalize_targets(invocation_path, targets),
+        "functions": collect_functions(files_complexities),
+        "updated_at": now_seconds(),
+    });
+    prune_cache_store(&mut cache_store);
+    if persist_cache(&cache_file, &cache_store) && is_default_cache_location {
+        remove_legacy_cache_files(&cache_dir_path);
+    }
+    previous_map
+}
+
+fn resolve_cache_dir(invocation_path: &str, cache_dir: Option<&str>) -> PathBuf {
+    match cache_dir {
+        Some(dir) if !dir.is_empty() => PathBuf::from(dir),
+        _ => Path::new(invocation_path).join(CACHE_DIR_NAME),
+    }
+}
+
+fn build_cache_key(invocation_path: &str, targets: &[String]) -> Option<String> {
+    let normalized_targets = normalize_targets(invocation_path, targets);
+    if normalized_targets.is_empty() {
+        return None;
+    }
+    Some(hash_targets(&normalized_targets.join("||")))
+}
+
+fn hash_targets(joined: &str) -> String {
+    let mut hasher = Blake2bVar::new(16).expect("digest size is valid");
+    hasher.update(joined.as_bytes());
+    let mut output = [0u8; 16];
+    hasher
+        .finalize_variable(&mut output)
+        .expect("output size matches");
+    output.iter().map(|byte| format!("{:02x}", byte)).collect()
+}
+
+fn normalize_targets(invocation_path: &str, targets: &[String]) -> Vec<String> {
+    let mut normalized_targets: Vec<String> = targets
+        .iter()
+        .filter_map(|target| normalize_target(invocation_path, target))
+        .collect();
+    normalized_targets.sort();
+    normalized_targets
+}
+
+fn normalize_target(invocation_path: &str, target: &str) -> Option<String> {
+    if looks_like_remote(target) {
+        return Some(target.to_string());
+    }
+
+    let base_path = Path::new(target);
+    let base_path = if base_path.is_absolute() {
+        base_path.to_path_buf()
+    } else {
+        Path::new(invocation_path).join(base_path)
+    };
+
+    match fs::canonicalize(&base_path) {
+        Ok(resolved) => Some(to_posix(&resolved)),
+        Err(_) => Some(to_posix(&lexically_clean(&base_path))),
+    }
+}
+
+fn lexically_clean(path: &Path) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                result.pop();
+            }
+            other => result.push(other.as_os_str()),
+        }
+    }
+    result
+}
+
+fn to_posix(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    if cfg!(windows) {
+        value.replace('\\', "/")
+    } else {
+        value.into_owned()
+    }
+}
+
+fn looks_like_remote(target: &str) -> bool {
+    const PREFIXES: [&str; 8] = [
+        "https://github.com",
+        "https://gitlab.com",
+        "http://github.com",
+        "http://gitlab.com",
+        "www.github.com",
+        "www.gitlab.com",
+        "git@github.com",
+        "git@gitlab.com",
+    ];
+    PREFIXES.iter().any(|prefix| target.starts_with(prefix))
+}
+
+fn collect_functions(files_complexities: &[FileComplexity]) -> Vec<Value> {
+    files_complexities
+        .iter()
+        .flat_map(|file_complexity| {
+            file_complexity.functions.iter().map(move |function| {
+                json!({
+                    "path": file_complexity.path.clone(),
+                    "file_name": file_complexity.file_name.clone(),
+                    "function_name": function.name.clone(),
+                    "complexity": function.complexity,
+                })
+            })
+        })
+        .collect()
+}
+
+fn cache_value_path(cache_dir: &Path, key: &str) -> PathBuf {
+    cache_dir.join(CACHE_VALUES_DIR).join(key)
+}
+
+fn load_cache_store(cache_file: &Path) -> Value {
+    match load_cache(cache_file) {
+        Some(raw)
+            if raw
+                .get("entries")
+                .is_some_and(|entries| entries.is_object()) =>
+        {
+            raw
+        }
+        _ => json!({ "entries": {} }),
+    }
+}
+
+fn migrate_legacy_cache_entry(cache_dir: &Path, cache_store: &mut Value, cache_key: &str) {
+    let Some(entries) = cache_store
+        .get_mut("entries")
+        .and_then(|entries| entries.as_object_mut())
+    else {
+        return;
+    };
+    if entries.contains_key(cache_key) {
+        return;
+    }
+
+    let legacy_cache_file = cache_dir.join(format!("{}.json", cache_key));
+    let Some(legacy_payload) = load_cache(&legacy_cache_file) else {
+        return;
+    };
+
+    let updated_at = fs::metadata(&legacy_cache_file)
+        .and_then(|metadata| metadata.modified())
+        .map(|modified| {
+            modified
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_secs_f64())
+                .unwrap_or(0.0)
+        })
+        .unwrap_or(0.0);
+
+    entries.insert(
+        cache_key.to_string(),
+        json!({
+            "targets": legacy_payload.get("targets").cloned().unwrap_or_else(|| json!([])),
+            "functions": legacy_payload.get("functions").cloned().unwrap_or_else(|| json!([])),
+            "updated_at": updated_at,
+        }),
+    );
+}
+
+fn load_previous_map_from_store(
+    cache_store: &Value,
+    cache_key: &str,
+) -> Option<HashMap<(String, String, String), u64>> {
+    let entry = cache_store.get("entries")?.get(cache_key)?;
+    if !entry.is_object() {
+        return None;
+    }
+    load_previous_map(entry)
+}
+
+fn load_previous_map(raw: &Value) -> Option<HashMap<(String, String, String), u64>> {
+    let functions = raw.get("functions")?;
+    if !functions.is_array() {
+        return None;
+    }
+
+    let mut mapping = HashMap::new();
+    for entry in functions.as_array()? {
+        if !entry.is_object() {
+            continue;
+        }
+        let key = build_function_key(
+            entry
+                .get("path")
+                .and_then(|value| value.as_str())
+                .unwrap_or(""),
+            entry
+                .get("file_name")
+                .and_then(|value| value.as_str())
+                .unwrap_or(""),
+            entry
+                .get("function_name")
+                .and_then(|value| value.as_str())
+                .unwrap_or(""),
+        );
+        let Some(key) = key else {
+            continue;
+        };
+        let complexity = entry.get("complexity");
+        if complexity.is_some_and(|value| value.is_boolean()) {
+            continue;
+        }
+        let Some(complexity) = complexity.and_then(python_int) else {
+            continue;
+        };
+        mapping.insert(key, complexity);
+    }
+
+    if mapping.is_empty() {
+        None
+    } else {
+        Some(mapping)
+    }
+}
+
+fn load_cache(cache_file: &Path) -> Option<Value> {
+    let content = fs::read_to_string(cache_file).ok()?;
+    let raw: Value = serde_json::from_str(&content).ok()?;
+    if !raw.is_object() {
+        return None;
+    }
+    Some(raw)
+}
+
+fn python_int(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(number) => {
+            if let Some(value) = number.as_u64() {
+                Some(value)
+            } else if let Some(value) = number.as_i64() {
+                u64::try_from(value).ok()
+            } else if let Some(value) = number.as_f64() {
+                if value >= 0.0 {
+                    Some(value.trunc() as u64)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
+        Value::String(text) => text.parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+fn build_function_key(
+    path: &str,
+    file_name: &str,
+    function_name: &str,
+) -> Option<(String, String, String)> {
+    if function_name.is_empty() {
+        return None;
+    }
+    Some((
+        path.to_string(),
+        file_name.to_string(),
+        function_name.to_string(),
+    ))
+}
+
+fn prune_cache_store(cache_store: &mut Value) {
+    let Some(entries) = cache_store
+        .get_mut("entries")
+        .and_then(|entries| entries.as_object_mut())
+    else {
+        return;
+    };
+    if entries.len() <= MAX_CACHE_ENTRIES {
+        return;
+    }
+
+    let taken = std::mem::take(entries);
+    let mut sorted_entries: Vec<(String, Value)> = taken.into_iter().collect();
+    sorted_entries.sort_by(|left, right| {
+        entry_updated_at(&right.1)
+            .partial_cmp(&entry_updated_at(&left.1))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    sorted_entries.truncate(MAX_CACHE_ENTRIES);
+    for (key, value) in sorted_entries {
+        entries.insert(key, value);
+    }
+}
+
+fn entry_updated_at(entry: &Value) -> f64 {
+    if !entry.is_object() {
+        return 0.0;
+    }
+    let Some(updated_at) = entry.get("updated_at") else {
+        return 0.0;
+    };
+    if updated_at.is_boolean() {
+        return 0.0;
+    }
+    if let Some(number) = updated_at.as_f64() {
+        return number;
+    }
+    if let Some(text) = updated_at.as_str() {
+        return text.parse::<f64>().unwrap_or(0.0);
+    }
+    0.0
+}
+
+fn persist_cache(cache_file: &Path, payload: &Value) -> bool {
+    let Some(parent) = cache_file.parent() else {
+        return false;
+    };
+    if fs::create_dir_all(parent).is_err() {
+        return false;
+    }
+    let Ok(serialized) = serde_json::to_string_pretty(payload) else {
+        return false;
+    };
+    fs::write(cache_file, serialized).is_ok()
+}
+
+fn remove_legacy_cache_files(cache_dir: &Path) {
+    let Ok(entries) = fs::read_dir(cache_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if is_legacy_cache_file_name(name) {
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+}
+
+fn is_legacy_cache_file_name(name: &str) -> bool {
+    name.len() == 37
+        && name.ends_with(".json")
+        && name[..32]
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+fn ensure_cache_dir_and_supporting_files(cache_dir: &Path) -> Option<()> {
+    fs::create_dir_all(cache_dir).ok()?;
+    write_support_file(&cache_dir.join(".gitignore"), "*\n");
+    write_support_file(&cache_dir.join("CACHEDIR.TAG"), CACHEDIR_TAG_CONTENT);
+    write_support_file(&cache_dir.join("README.md"), README_CONTENT);
+    Some(())
+}
+
+fn write_support_file(path: &Path, content: &str) {
+    if path.exists() {
+        return;
+    }
+    let _ = fs::write(path, content);
+}
+
+fn now_seconds() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/cache.rs"]
+mod tests;

--- a/src/tests/cli/cache.rs
+++ b/src/tests/cli/cache.rs
@@ -1,0 +1,451 @@
+//! Wired in from `src/cli/utils/cache.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::collections::HashMap;
+use std::fs;
+
+use serde_json::{Value, json};
+use tempfile::tempdir;
+
+use crate::classes::{FileComplexity, FunctionComplexity};
+use crate::cli::utils::cache::{
+    build_cache_key, hash_targets, is_legacy_cache_file_name, lexically_clean,
+    remember_previous_functions,
+};
+
+fn file_complexity(path: &str, file_name: &str, functions: &[(&str, u64)]) -> FileComplexity {
+    FileComplexity {
+        path: path.to_string(),
+        file_name: file_name.to_string(),
+        functions: functions
+            .iter()
+            .map(|(name, complexity)| FunctionComplexity {
+                name: name.to_string(),
+                complexity: *complexity,
+                line_start: 0,
+                line_end: 0,
+                line_complexities: vec![],
+                refactor_plans: vec![],
+                additional_refactor_plans: 0,
+            })
+            .collect(),
+        complexity: 0,
+    }
+}
+
+fn load_functions_file(cache_dir: &std::path::Path) -> Value {
+    let path = cache_dir.join("v/cache/functions");
+    let content = fs::read_to_string(&path).expect("functions file should exist");
+    serde_json::from_str(&content).expect("functions file should parse")
+}
+
+#[test]
+fn cache_key_matches_python_blake2b() {
+    assert_eq!(
+        hash_targets("src||tests"),
+        "c7f7a0c9374f38debd3947990e36306c"
+    );
+}
+
+#[test]
+fn legacy_file_name_pattern_matches_python() {
+    let key = "c7f7a0c9374f38debd3947990e36306c";
+    assert!(is_legacy_cache_file_name(&format!("{}.json", key)));
+    assert!(!is_legacy_cache_file_name("functions"));
+    assert!(!is_legacy_cache_file_name("notes.txt"));
+    assert!(!is_legacy_cache_file_name(&format!(
+        "{}.json",
+        "G7f7a0c9374f38debd3947990e36306c"
+    )));
+}
+
+#[test]
+fn lexical_clean_normalizes_dot_components() {
+    let base = std::path::Path::new("/proj");
+    let cleaned = lexically_clean(&base.join("src/../tests/./main.py"));
+    assert_eq!(cleaned, base.join("tests/main.py"));
+}
+
+#[test]
+fn first_run_creates_cache_directory_and_support_files() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+
+    let result = remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+
+    assert_eq!(result, None);
+    let cache_dir = inv.join(".complexipy_cache");
+    assert_eq!(
+        fs::read_to_string(cache_dir.join(".gitignore")).expect("gitignore"),
+        "*\n"
+    );
+    assert!(cache_dir.join("CACHEDIR.TAG").exists());
+    assert!(cache_dir.join("README.md").exists());
+
+    let store = load_functions_file(&cache_dir);
+    let entries = store
+        .get("entries")
+        .expect("entries")
+        .as_object()
+        .expect("object");
+    assert_eq!(entries.len(), 1);
+    let entry = entries.values().next().expect("entry");
+    assert_eq!(
+        entry.get("targets").expect("targets"),
+        &json!([inv.join("src").to_string_lossy()])
+    );
+    assert_eq!(
+        entry.get("functions").expect("functions"),
+        &json!([{
+            "path": "src/a.py",
+            "file_name": "a.py",
+            "function_name": "f",
+            "complexity": 5,
+        }])
+    );
+    assert!(entry.get("updated_at").expect("updated_at").is_number());
+}
+
+#[test]
+fn second_run_returns_previous_map() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    let files = [file_complexity("src/a.py", "a.py", &[("f", 5)])];
+
+    let first =
+        remember_previous_functions(inv.to_str().unwrap(), &["src".to_string()], &files, None);
+    assert_eq!(first, None);
+
+    let second =
+        remember_previous_functions(inv.to_str().unwrap(), &["src".to_string()], &files, None);
+    assert_eq!(
+        second,
+        Some(HashMap::from([(
+            ("src/a.py".to_string(), "a.py".to_string(), "f".to_string()),
+            5
+        )]))
+    );
+}
+
+#[test]
+fn gitignore_is_not_recreated_if_exists() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    let cache_dir = inv.join(".complexipy_cache");
+    fs::create_dir_all(&cache_dir).expect("should create");
+    fs::write(cache_dir.join(".gitignore"), "custom\n").expect("should write");
+
+    remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+
+    assert_eq!(
+        fs::read_to_string(cache_dir.join(".gitignore")).expect("gitignore"),
+        "custom\n"
+    );
+}
+
+#[test]
+fn target_sets_share_single_functions_file() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+
+    remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+    remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["tests".to_string(), "src".to_string()],
+        &[file_complexity("tests/t.py", "t.py", &[("g", 3)])],
+        None,
+    );
+
+    let cache_dir = inv.join(".complexipy_cache");
+    let store = load_functions_file(&cache_dir);
+    let entries = store
+        .get("entries")
+        .expect("entries")
+        .as_object()
+        .expect("object");
+    assert_eq!(entries.len(), 2);
+}
+
+#[test]
+fn legacy_hash_file_is_migrated_and_removed() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    let cache_dir = inv.join(".complexipy_cache");
+    fs::create_dir_all(&cache_dir).expect("should create");
+
+    let targets = vec!["src".to_string()];
+    let key = build_cache_key(inv.to_str().unwrap(), &targets).expect("key");
+    let legacy_payload = json!({
+        "targets": [inv.join("src").to_string_lossy()],
+        "functions": [{
+            "path": "src/legacy.py",
+            "file_name": "legacy.py",
+            "function_name": "old",
+            "complexity": 9,
+        }],
+    });
+    fs::write(
+        cache_dir.join(format!("{}.json", key)),
+        serde_json::to_string_pretty(&legacy_payload).expect("serialize"),
+    )
+    .expect("should write");
+
+    let result = remember_previous_functions(
+        inv.to_str().unwrap(),
+        &targets,
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+
+    assert_eq!(
+        result,
+        Some(HashMap::from([(
+            (
+                "src/legacy.py".to_string(),
+                "legacy.py".to_string(),
+                "old".to_string()
+            ),
+            9
+        )]))
+    );
+    assert!(!cache_dir.join(format!("{}.json", key)).exists());
+
+    let store = load_functions_file(&cache_dir);
+    let entries = store
+        .get("entries")
+        .expect("entries")
+        .as_object()
+        .expect("object");
+    let entry = entries.get(&key).expect("entry");
+    assert_eq!(
+        entry.get("functions").expect("functions"),
+        &json!([{
+            "path": "src/a.py",
+            "file_name": "a.py",
+            "function_name": "f",
+            "complexity": 5,
+        }])
+    );
+}
+
+#[test]
+fn legacy_migration_skipped_for_custom_cache_dir() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    let custom_dir = dir.path().join("custom");
+    fs::create_dir_all(&custom_dir).expect("should create");
+
+    let key = build_cache_key(inv.to_str().unwrap(), &["src".to_string()]).expect("key");
+    let legacy_file = custom_dir.join(format!("{}.json", key));
+    fs::write(&legacy_file, "{}").expect("should write");
+
+    let result = remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        Some(custom_dir.to_str().unwrap()),
+    );
+
+    assert_eq!(result, None);
+    assert!(legacy_file.exists());
+    let store = load_functions_file(&custom_dir);
+    let entries = store
+        .get("entries")
+        .expect("entries")
+        .as_object()
+        .expect("object");
+    assert_eq!(entries.len(), 1);
+    let entry = entries.values().next().expect("entry");
+    assert_eq!(
+        entry.get("functions").expect("functions"),
+        &json!([{
+            "path": "src/a.py",
+            "file_name": "a.py",
+            "function_name": "f",
+            "complexity": 5,
+        }])
+    );
+}
+
+#[test]
+fn custom_cache_dir_honored_when_none_provided() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    let default_dir = inv.join(".complexipy_cache");
+
+    remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+
+    assert!(default_dir.join("v/cache/functions").exists());
+    assert!(!dir.path().join("custom").exists());
+}
+
+#[test]
+fn nested_custom_cache_dir_created() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    let nested = dir.path().join("a").join("b").join("c");
+
+    let result = remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        Some(nested.to_str().unwrap()),
+    );
+
+    assert_eq!(result, None);
+    assert!(nested.join("v/cache/functions").exists());
+}
+
+#[test]
+fn cache_prunes_old_target_set_entries() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    let cache_dir = inv.join(".complexipy_cache");
+    let values_dir = cache_dir.join("v/cache");
+    fs::create_dir_all(&values_dir).expect("should create");
+
+    let mut entries = serde_json::Map::new();
+    for i in 0..65u64 {
+        entries.insert(
+            format!("key-{:02}", i),
+            json!({ "targets": [], "functions": [], "updated_at": i as f64 }),
+        );
+    }
+    let store = json!({ "entries": entries });
+    fs::write(
+        values_dir.join("functions"),
+        serde_json::to_string_pretty(&store).expect("serialize"),
+    )
+    .expect("should write");
+
+    remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+
+    let stored = load_functions_file(&cache_dir);
+    let entries = stored
+        .get("entries")
+        .expect("entries")
+        .as_object()
+        .expect("object");
+    assert_eq!(entries.len(), 64);
+    assert!(!entries.contains_key("key-00"));
+    assert!(!entries.contains_key("key-01"));
+    assert!(entries.contains_key("key-63"));
+}
+
+#[test]
+fn filesystem_failure_returns_none() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    fs::write(inv.join(".complexipy_cache"), "blocking").expect("should write");
+
+    let result = remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+
+    assert_eq!(result, None);
+}
+
+#[test]
+fn empty_targets_produce_no_cache_key() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+
+    let result = remember_previous_functions(
+        inv.to_str().unwrap(),
+        &[],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+
+    assert_eq!(result, None);
+    assert!(!inv.join(".complexipy_cache").exists());
+}
+
+#[test]
+fn malformed_entries_are_skipped() {
+    let dir = tempdir().expect("tempdir should work");
+    let inv = dir.path().join("proj");
+    fs::create_dir(&inv).expect("should create");
+    let cache_dir = inv.join(".complexipy_cache");
+    let values_dir = cache_dir.join("v/cache");
+    fs::create_dir_all(&values_dir).expect("should create");
+
+    let key = build_cache_key(inv.to_str().unwrap(), &["src".to_string()]).expect("key");
+    let store = json!({
+        "entries": {
+            key: {
+                "targets": [],
+                "functions": [
+                    42,
+                    { "path": "x.py", "file_name": "x.py", "function_name": "", "complexity": 3 },
+                    { "path": "x.py", "file_name": "x.py", "function_name": "b", "complexity": true },
+                    { "path": "x.py", "file_name": "x.py", "function_name": "c", "complexity": "abc" },
+                    { "path": "x.py", "file_name": "x.py", "function_name": "d", "complexity": "7" },
+                    { "path": "x.py", "file_name": "x.py", "function_name": "e", "complexity": 11 },
+                ],
+                "updated_at": 1.0,
+            }
+        }
+    });
+    fs::write(
+        values_dir.join("functions"),
+        serde_json::to_string_pretty(&store).expect("serialize"),
+    )
+    .expect("should write");
+
+    let result = remember_previous_functions(
+        inv.to_str().unwrap(),
+        &["src".to_string()],
+        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
+        None,
+    );
+
+    assert_eq!(
+        result,
+        Some(HashMap::from([
+            (("x.py".to_string(), "x.py".to_string(), "d".to_string()), 7),
+            (
+                ("x.py".to_string(), "x.py".to_string(), "e".to_string()),
+                11
+            ),
+        ]))
+    );
+}


### PR DESCRIPTION
## What

Ports `utils/cache.py` — previous-run caching for complexity delta reporting — to Rust, as step 5 of the CLI migration in issue #224.

## Why

Each migration step merges to main directly once validated. The cache module is the data source for delta reporting; its first Rust consumer lands with Step 13 (output). The port must stay byte-compatible with existing cache files, which is why hashing and storage semantics mirror Python exactly.

## Changes

- `feat(cargo)` — add `blake2` optional dependency (RFC 7693, byte-identical to Python's `hashlib.blake2b(digest_size=16)`)
- `src/cli/utils/cache.rs` — `remember_previous_functions` + 19 helpers:
  - `serde_json::Value` store (user-confirmed design), tolerant loading, BTreeMap sorted keys on persist (matches `sort_keys=True`)
  - blake2b-16 hex cache key, verified against a Python-computed vector
  - target normalization with `canonicalize` + lexical `.`/`..` fallback (Python `resolve()` parity)
  - `int()` coercion for stored complexities (numeric strings, float truncation); negatives skipped
  - legacy `{key}.json` migration + removal (default location only)
  - pruning to 64 entries by `updated_at`
  - support files (.gitignore, CACHEDIR.TAG, README.md), fs failures never propagate
- `src/tests/cli/cache.rs` — 15 tests mirroring the 10 `test_cache.py` contracts plus blake2b vector, lexical-clean, and legacy-pattern tests

Issue: #224