### PR TITLE
feat(cli): extract shared export writers (steps 6-7)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde", "dep:blake2"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv"]
 python = [
     "serde",
     "pyo3",

--- a/src/tests/export.rs
+++ b/src/tests/export.rs
@@ -1,0 +1,287 @@
+//! Wired in from `src/utils.rs` via `#[cfg(test)] #[path = ...] mod export_tests;`
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use crate::classes::{
+    Applicability, CodeSuggestion, FileComplexity, FunctionComplexity, RefactorPlan, RuleCategory,
+};
+use crate::utils::{ExportError, output_csv_shared, output_json_shared};
+
+fn function_complexity(name: &str, complexity: u64) -> FunctionComplexity {
+    FunctionComplexity {
+        name: name.to_string(),
+        complexity,
+        line_start: 0,
+        line_end: 0,
+        line_complexities: vec![],
+        refactor_plans: vec![],
+        additional_refactor_plans: 0,
+    }
+}
+
+fn file_complexity(
+    path: &str,
+    file_name: &str,
+    functions: Vec<FunctionComplexity>,
+) -> FileComplexity {
+    FileComplexity {
+        path: path.to_string(),
+        file_name: file_name.to_string(),
+        functions,
+        complexity: 0,
+    }
+}
+
+fn refactor_plan() -> RefactorPlan {
+    RefactorPlan {
+        kind: "test".to_string(),
+        title: "Extract method".to_string(),
+        line_start: 1,
+        line_end: 5,
+        column_start: 0,
+        current_complexity: 5,
+        estimated_reduction: 2,
+        estimated_complexity_after: 3,
+        reduction_is_measured: true,
+        rule_id: "C001".to_string(),
+        category: RuleCategory::Complexity,
+        applicability: Applicability::MachineApplicable,
+        description: "test plan".to_string(),
+        explanation: "".to_string(),
+        references: vec![],
+        suggestion: None::<CodeSuggestion>,
+        help: None,
+        doc_url: "".to_string(),
+    }
+}
+
+#[test]
+fn csv_writes_header_and_rows() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.csv");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 5)],
+    )];
+
+    output_csv_shared(output.to_str().unwrap(), files, "asc", true, 0).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    assert_eq!(
+        content,
+        "Path,File Name,Function Name,Cognitive Complexity\nsrc/a.py,a.py,f,5\n"
+    );
+}
+
+#[test]
+fn csv_asc_sorts_by_complexity_keeping_ties() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.csv");
+    let files = vec![
+        file_complexity("src/b.py", "b.py", vec![function_complexity("high", 9)]),
+        file_complexity(
+            "src/a.py",
+            "a.py",
+            vec![
+                function_complexity("low", 1),
+                function_complexity("tie1", 5),
+                function_complexity("tie2", 5),
+            ],
+        ),
+    ];
+
+    output_csv_shared(output.to_str().unwrap(), files, "asc", true, 0).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    let rows: Vec<&str> = content.lines().skip(1).collect();
+    assert_eq!(rows[0], "src/a.py,a.py,low,1");
+    assert_eq!(rows[1], "src/a.py,a.py,tie1,5");
+    assert_eq!(rows[2], "src/a.py,a.py,tie2,5");
+    assert_eq!(rows[3], "src/b.py,b.py,high,9");
+}
+
+#[test]
+fn csv_desc_reverses_complexity_order() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.csv");
+    let files = vec![
+        file_complexity("src/a.py", "a.py", vec![function_complexity("low", 1)]),
+        file_complexity("src/b.py", "b.py", vec![function_complexity("high", 9)]),
+    ];
+
+    output_csv_shared(output.to_str().unwrap(), files, "desc", true, 0).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    let rows: Vec<&str> = content.lines().skip(1).collect();
+    assert_eq!(rows[0], "src/b.py,b.py,high,9");
+    assert_eq!(rows[1], "src/a.py,a.py,low,1");
+}
+
+#[test]
+fn csv_file_name_sorts_by_path_keeping_function_order() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.csv");
+    let files = vec![
+        file_complexity(
+            "src/z.py",
+            "z.py",
+            vec![
+                function_complexity("first", 9),
+                function_complexity("second", 1),
+            ],
+        ),
+        file_complexity("src/a.py", "a.py", vec![function_complexity("only", 5)]),
+    ];
+
+    output_csv_shared(output.to_str().unwrap(), files, "file_name", true, 0).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    let rows: Vec<&str> = content.lines().skip(1).collect();
+    assert_eq!(rows[0], "src/a.py,a.py,only,5");
+    assert_eq!(rows[1], "src/z.py,z.py,first,9");
+    assert_eq!(rows[2], "src/z.py,z.py,second,1");
+}
+
+#[test]
+fn csv_name_spelling_sorts_by_path() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.csv");
+    let files = vec![
+        file_complexity("src/b.py", "b.py", vec![function_complexity("f", 5)]),
+        file_complexity("src/a.py", "a.py", vec![function_complexity("g", 5)]),
+    ];
+
+    output_csv_shared(output.to_str().unwrap(), files, "name", true, 0).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    let rows: Vec<&str> = content.lines().skip(1).collect();
+    assert_eq!(rows[0], "src/a.py,a.py,g,5");
+    assert_eq!(rows[1], "src/b.py,b.py,f,5");
+}
+
+#[test]
+fn csv_filters_below_threshold_when_not_detailed() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.csv");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![
+            function_complexity("below", 3),
+            function_complexity("at", 5),
+            function_complexity("above", 7),
+        ],
+    )];
+
+    output_csv_shared(output.to_str().unwrap(), files, "asc", false, 5).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    let rows: Vec<&str> = content.lines().skip(1).collect();
+    assert_eq!(rows, vec!["src/a.py,a.py,above,7"]);
+}
+
+#[test]
+fn csv_invalid_sort_rejected() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.csv");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 5)],
+    )];
+
+    let result = output_csv_shared(output.to_str().unwrap(), files, "bogus", true, 0);
+
+    assert_eq!(result, Err(ExportError::InvalidSort("bogus".to_string())));
+    assert!(!output.exists());
+}
+
+#[test]
+fn csv_write_failure_is_io_error() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = output_csv_shared(dir.path().to_str().unwrap(), vec![], "asc", true, 0);
+
+    assert!(matches!(result, Err(ExportError::Io(_))));
+}
+
+#[test]
+fn json_writes_entries_with_trailing_newline() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 5)],
+    )];
+
+    output_json_shared(output.to_str().unwrap(), files, true, 0, false).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    assert!(content.ends_with('\n'));
+    let parsed: serde_json::Value = serde_json::from_str(&content).expect("should parse");
+    assert_eq!(parsed.as_array().expect("array").len(), 1);
+    let entry = &parsed[0];
+    assert_eq!(entry["path"], "src/a.py");
+    assert_eq!(entry["file_name"], "a.py");
+    assert_eq!(entry["function_name"], "f");
+    assert_eq!(entry["complexity"], 5);
+    assert_eq!(entry["refactor_plans"], serde_json::json!([]));
+}
+
+#[test]
+fn json_includes_refactor_plans_when_requested() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![FunctionComplexity {
+            refactor_plans: vec![refactor_plan()],
+            ..function_complexity("f", 5)
+        }],
+    )];
+
+    output_json_shared(output.to_str().unwrap(), files, true, 0, true).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    let parsed: serde_json::Value = serde_json::from_str(&content).expect("should parse");
+    assert_eq!(
+        parsed[0]["refactor_plans"].as_array().expect("array").len(),
+        1
+    );
+    assert_eq!(parsed[0]["refactor_plans"][0]["title"], "Extract method");
+}
+
+#[test]
+fn json_filters_below_threshold_when_not_detailed() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![
+            function_complexity("below", 3),
+            function_complexity("above", 7),
+        ],
+    )];
+
+    output_json_shared(output.to_str().unwrap(), files, false, 5, false).expect("should write");
+
+    let content = fs::read_to_string(&output).expect("should read");
+    let parsed: serde_json::Value = serde_json::from_str(&content).expect("should parse");
+    assert_eq!(parsed.as_array().expect("array").len(), 1);
+    assert_eq!(parsed[0]["function_name"], "above");
+}
+
+#[test]
+fn json_write_failure_is_io_error() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = output_json_shared(dir.path().to_str().unwrap(), vec![], true, 0, false);
+
+    assert!(matches!(result, Err(ExportError::Io(_))));
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,31 +5,67 @@ use ruff_python_ast::{self as ast, Stmt};
 #[cfg(any(feature = "python", feature = "wasm"))]
 use std::sync::OnceLock;
 
+#[cfg(any(feature = "python", feature = "cli"))]
+mod export_deps {
+    pub use crate::classes::FileComplexity;
+    pub use csv::Writer;
+    pub use serde_json;
+    pub use std::fs::File;
+    pub use std::io::Write;
+}
+
 #[cfg(feature = "python")]
 mod python_deps {
-    pub use crate::classes::{FileComplexity, FunctionComplexity};
-    pub use csv::Writer;
+    pub use super::export_deps::*;
+    pub use crate::classes::FunctionComplexity;
     pub use pyo3::exceptions::{PyIOError, PyValueError};
     pub use pyo3::prelude::*;
-    pub use serde_json;
-    pub use std::fs::{File, read_to_string};
-    pub use std::io::Write;
+    pub use std::fs::read_to_string;
 }
 
 #[cfg(feature = "python")]
 use python_deps::*;
 
-#[cfg(feature = "python")]
-#[pyfunction]
-pub fn output_csv(
+#[cfg(any(feature = "python", feature = "cli"))]
+use std::fmt;
+
+#[cfg(any(feature = "python", feature = "cli"))]
+#[derive(Debug, PartialEq)]
+pub enum ExportError {
+    Io(String),
+    Serialize(String),
+    InvalidSort(String),
+}
+
+#[cfg(any(feature = "python", feature = "cli"))]
+impl fmt::Display for ExportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(message) => write!(f, "{}", message),
+            Self::Serialize(message) => write!(f, "{}", message),
+            Self::InvalidSort(message) => write!(f, "Invalid sort value: {}", message),
+        }
+    }
+}
+
+#[cfg(any(feature = "python", feature = "cli"))]
+impl std::error::Error for ExportError {}
+
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn output_csv_shared(
     invocation_path: &str,
     functions_complexity: Vec<FileComplexity>,
     sort: &str,
     show_detailed_results: bool,
-    max_complexity: i32,
-) -> PyResult<()> {
+    max_complexity: u64,
+) -> Result<(), ExportError> {
+    match sort {
+        "asc" | "desc" | "name" | "file_name" => {}
+        other => return Err(ExportError::InvalidSort(other.to_string())),
+    }
+
     let mut writer = Writer::from_path(invocation_path).map_err(|e| {
-        PyIOError::new_err(format!(
+        ExportError::Io(format!(
             "Failed to create CSV at {}: {}",
             invocation_path, e
         ))
@@ -38,81 +74,64 @@ pub fn output_csv(
     writer
         .write_record(["Path", "File Name", "Function Name", "Cognitive Complexity"])
         .map_err(|e| {
-            PyIOError::new_err(format!(
+            ExportError::Io(format!(
                 "Failed to write CSV header at {}: {}",
                 invocation_path, e
             ))
         })?;
 
-    let max_complexity_limit = u64::try_from(max_complexity)
-        .map_err(|_| PyValueError::new_err("max_complexity must be non-negative"))?;
-
-    if sort != "name" {
-        let mut all_functions: Vec<(String, String, FunctionComplexity)> = vec![];
-
-        for file in functions_complexity {
-            for function in file.functions {
-                if show_detailed_results || function.complexity > max_complexity_limit {
-                    all_functions.push((file.path.clone(), file.file_name.clone(), function));
-                }
-            }
-        }
-
-        all_functions.sort_by_key(|f| f.2.complexity);
-
-        if sort == "desc" {
-            all_functions.reverse();
-        }
-
-        for (path, file_name, function) in all_functions.into_iter() {
-            writer
-                .write_record([
-                    &path,
-                    &file_name,
-                    &function.name,
-                    &function.complexity.to_string(),
-                ])
-                .map_err(|e| PyIOError::new_err(format!("Failed to write CSV row: {}", e)))?;
-        }
-    } else {
-        for file in functions_complexity {
-            for function in file.functions {
-                writer
-                    .write_record([
-                        &file.path,
-                        &file.file_name,
-                        &function.name,
-                        &function.complexity.to_string(),
-                    ])
-                    .map_err(|e| PyIOError::new_err(format!("Failed to write CSV row: {}", e)))?;
+    let mut all_functions: Vec<(String, String, FunctionComplexity)> = vec![];
+    for file in functions_complexity {
+        for function in file.functions {
+            if show_detailed_results || function.complexity > max_complexity {
+                all_functions.push((file.path.clone(), file.file_name.clone(), function));
             }
         }
     }
 
+    match sort {
+        "desc" => {
+            all_functions.sort_by_key(|f| f.2.complexity);
+            all_functions.reverse();
+        }
+        "asc" => all_functions.sort_by_key(|f| f.2.complexity),
+        "name" | "file_name" => {
+            all_functions.sort_by(|left, right| left.0.cmp(&right.0).then(left.1.cmp(&right.1)))
+        }
+        other => return Err(ExportError::InvalidSort(other.to_string())),
+    }
+
+    for (path, file_name, function) in all_functions {
+        writer
+            .write_record([
+                &path,
+                &file_name,
+                &function.name,
+                &function.complexity.to_string(),
+            ])
+            .map_err(|e| ExportError::Io(format!("Failed to write CSV row: {}", e)))?;
+    }
+
     writer
         .flush()
-        .map_err(|e| PyIOError::new_err(format!("Failed to flush CSV to disk: {}", e)))?;
+        .map_err(|e| ExportError::Io(format!("Failed to flush CSV to disk: {}", e)))?;
 
     Ok(())
 }
 
-#[cfg(feature = "python")]
-#[pyfunction]
-#[pyo3(signature = (invocation_path, functions_complexity, show_detailed_results, max_complexity, suggest_refactors=false))]
-pub fn output_json(
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn output_json_shared(
     invocation_path: &str,
     functions_complexity: Vec<FileComplexity>,
     show_detailed_results: bool,
-    max_complexity: i32,
+    max_complexity: u64,
     suggest_refactors: bool,
-) -> PyResult<()> {
+) -> Result<(), ExportError> {
     let mut json_data = Vec::new();
-    let max_complexity_limit = u64::try_from(max_complexity)
-        .map_err(|_| PyValueError::new_err("max_complexity must be non-negative"))?;
 
     for file in functions_complexity {
         for function in file.functions {
-            if show_detailed_results || function.complexity > max_complexity_limit {
+            if show_detailed_results || function.complexity > max_complexity {
                 let refactor_plans = if suggest_refactors {
                     function.refactor_plans
                 } else {
@@ -131,27 +150,79 @@ pub fn output_json(
     }
 
     let json_string = serde_json::to_string_pretty(&json_data)
-        .map_err(|e| PyValueError::new_err(format!("Failed to serialize JSON: {}", e)))?;
+        .map_err(|e| ExportError::Serialize(format!("Failed to serialize JSON: {}", e)))?;
     let mut file = File::create(invocation_path).map_err(|e| {
-        PyIOError::new_err(format!(
+        ExportError::Io(format!(
             "Failed to create JSON file at {}: {}",
             invocation_path, e
         ))
     })?;
     file.write_all(json_string.as_bytes()).map_err(|e| {
-        PyIOError::new_err(format!(
+        ExportError::Io(format!(
             "Failed to write JSON to {}: {}",
             invocation_path, e
         ))
     })?;
     file.write_all(b"\n").map_err(|e| {
-        PyIOError::new_err(format!(
+        ExportError::Io(format!(
             "Failed to write JSON to {}: {}",
             invocation_path, e
         ))
     })?;
 
     Ok(())
+}
+
+#[cfg(feature = "python")]
+fn export_error_to_py_error(error: ExportError) -> PyErr {
+    match error {
+        ExportError::Io(message) => PyIOError::new_err(message),
+        ExportError::Serialize(message) => PyValueError::new_err(message),
+        ExportError::InvalidSort(message) => PyValueError::new_err(message),
+    }
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+pub fn output_csv(
+    invocation_path: &str,
+    functions_complexity: Vec<FileComplexity>,
+    sort: &str,
+    show_detailed_results: bool,
+    max_complexity: i32,
+) -> PyResult<()> {
+    let max_complexity = u64::try_from(max_complexity)
+        .map_err(|_| PyValueError::new_err("max_complexity must be non-negative"))?;
+    output_csv_shared(
+        invocation_path,
+        functions_complexity,
+        sort,
+        show_detailed_results,
+        max_complexity,
+    )
+    .map_err(export_error_to_py_error)
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (invocation_path, functions_complexity, show_detailed_results, max_complexity, suggest_refactors=false))]
+pub fn output_json(
+    invocation_path: &str,
+    functions_complexity: Vec<FileComplexity>,
+    show_detailed_results: bool,
+    max_complexity: i32,
+    suggest_refactors: bool,
+) -> PyResult<()> {
+    let max_complexity = u64::try_from(max_complexity)
+        .map_err(|_| PyValueError::new_err("max_complexity must be non-negative"))?;
+    output_json_shared(
+        invocation_path,
+        functions_complexity,
+        show_detailed_results,
+        max_complexity,
+        suggest_refactors,
+    )
+    .map_err(export_error_to_py_error)
 }
 
 #[cfg(feature = "python")]
@@ -588,3 +659,7 @@ pub fn filter_removable_ignores(
 #[cfg(test)]
 #[path = "tests/removable.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "tests/export.rs"]
+mod export_tests;


### PR DESCRIPTION
## What

Extracts the CSV and JSON export writers from their PyO3-bound pyfunctions into shared plain-Rust functions, as steps 6–7 of the CLI migration in issue #224.

## Why

Both Python modules (`utils/csv.py`, `utils/json.py`) are 21-line passthrough wrappers over the existing Rust writers — "no port needed" per the issue. But the writers were `#[pyfunction]`s returning `PyResult`, so the future Rust CLI could not call them. This change makes them callable from both the extension and the CLI, and fixes a latent sort quirk found during exploration.

## Changes

- `src/utils.rs`:
  - `export_deps` module gated `any(python, cli)`; `python_deps` keeps pyo3 and re-exports it
  - `ExportError { Io, Serialize, InvalidSort }` with `Display`
  - `output_csv_shared` / `output_json_shared` — plain `Result<(), ExportError>`, `max_complexity` as `u64`
  - pyfunctions are thin wrappers (`i32 → u64` validation, error mapping to `PyIOError`/`PyValueError`); signatures unchanged — `test_refactor_plans.py` still passes
- **Sort fix** (accepted via clarification UI): `asc`/`desc` sort by complexity; `name`/`file_name` sort by `(path, file_name)` stable; invalid values rejected before any file is created. Previously `--sort file_name` silently exported complexity-asc (the Rust check `sort != "name"` never matched Python's enum values) and the dead `"name"` branch skipped the complexity filter
- `feat(cargo)` — `csv` added to the `cli` feature (wasm stays clean)
- `src/tests/export.rs` — 12 tests: header, all three sorts, tie stability, filtering, threshold, JSON shape, refactor_plans, trailing newline, invalid sort, write failures

Issue: #224