### PR TITLE
feat(cli): port sarif and gitlab reports to rust (steps 8-9)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "sha2",
  "tempfile",
  "toml",
  "wasm-bindgen",
@@ -287,6 +288,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1124,6 +1134,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2"]
 python = [
     "serde",
     "pyo3",
@@ -74,6 +74,7 @@ wax = "0.7.0"
 toml = { version = "1.1.4", optional = true }
 clap = { version = "4.6.6", features = ["derive"], optional = true }
 blake2 = { version = "0.10", optional = true }
+sha2 = { version = "0.10", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,4 +1,6 @@
 pub mod cache;
 pub mod config;
+pub mod gitlab;
 pub mod paths;
+pub mod sarif;
 pub mod toml;

--- a/src/cli/utils/gitlab.rs
+++ b/src/cli/utils/gitlab.rs
@@ -1,0 +1,125 @@
+use std::fs;
+
+use serde_json::{Value, json};
+
+use sha2::{Digest, Sha256};
+
+use crate::classes::{Applicability, FileComplexity, RefactorPlan};
+use crate::cli::utils::paths::normalize_path;
+use crate::utils::ExportError;
+
+const CHECK_NAME: &str = "complexipy/cognitive-complexity";
+const DEFAULT_SEVERITY: &str = "minor";
+
+pub fn store_gitlab(
+    output_path: &str,
+    files: &[FileComplexity],
+    max_complexity: u64,
+    suggest_refactors: bool,
+) -> Result<(), ExportError> {
+    let mut report = Vec::new();
+
+    for file in files {
+        let normalized_path = normalize_path(&file.path, &file.file_name);
+        let relative_path = normalized_path
+            .strip_prefix("./")
+            .unwrap_or(&normalized_path);
+
+        for function in &file.functions {
+            if function.complexity > max_complexity {
+                report.push(json!({
+                    "description": build_description(
+                        &function.name,
+                        function.complexity,
+                        max_complexity,
+                    ),
+                    "check_name": CHECK_NAME,
+                    "fingerprint": build_fingerprint(
+                        "CC001",
+                        relative_path,
+                        &function.name,
+                        function.line_start,
+                    ),
+                    "severity": DEFAULT_SEVERITY,
+                    "location": {
+                        "path": relative_path,
+                        "lines": {"begin": function.line_start},
+                    },
+                }));
+            }
+
+            if suggest_refactors {
+                for plan in &function.refactor_plans {
+                    report.push(refactor_plan_issue(relative_path, &function.name, plan));
+                }
+            }
+        }
+    }
+
+    let serialized = serde_json::to_string_pretty(&report)
+        .map_err(|e| ExportError::Serialize(format!("Failed to serialize GitLab report: {}", e)))?;
+    let mut file = fs::File::create(output_path).map_err(|e| {
+        ExportError::Io(format!(
+            "Failed to create GitLab report at {}: {}",
+            output_path, e
+        ))
+    })?;
+    use std::io::Write;
+    file.write_all(serialized.as_bytes()).map_err(|e| {
+        ExportError::Io(format!(
+            "Failed to write GitLab report to {}: {}",
+            output_path, e
+        ))
+    })?;
+    file.write_all(b"\n").map_err(|e| {
+        ExportError::Io(format!(
+            "Failed to write GitLab report to {}: {}",
+            output_path, e
+        ))
+    })?;
+
+    Ok(())
+}
+
+fn build_description(function_name: &str, complexity: u64, max_complexity: u64) -> String {
+    format!(
+        "Function '{}' has cognitive complexity {} (max allowed: {}).",
+        function_name, complexity, max_complexity
+    )
+}
+
+fn build_fingerprint(check_id: &str, path: &str, function_name: &str, line_start: u64) -> String {
+    let payload = format!("{}:{}:{}:{}", check_id, path, function_name, line_start);
+    let digest = Sha256::digest(payload.as_bytes());
+    digest.iter().map(|byte| format!("{:02x}", byte)).collect()
+}
+
+fn refactor_plan_severity(applicability: &Applicability) -> &'static str {
+    match applicability {
+        Applicability::MachineApplicable => "minor",
+        Applicability::MaybeIncorrect => "major",
+        Applicability::Informational => "info",
+    }
+}
+
+fn refactor_plan_issue(relative_path: &str, function_name: &str, plan: &RefactorPlan) -> Value {
+    json!({
+        "description": format!("[{}] {}: {}", plan.rule_id, plan.title, plan.explanation),
+        "check_name": format!("complexipy/{}", plan.rule_id.to_lowercase()),
+        "fingerprint": build_fingerprint(
+            &plan.rule_id,
+            relative_path,
+            function_name,
+            plan.line_start,
+        ),
+        "severity": refactor_plan_severity(&plan.applicability),
+        "location": {
+            "path": relative_path,
+            "lines": {"begin": plan.line_start, "end": plan.line_end},
+        },
+    })
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/gitlab.rs"]
+mod tests;

--- a/src/cli/utils/paths.rs
+++ b/src/cli/utils/paths.rs
@@ -100,6 +100,17 @@ pub fn is_directory_output_hint(output: &str) -> bool {
     output.ends_with('/') || (cfg!(windows) && output.ends_with('\\'))
 }
 
+pub fn normalize_path(path: &str, file_name: &str) -> String {
+    let cleaned = path.trim_end_matches('/');
+    if cleaned.ends_with(file_name) {
+        cleaned.to_string()
+    } else if !cleaned.is_empty() {
+        format!("{}/{}", cleaned, file_name)
+    } else {
+        file_name.to_string()
+    }
+}
+
 pub fn ensure_directory_destination(
     destination: &Path,
     is_directory_hint: bool,

--- a/src/cli/utils/sarif.rs
+++ b/src/cli/utils/sarif.rs
@@ -1,0 +1,188 @@
+use std::fs;
+
+use serde_json::{Map, Value, json};
+
+use crate::classes::{
+    Applicability, FileComplexity, FunctionComplexity, RefactorPlan, RuleCategory,
+};
+use crate::utils::ExportError;
+
+const RULE_ID: &str = "CC001";
+const SCHEMA: &str = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
+const INFO_URI: &str = "https://rohaquinlop.github.io/complexipy/";
+const HELP_URI: &str = "https://rohaquinlop.github.io/complexipy/understanding-scores/";
+
+pub fn store_sarif(
+    output_path: &str,
+    files: &[FileComplexity],
+    max_complexity: u64,
+    suggest_refactors: bool,
+) -> Result<(), ExportError> {
+    let (results, refactor_rule_definitions) =
+        collect_results(files, max_complexity, suggest_refactors);
+
+    let mut rules = vec![complexity_rule_definition()];
+    rules.extend(refactor_rule_definitions.values().cloned());
+
+    let sarif_doc = json!({
+        "version": "2.1.0",
+        "$schema": SCHEMA,
+        "runs": [{
+            "tool": {
+                "driver": {
+                    "name": "complexipy",
+                    "version": env!("CARGO_PKG_VERSION"),
+                    "informationUri": INFO_URI,
+                    "rules": rules,
+                }
+            },
+            "results": results,
+        }],
+    });
+
+    let serialized = serde_json::to_string_pretty(&sarif_doc)
+        .map_err(|e| ExportError::Serialize(format!("Failed to serialize SARIF: {}", e)))?;
+    fs::write(output_path, serialized)
+        .map_err(|e| ExportError::Io(format!("Failed to write SARIF to {}: {}", output_path, e)))?;
+    Ok(())
+}
+
+fn collect_results(
+    files: &[FileComplexity],
+    max_complexity: u64,
+    suggest_refactors: bool,
+) -> (Vec<Value>, Map<String, Value>) {
+    let mut results = Vec::new();
+    let mut refactor_rule_definitions = Map::new();
+
+    for file in files {
+        for function in &file.functions {
+            if function.complexity > max_complexity {
+                results.push(complexity_result(file, function, max_complexity));
+            }
+            if suggest_refactors {
+                add_refactor_plan_results(
+                    file,
+                    function,
+                    &mut results,
+                    &mut refactor_rule_definitions,
+                );
+            }
+        }
+    }
+
+    (results, refactor_rule_definitions)
+}
+
+fn add_refactor_plan_results(
+    file: &FileComplexity,
+    function: &FunctionComplexity,
+    results: &mut Vec<Value>,
+    refactor_rule_definitions: &mut Map<String, Value>,
+) {
+    for plan in &function.refactor_plans {
+        if !refactor_rule_definitions.contains_key(&plan.rule_id) {
+            refactor_rule_definitions
+                .insert(plan.rule_id.clone(), refactor_plan_rule_definition(plan));
+        }
+        results.push(refactor_plan_result(file, function, plan));
+    }
+}
+
+fn complexity_result(
+    file: &FileComplexity,
+    function: &FunctionComplexity,
+    max_complexity: u64,
+) -> Value {
+    json!({
+        "ruleId": RULE_ID,
+        "level": "warning",
+        "message": {
+            "text": format!(
+                "Function '{}' has a cognitive complexity of {}, which exceeds the maximum allowed complexity of {}.",
+                function.name, function.complexity, max_complexity
+            )
+        },
+        "locations": [{
+            "physicalLocation": {
+                "artifactLocation": {
+                    "uri": file.path,
+                    "uriBaseId": "%SRCROOT%",
+                },
+                "region": {
+                    "startLine": function.line_start,
+                    "endLine": function.line_end,
+                },
+            },
+            "logicalLocations": [
+                {"name": function.name, "kind": "function"}
+            ],
+        }],
+    })
+}
+
+fn complexity_rule_definition() -> Value {
+    json!({
+        "id": RULE_ID,
+        "name": "CognitiveComplexity",
+        "shortDescription": {"text": "Cognitive complexity exceeds threshold"},
+        "helpUri": HELP_URI,
+        "properties": {"tags": ["maintainability", "readability"]},
+    })
+}
+
+fn refactor_plan_result(
+    file: &FileComplexity,
+    function: &FunctionComplexity,
+    plan: &RefactorPlan,
+) -> Value {
+    json!({
+        "ruleId": plan.rule_id,
+        "level": refactor_plan_level(&plan.applicability),
+        "message": {"text": format!("{}: {}", plan.title, plan.explanation)},
+        "locations": [{
+            "physicalLocation": {
+                "artifactLocation": {
+                    "uri": file.path,
+                    "uriBaseId": "%SRCROOT%",
+                },
+                "region": {
+                    "startLine": plan.line_start,
+                    "startColumn": plan.column_start,
+                    "endLine": plan.line_end,
+                },
+            },
+            "logicalLocations": [
+                {"name": function.name, "kind": "function"}
+            ],
+        }],
+    })
+}
+
+fn refactor_plan_rule_definition(plan: &RefactorPlan) -> Value {
+    json!({
+        "id": plan.rule_id,
+        "name": plan.kind,
+        "shortDescription": {"text": plan.description},
+        "helpUri": plan.doc_url,
+        "properties": {"tags": [rule_category_tag(&plan.category)]},
+    })
+}
+
+fn refactor_plan_level(applicability: &Applicability) -> &'static str {
+    match applicability {
+        Applicability::Informational => "note",
+        _ => "warning",
+    }
+}
+
+fn rule_category_tag(category: &RuleCategory) -> &'static str {
+    match category {
+        RuleCategory::Complexity => "complexity",
+        RuleCategory::Readability => "readability",
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/sarif.rs"]
+mod tests;

--- a/src/tests/cli/gitlab.rs
+++ b/src/tests/cli/gitlab.rs
@@ -1,0 +1,239 @@
+//! Wired in from `src/cli/utils/gitlab.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::fs;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+use crate::classes::{
+    Applicability, CodeSuggestion, FileComplexity, FunctionComplexity, RefactorPlan, RuleCategory,
+};
+use crate::cli::utils::gitlab::store_gitlab;
+
+fn function_complexity(name: &str, complexity: u64) -> FunctionComplexity {
+    FunctionComplexity {
+        name: name.to_string(),
+        complexity,
+        line_start: 10,
+        line_end: 20,
+        line_complexities: vec![],
+        refactor_plans: vec![],
+        additional_refactor_plans: 0,
+    }
+}
+
+fn file_complexity(
+    path: &str,
+    file_name: &str,
+    functions: Vec<FunctionComplexity>,
+) -> FileComplexity {
+    FileComplexity {
+        path: path.to_string(),
+        file_name: file_name.to_string(),
+        functions,
+        complexity: 0,
+    }
+}
+
+fn refactor_plan() -> RefactorPlan {
+    RefactorPlan {
+        kind: "extract-method".to_string(),
+        title: "Extract method".to_string(),
+        line_start: 11,
+        line_end: 15,
+        column_start: 4,
+        current_complexity: 5,
+        estimated_reduction: 2,
+        estimated_complexity_after: 3,
+        reduction_is_measured: true,
+        rule_id: "C001".to_string(),
+        category: RuleCategory::Complexity,
+        applicability: Applicability::MachineApplicable,
+        description: "Extract the method body".to_string(),
+        explanation: "Reduces nesting".to_string(),
+        references: vec![],
+        suggestion: None::<CodeSuggestion>,
+        help: None,
+        doc_url: "https://example.com/c001".to_string(),
+    }
+}
+
+fn write_and_load(
+    output: &std::path::Path,
+    files: &[FileComplexity],
+    max_complexity: u64,
+    suggest_refactors: bool,
+) -> Value {
+    store_gitlab(
+        output.to_str().unwrap(),
+        files,
+        max_complexity,
+        suggest_refactors,
+    )
+    .expect("should write");
+    let content = fs::read_to_string(output).expect("should read");
+    serde_json::from_str(&content).expect("should parse")
+}
+
+#[test]
+fn gitlab_report_has_single_final_newline() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.gitlab.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 20)],
+    )];
+
+    write_and_load(&output, &files, 15, false);
+
+    let content = fs::read_to_string(&output).expect("should read");
+    assert!(content.ends_with('\n'));
+    assert!(!content.ends_with("\n\n"));
+}
+
+#[test]
+fn gitlab_report_contains_required_fields() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.gitlab.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 20)],
+    )];
+
+    let report = write_and_load(&output, &files, 15, false);
+    let issue = &report[0];
+
+    assert!(
+        issue["description"]
+            .as_str()
+            .expect("description")
+            .contains("Function 'f' has cognitive complexity 20")
+    );
+    assert_eq!(issue["check_name"], "complexipy/cognitive-complexity");
+    let fingerprint = issue["fingerprint"].as_str().expect("fingerprint");
+    assert_eq!(fingerprint.len(), 64);
+    assert!(fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
+    assert_eq!(issue["severity"], "minor");
+    assert_eq!(issue["location"]["path"], "src/a.py");
+    assert_eq!(issue["location"]["lines"]["begin"], 10);
+}
+
+#[test]
+fn gitlab_report_is_empty_when_threshold_is_high() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.gitlab.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 5)],
+    )];
+
+    let report = write_and_load(&output, &files, 15, false);
+
+    assert_eq!(report, serde_json::json!([]));
+}
+
+#[test]
+fn gitlab_report_omits_refactor_plans_by_default() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.gitlab.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![FunctionComplexity {
+            refactor_plans: vec![refactor_plan()],
+            ..function_complexity("f", 5)
+        }],
+    )];
+
+    let report = write_and_load(&output, &files, 15, false);
+
+    assert_eq!(report, serde_json::json!([]));
+}
+
+#[test]
+fn gitlab_report_includes_refactor_plans_when_requested() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.gitlab.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![FunctionComplexity {
+            refactor_plans: vec![refactor_plan()],
+            ..function_complexity("f", 20)
+        }],
+    )];
+
+    let report = write_and_load(&output, &files, 15, true);
+
+    let plan_issue = report
+        .as_array()
+        .expect("report")
+        .iter()
+        .find(|issue| issue["check_name"] == "complexipy/c001")
+        .expect("plan issue");
+    assert_eq!(
+        plan_issue["description"],
+        "[C001] Extract method: Reduces nesting"
+    );
+    assert_eq!(plan_issue["severity"], "minor");
+    assert_eq!(plan_issue["location"]["path"], "src/a.py");
+    assert_eq!(plan_issue["location"]["lines"]["begin"], 11);
+    assert_eq!(plan_issue["location"]["lines"]["end"], 15);
+}
+
+#[test]
+fn gitlab_report_normalizes_paths_and_strips_dot_slash() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.gitlab.json");
+    let files = vec![
+        file_complexity("src", "a.py", vec![function_complexity("f", 20)]),
+        file_complexity("./src/b.py", "b.py", vec![function_complexity("g", 20)]),
+    ];
+
+    let report = write_and_load(&output, &files, 15, false);
+
+    let paths: Vec<&str> = report
+        .as_array()
+        .expect("report")
+        .iter()
+        .map(|issue| issue["location"]["path"].as_str().expect("path"))
+        .collect();
+    assert_eq!(paths, vec!["src/a.py", "src/b.py"]);
+}
+
+#[test]
+fn gitlab_fingerprint_is_stable() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.gitlab.json");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 20)],
+    )];
+
+    let first = write_and_load(&output, &files, 15, false);
+    let second = write_and_load(&output, &files, 15, false);
+
+    assert_eq!(first[0]["fingerprint"], second[0]["fingerprint"]);
+}
+
+#[test]
+fn gitlab_write_failure_is_io_error() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = store_gitlab(
+        dir.path().to_str().unwrap(),
+        &[file_complexity(
+            "src/a.py",
+            "a.py",
+            vec![function_complexity("f", 20)],
+        )],
+        15,
+        false,
+    );
+
+    assert!(result.is_err());
+}

--- a/src/tests/cli/paths.rs
+++ b/src/tests/cli/paths.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 use crate::cli::types::OutputFormat;
 use crate::cli::utils::paths::{
     PathsError, build_output_paths, ensure_directory_destination, is_directory_output_hint,
-    resolve_output_paths,
+    normalize_path, resolve_output_paths,
 };
 
 fn default_paths(destination: &Path) -> Vec<(OutputFormat, PathBuf)> {
@@ -301,6 +301,34 @@ fn directory_hint_detects_trailing_separators() {
     assert!(is_directory_output_hint("out/"));
     assert!(!is_directory_output_hint("out"));
     assert!(!is_directory_output_hint(""));
+}
+
+#[test]
+fn normalize_path_returns_cleaned_path_when_ends_with_file_name() {
+    assert_eq!(normalize_path("src/a.py", "a.py"), "src/a.py");
+    assert_eq!(normalize_path("src/a.py/", "a.py"), "src/a.py");
+}
+
+#[test]
+fn normalize_path_joins_path_and_file_name() {
+    assert_eq!(normalize_path("src", "a.py"), "src/a.py");
+    assert_eq!(normalize_path("src/", "a.py"), "src/a.py");
+}
+
+#[test]
+fn normalize_path_empty_path_returns_file_name() {
+    assert_eq!(normalize_path("", "a.py"), "a.py");
+    assert_eq!(normalize_path("/", "a.py"), "a.py");
+}
+
+#[test]
+fn normalize_path_empty_file_name_returns_cleaned() {
+    assert_eq!(normalize_path("src/a.py", ""), "src/a.py");
+}
+
+#[test]
+fn normalize_path_strips_all_trailing_slashes() {
+    assert_eq!(normalize_path("src///", "a.py"), "src/a.py");
 }
 
 #[test]

--- a/src/tests/cli/sarif.rs
+++ b/src/tests/cli/sarif.rs
@@ -1,0 +1,272 @@
+//! Wired in from `src/cli/utils/sarif.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::fs;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+use crate::classes::{
+    Applicability, CodeSuggestion, FileComplexity, FunctionComplexity, RefactorPlan, RuleCategory,
+};
+use crate::cli::utils::sarif::store_sarif;
+
+fn function_complexity(name: &str, complexity: u64) -> FunctionComplexity {
+    FunctionComplexity {
+        name: name.to_string(),
+        complexity,
+        line_start: 10,
+        line_end: 20,
+        line_complexities: vec![],
+        refactor_plans: vec![],
+        additional_refactor_plans: 0,
+    }
+}
+
+fn file_complexity(
+    path: &str,
+    file_name: &str,
+    functions: Vec<FunctionComplexity>,
+) -> FileComplexity {
+    FileComplexity {
+        path: path.to_string(),
+        file_name: file_name.to_string(),
+        functions,
+        complexity: 0,
+    }
+}
+
+fn refactor_plan() -> RefactorPlan {
+    RefactorPlan {
+        kind: "extract-method".to_string(),
+        title: "Extract method".to_string(),
+        line_start: 11,
+        line_end: 15,
+        column_start: 4,
+        current_complexity: 5,
+        estimated_reduction: 2,
+        estimated_complexity_after: 3,
+        reduction_is_measured: true,
+        rule_id: "C001".to_string(),
+        category: RuleCategory::Complexity,
+        applicability: Applicability::MachineApplicable,
+        description: "Extract the method body".to_string(),
+        explanation: "Reduces nesting".to_string(),
+        references: vec![],
+        suggestion: None::<CodeSuggestion>,
+        help: None,
+        doc_url: "https://example.com/c001".to_string(),
+    }
+}
+
+fn write_and_load(
+    output: &std::path::Path,
+    files: &[FileComplexity],
+    max_complexity: u64,
+    suggest_refactors: bool,
+) -> Value {
+    store_sarif(
+        output.to_str().unwrap(),
+        files,
+        max_complexity,
+        suggest_refactors,
+    )
+    .expect("should write");
+    let content = fs::read_to_string(output).expect("should read");
+    serde_json::from_str(&content).expect("should parse")
+}
+
+#[test]
+fn sarif_file_created_and_valid() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.sarif");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 20)],
+    )];
+
+    let doc = write_and_load(&output, &files, 15, false);
+
+    assert_eq!(doc["version"], "2.1.0");
+    assert!(doc["$schema"].is_string());
+    let driver = &doc["runs"][0]["tool"]["driver"];
+    assert_eq!(driver["name"], "complexipy");
+    assert_eq!(driver["version"], env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn sarif_contains_violations() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.sarif");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 20)],
+    )];
+
+    let doc = write_and_load(&output, &files, 15, false);
+
+    let results = doc["runs"][0]["results"].as_array().expect("results");
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0]["ruleId"], "CC001");
+    assert_eq!(results[0]["level"], "warning");
+    assert!(
+        results[0]["message"]["text"]
+            .as_str()
+            .expect("message")
+            .contains("Function 'f' has a cognitive complexity of 20")
+    );
+}
+
+#[test]
+fn sarif_no_violations_when_threshold_high() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.sarif");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 5)],
+    )];
+
+    let doc = write_and_load(&output, &files, 15, false);
+
+    assert_eq!(doc["runs"][0]["results"], serde_json::json!([]));
+}
+
+#[test]
+fn sarif_result_has_location() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.sarif");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 20)],
+    )];
+
+    let doc = write_and_load(&output, &files, 15, false);
+
+    let location = &doc["runs"][0]["results"][0]["locations"][0];
+    assert_eq!(
+        location["physicalLocation"]["artifactLocation"]["uri"],
+        "src/a.py"
+    );
+    assert_eq!(
+        location["physicalLocation"]["artifactLocation"]["uriBaseId"],
+        "%SRCROOT%"
+    );
+    assert_eq!(location["physicalLocation"]["region"]["startLine"], 10);
+    assert_eq!(location["physicalLocation"]["region"]["endLine"], 20);
+    assert_eq!(location["logicalLocations"][0]["name"], "f");
+    assert_eq!(location["logicalLocations"][0]["kind"], "function");
+}
+
+#[test]
+fn sarif_rule_defined() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.sarif");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![function_complexity("f", 5)],
+    )];
+
+    let doc = write_and_load(&output, &files, 15, false);
+
+    let rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("rules");
+    assert_eq!(rules.len(), 1);
+    assert_eq!(rules[0]["id"], "CC001");
+    assert_eq!(rules[0]["name"], "CognitiveComplexity");
+    assert_eq!(
+        rules[0]["helpUri"],
+        "https://rohaquinlop.github.io/complexipy/understanding-scores/"
+    );
+}
+
+#[test]
+fn sarif_omits_refactor_plan_results_by_default() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.sarif");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![FunctionComplexity {
+            refactor_plans: vec![refactor_plan()],
+            ..function_complexity("f", 5)
+        }],
+    )];
+
+    let doc = write_and_load(&output, &files, 15, false);
+
+    let results = doc["runs"][0]["results"].as_array().expect("results");
+    assert!(results.iter().all(|result| result["ruleId"] == "CC001"));
+    let rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("rules");
+    assert_eq!(rules.len(), 1);
+}
+
+#[test]
+fn sarif_includes_refactor_plan_rules_when_requested() {
+    let dir = tempdir().expect("tempdir should work");
+    let output = dir.path().join("results.sarif");
+    let files = vec![file_complexity(
+        "src/a.py",
+        "a.py",
+        vec![FunctionComplexity {
+            refactor_plans: vec![refactor_plan()],
+            ..function_complexity("f", 20)
+        }],
+    )];
+
+    let doc = write_and_load(&output, &files, 15, true);
+
+    let results = doc["runs"][0]["results"].as_array().expect("results");
+    let plan_result = results
+        .iter()
+        .find(|result| result["ruleId"] == "C001")
+        .expect("plan result");
+    assert_eq!(plan_result["level"], "warning");
+    assert_eq!(
+        plan_result["message"]["text"],
+        "Extract method: Reduces nesting"
+    );
+    assert_eq!(
+        plan_result["locations"][0]["physicalLocation"]["region"]["startColumn"],
+        4
+    );
+
+    let rules = doc["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("rules");
+    let plan_rule = rules
+        .iter()
+        .find(|rule| rule["id"] == "C001")
+        .expect("plan rule");
+    assert_eq!(plan_rule["name"], "extract-method");
+    assert_eq!(
+        plan_rule["shortDescription"]["text"],
+        "Extract the method body"
+    );
+    assert_eq!(plan_rule["helpUri"], "https://example.com/c001");
+    assert_eq!(plan_rule["properties"]["tags"][0], "complexity");
+}
+
+#[test]
+fn sarif_write_failure_is_io_error() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = store_sarif(
+        dir.path().to_str().unwrap(),
+        &[file_complexity(
+            "src/a.py",
+            "a.py",
+            vec![function_complexity("f", 20)],
+        )],
+        15,
+        false,
+    );
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## What

Ports `utils/sarif.py` (SARIF 2.1.0 report) and `utils/gitlab.py` (GitLab Code Quality report) to Rust, as steps 8–9 of the CLI migration in issue #224, including the `normalize_path` extraction prerequisite.

## Why

Both are pure JSON report builders over the FFI types, sharing the extraction pattern, the `ExportError` type, and the test approach — joined into one change. Step 9 required `normalize_path` to move out of `output.py` first; it lands in `paths.rs` (resolving the issue's open decision).

## Changes

- `normalize_path` → `src/cli/utils/paths.rs` — `rstrip("/")`/`endswith`/join semantics, 5 new tests (Python `output.py` keeps its copy until Step 13)
- `src/cli/utils/sarif.rs` — `store_sarif` + helpers: CC001 built-in rule, dynamic refactor-plan rules deduped by `rule_id`, version from `CARGO_PKG_VERSION`, direct `Applicability`/`RuleCategory` enum matches replacing Python `str()` contains-checks, no trailing newline (matches `json.dump`)
- `src/cli/utils/gitlab.rs` — `store_gitlab` + helpers: sha256 fingerprints (`sha2` crate, `feat(cargo)`), severity mapping via enum match, `normalize_path` + `./` prefix strip, trailing newline
- Both return `Result<(), ExportError>` reusing the `Io`/`Serialize` variants from steps 6–7
- Tests: `src/tests/cli/sarif.rs` (8), `src/tests/cli/gitlab.rs` (8) mirroring the Python contracts; 139 Rust tests total
- Documented divergence: serde_json BTreeMap sorts keys vs Python insertion order — semantically identical JSON

Issue: #224