### PR TITLE
feat(cli): port snapshot evaluation to rust (step 10)

### DIFF
--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -3,4 +3,5 @@ pub mod config;
 pub mod gitlab;
 pub mod paths;
 pub mod sarif;
+pub mod snapshot;
 pub mod toml;

--- a/src/cli/utils/cache.rs
+++ b/src/cli/utils/cache.rs
@@ -35,16 +35,11 @@ pub fn remember_previous_functions(
     let cache_key = build_cache_key(invocation_path, targets)?;
 
     let cache_dir_path = resolve_cache_dir(invocation_path, cache_dir);
-    let is_default_cache_location =
-        cache_dir_path == Path::new(invocation_path).join(CACHE_DIR_NAME);
     let cache_file = cache_value_path(&cache_dir_path, FUNCTIONS_CACHE_KEY);
 
     ensure_cache_dir_and_supporting_files(&cache_dir_path)?;
 
     let mut cache_store = load_cache_store(&cache_file);
-    if is_default_cache_location {
-        migrate_legacy_cache_entry(&cache_dir_path, &mut cache_store, &cache_key);
-    }
     let previous_map = load_previous_map_from_store(&cache_store, &cache_key);
 
     cache_store["entries"][cache_key.as_str()] = json!({
@@ -53,9 +48,7 @@ pub fn remember_previous_functions(
         "updated_at": now_seconds(),
     });
     prune_cache_store(&mut cache_store);
-    if persist_cache(&cache_file, &cache_store) && is_default_cache_location {
-        remove_legacy_cache_files(&cache_dir_path);
-    }
+    persist_cache(&cache_file, &cache_store);
     previous_map
 }
 
@@ -179,42 +172,6 @@ fn load_cache_store(cache_file: &Path) -> Value {
         }
         _ => json!({ "entries": {} }),
     }
-}
-
-fn migrate_legacy_cache_entry(cache_dir: &Path, cache_store: &mut Value, cache_key: &str) {
-    let Some(entries) = cache_store
-        .get_mut("entries")
-        .and_then(|entries| entries.as_object_mut())
-    else {
-        return;
-    };
-    if entries.contains_key(cache_key) {
-        return;
-    }
-
-    let legacy_cache_file = cache_dir.join(format!("{}.json", cache_key));
-    let Some(legacy_payload) = load_cache(&legacy_cache_file) else {
-        return;
-    };
-
-    let updated_at = fs::metadata(&legacy_cache_file)
-        .and_then(|metadata| metadata.modified())
-        .map(|modified| {
-            modified
-                .duration_since(UNIX_EPOCH)
-                .map(|duration| duration.as_secs_f64())
-                .unwrap_or(0.0)
-        })
-        .unwrap_or(0.0);
-
-    entries.insert(
-        cache_key.to_string(),
-        json!({
-            "targets": legacy_payload.get("targets").cloned().unwrap_or_else(|| json!([])),
-            "functions": legacy_payload.get("functions").cloned().unwrap_or_else(|| json!([])),
-            "updated_at": updated_at,
-        }),
-    );
 }
 
 fn load_previous_map_from_store(
@@ -373,29 +330,6 @@ fn persist_cache(cache_file: &Path, payload: &Value) -> bool {
         return false;
     };
     fs::write(cache_file, serialized).is_ok()
-}
-
-fn remove_legacy_cache_files(cache_dir: &Path) {
-    let Ok(entries) = fs::read_dir(cache_dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let file_name = entry.file_name();
-        let Some(name) = file_name.to_str() else {
-            continue;
-        };
-        if is_legacy_cache_file_name(name) {
-            let _ = fs::remove_file(entry.path());
-        }
-    }
-}
-
-fn is_legacy_cache_file_name(name: &str) -> bool {
-    name.len() == 37
-        && name.ends_with(".json")
-        && name[..32]
-            .bytes()
-            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
 }
 
 fn ensure_cache_dir_and_supporting_files(cache_dir: &Path) -> Option<()> {

--- a/src/cli/utils/snapshot.rs
+++ b/src/cli/utils/snapshot.rs
@@ -1,0 +1,253 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::classes::FileComplexity;
+use crate::utils::{ExportError, create_snapshot_file_shared, load_snapshot_file_shared};
+
+pub struct SnapshotEvaluation {
+    pub should_run: bool,
+    pub active_snapshot_map: Option<HashMap<(String, String, String), u64>>,
+    pub watermark_success: bool,
+    pub watermark_messages: Vec<String>,
+    pub snapshot_result: bool,
+}
+
+pub fn evaluate_snapshot(
+    snapshot_create: bool,
+    snapshot_ignore: bool,
+    output_snapshot_path: &str,
+    max_complexity_allowed: u64,
+    files_complexities: &[FileComplexity],
+) -> Result<SnapshotEvaluation, ExportError> {
+    handle_snapshot_file_creation(
+        snapshot_create,
+        output_snapshot_path,
+        max_complexity_allowed,
+        files_complexities,
+    )?;
+
+    let snapshot_file_exists = Path::new(output_snapshot_path).exists();
+    let snapshot_files = handle_snapshot_functions_load(output_snapshot_path)?;
+    let should_run = snapshot_file_exists && !snapshot_ignore;
+
+    let active_snapshot_map = if should_run {
+        Some(build_snapshot_map(&snapshot_files))
+    } else {
+        None
+    };
+
+    let (watermark_success, watermark_messages) = handle_snapshot_watermark(
+        should_run,
+        snapshot_file_exists,
+        output_snapshot_path,
+        files_complexities,
+        &snapshot_files,
+        max_complexity_allowed,
+    )?;
+
+    let snapshot_result = if should_run { watermark_success } else { true };
+
+    Ok(SnapshotEvaluation {
+        should_run,
+        active_snapshot_map,
+        watermark_success,
+        watermark_messages,
+        snapshot_result,
+    })
+}
+
+fn handle_snapshot_file_creation(
+    create_snapshot: bool,
+    snapshot_file_path: &str,
+    max_complexity_allowed: u64,
+    files_complexities: &[FileComplexity],
+) -> Result<(), ExportError> {
+    if create_snapshot {
+        let snapshot_files = handle_snapshot_functions_load(snapshot_file_path)?;
+        create_snapshot_file_shared(
+            snapshot_file_path,
+            max_complexity_allowed,
+            merge_snapshot_files(snapshot_files, files_complexities),
+        )?;
+    }
+    Ok(())
+}
+
+fn handle_snapshot_functions_load(
+    snapshot_file_path: &str,
+) -> Result<Vec<FileComplexity>, ExportError> {
+    if Path::new(snapshot_file_path).exists() {
+        load_snapshot_file_shared(snapshot_file_path)
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+pub fn merge_snapshot_files(
+    snapshot_files: Vec<FileComplexity>,
+    files_complexities: &[FileComplexity],
+) -> Vec<FileComplexity> {
+    let current_entries: HashMap<(String, String), &FileComplexity> = files_complexities
+        .iter()
+        .map(|file_complexity| {
+            (
+                (
+                    file_complexity.path.clone(),
+                    file_complexity.file_name.clone(),
+                ),
+                file_complexity,
+            )
+        })
+        .collect();
+
+    let mut merged = Vec::new();
+    let mut merged_keys = std::collections::HashSet::new();
+
+    for file_complexity in snapshot_files {
+        let key = (
+            file_complexity.path.clone(),
+            file_complexity.file_name.clone(),
+        );
+        if let Some(current) = current_entries.get(&key) {
+            if merged_keys.insert(key) {
+                merged.push((*current).clone());
+            }
+        } else if merged_keys.insert(key) {
+            merged.push(file_complexity);
+        }
+    }
+
+    for file_complexity in files_complexities {
+        let key = (
+            file_complexity.path.clone(),
+            file_complexity.file_name.clone(),
+        );
+        if merged_keys.insert(key) {
+            merged.push(file_complexity.clone());
+        }
+    }
+
+    merged
+}
+
+fn handle_snapshot_watermark(
+    snapshot_watermark: bool,
+    snapshot_exists: bool,
+    output_snapshot_path: &str,
+    files_complexities: &[FileComplexity],
+    snapshot_files: &[FileComplexity],
+    max_complexity_allowed: u64,
+) -> Result<(bool, Vec<String>), ExportError> {
+    if !snapshot_watermark {
+        return Ok((true, Vec::new()));
+    }
+
+    if !snapshot_exists {
+        return Ok((
+            false,
+            vec![
+                "Snapshot watermark requested but no snapshot file was found. Run complexipy with --snapshot-create first.".to_string(),
+            ],
+        ));
+    }
+
+    let snapshot_map = build_snapshot_map(snapshot_files);
+    let mut violations = Vec::new();
+
+    for file_complexity in files_complexities {
+        for function in file_complexity
+            .functions
+            .iter()
+            .filter(|function| function.complexity > max_complexity_allowed)
+        {
+            let key = build_function_key(
+                &file_complexity.path,
+                &file_complexity.file_name,
+                &function.name,
+            );
+            let previous_complexity = snapshot_map.get(&key);
+
+            if let Some(previous_complexity) = previous_complexity {
+                if function.complexity > *previous_complexity {
+                    violations.push(format!(
+                        "{} increased from {} to {}.",
+                        format_function_location(
+                            &file_complexity.path,
+                            &file_complexity.file_name,
+                            &function.name
+                        ),
+                        previous_complexity,
+                        function.complexity
+                    ));
+                }
+            } else {
+                violations.push(format!(
+                    "{} exceeds {} but was not part of the snapshot.",
+                    format_function_location(
+                        &file_complexity.path,
+                        &file_complexity.file_name,
+                        &function.name
+                    ),
+                    max_complexity_allowed
+                ));
+            }
+        }
+    }
+
+    if !violations.is_empty() {
+        return Ok((false, violations));
+    }
+
+    create_snapshot_file_shared(
+        output_snapshot_path,
+        max_complexity_allowed,
+        merge_snapshot_files(snapshot_files.to_vec(), files_complexities),
+    )?;
+
+    Ok((true, Vec::new()))
+}
+
+pub fn build_snapshot_map(
+    snapshot_files: &[FileComplexity],
+) -> HashMap<(String, String, String), u64> {
+    let mut snapshot_map = HashMap::new();
+    for file_complexity in snapshot_files {
+        for function in &file_complexity.functions {
+            let key = build_function_key(
+                &file_complexity.path,
+                &file_complexity.file_name,
+                &function.name,
+            );
+            snapshot_map.insert(key, function.complexity);
+        }
+    }
+    snapshot_map
+}
+
+fn build_function_key(
+    path: &str,
+    file_name: &str,
+    function_name: &str,
+) -> (String, String, String) {
+    (
+        path.to_string(),
+        file_name.to_string(),
+        function_name.to_string(),
+    )
+}
+
+fn format_function_location(path: &str, file_name: &str, function_name: &str) -> String {
+    let location = if path.is_empty() {
+        file_name.to_string()
+    } else {
+        Path::new(path)
+            .join(file_name)
+            .to_string_lossy()
+            .into_owned()
+    };
+    format!("{}:{}", location, function_name)
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/snapshot.rs"]
+mod tests;

--- a/src/tests/cli/cache.rs
+++ b/src/tests/cli/cache.rs
@@ -8,8 +8,7 @@ use tempfile::tempdir;
 
 use crate::classes::{FileComplexity, FunctionComplexity};
 use crate::cli::utils::cache::{
-    build_cache_key, hash_targets, is_legacy_cache_file_name, lexically_clean,
-    remember_previous_functions,
+    build_cache_key, hash_targets, lexically_clean, remember_previous_functions,
 };
 
 fn file_complexity(path: &str, file_name: &str, functions: &[(&str, u64)]) -> FileComplexity {
@@ -44,18 +43,6 @@ fn cache_key_matches_python_blake2b() {
         hash_targets("src||tests"),
         "c7f7a0c9374f38debd3947990e36306c"
     );
-}
-
-#[test]
-fn legacy_file_name_pattern_matches_python() {
-    let key = "c7f7a0c9374f38debd3947990e36306c";
-    assert!(is_legacy_cache_file_name(&format!("{}.json", key)));
-    assert!(!is_legacy_cache_file_name("functions"));
-    assert!(!is_legacy_cache_file_name("notes.txt"));
-    assert!(!is_legacy_cache_file_name(&format!(
-        "{}.json",
-        "G7f7a0c9374f38debd3947990e36306c"
-    )));
 }
 
 #[test]
@@ -182,109 +169,6 @@ fn target_sets_share_single_functions_file() {
         .as_object()
         .expect("object");
     assert_eq!(entries.len(), 2);
-}
-
-#[test]
-fn legacy_hash_file_is_migrated_and_removed() {
-    let dir = tempdir().expect("tempdir should work");
-    let inv = dir.path().join("proj");
-    fs::create_dir(&inv).expect("should create");
-    let cache_dir = inv.join(".complexipy_cache");
-    fs::create_dir_all(&cache_dir).expect("should create");
-
-    let targets = vec!["src".to_string()];
-    let key = build_cache_key(inv.to_str().unwrap(), &targets).expect("key");
-    let legacy_payload = json!({
-        "targets": [inv.join("src").to_string_lossy()],
-        "functions": [{
-            "path": "src/legacy.py",
-            "file_name": "legacy.py",
-            "function_name": "old",
-            "complexity": 9,
-        }],
-    });
-    fs::write(
-        cache_dir.join(format!("{}.json", key)),
-        serde_json::to_string_pretty(&legacy_payload).expect("serialize"),
-    )
-    .expect("should write");
-
-    let result = remember_previous_functions(
-        inv.to_str().unwrap(),
-        &targets,
-        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
-        None,
-    );
-
-    assert_eq!(
-        result,
-        Some(HashMap::from([(
-            (
-                "src/legacy.py".to_string(),
-                "legacy.py".to_string(),
-                "old".to_string()
-            ),
-            9
-        )]))
-    );
-    assert!(!cache_dir.join(format!("{}.json", key)).exists());
-
-    let store = load_functions_file(&cache_dir);
-    let entries = store
-        .get("entries")
-        .expect("entries")
-        .as_object()
-        .expect("object");
-    let entry = entries.get(&key).expect("entry");
-    assert_eq!(
-        entry.get("functions").expect("functions"),
-        &json!([{
-            "path": "src/a.py",
-            "file_name": "a.py",
-            "function_name": "f",
-            "complexity": 5,
-        }])
-    );
-}
-
-#[test]
-fn legacy_migration_skipped_for_custom_cache_dir() {
-    let dir = tempdir().expect("tempdir should work");
-    let inv = dir.path().join("proj");
-    fs::create_dir(&inv).expect("should create");
-    let custom_dir = dir.path().join("custom");
-    fs::create_dir_all(&custom_dir).expect("should create");
-
-    let key = build_cache_key(inv.to_str().unwrap(), &["src".to_string()]).expect("key");
-    let legacy_file = custom_dir.join(format!("{}.json", key));
-    fs::write(&legacy_file, "{}").expect("should write");
-
-    let result = remember_previous_functions(
-        inv.to_str().unwrap(),
-        &["src".to_string()],
-        &[file_complexity("src/a.py", "a.py", &[("f", 5)])],
-        Some(custom_dir.to_str().unwrap()),
-    );
-
-    assert_eq!(result, None);
-    assert!(legacy_file.exists());
-    let store = load_functions_file(&custom_dir);
-    let entries = store
-        .get("entries")
-        .expect("entries")
-        .as_object()
-        .expect("object");
-    assert_eq!(entries.len(), 1);
-    let entry = entries.values().next().expect("entry");
-    assert_eq!(
-        entry.get("functions").expect("functions"),
-        &json!([{
-            "path": "src/a.py",
-            "file_name": "a.py",
-            "function_name": "f",
-            "complexity": 5,
-        }])
-    );
 }
 
 #[test]

--- a/src/tests/cli/snapshot.rs
+++ b/src/tests/cli/snapshot.rs
@@ -1,0 +1,358 @@
+//! Wired in from `src/cli/utils/snapshot.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::fs;
+
+use serde_json::json;
+use tempfile::tempdir;
+
+use crate::classes::FileComplexity;
+use crate::cli::utils::snapshot::{build_snapshot_map, evaluate_snapshot, merge_snapshot_files};
+use crate::utils::{create_snapshot_file_shared, load_snapshot_file_shared};
+
+fn file_complexity(path: &str, file_name: &str, functions: &[(&str, u64)]) -> FileComplexity {
+    use crate::classes::FunctionComplexity;
+    FileComplexity {
+        path: path.to_string(),
+        file_name: file_name.to_string(),
+        functions: functions
+            .iter()
+            .map(|(name, complexity)| FunctionComplexity {
+                name: name.to_string(),
+                complexity: *complexity,
+                line_start: 1,
+                line_end: 2,
+                line_complexities: vec![],
+                refactor_plans: vec![],
+                additional_refactor_plans: 0,
+            })
+            .collect(),
+        complexity: 0,
+    }
+}
+
+fn snapshot_path(dir: &tempfile::TempDir) -> std::path::PathBuf {
+    dir.path().join("complexipy-snapshot.json")
+}
+
+#[test]
+fn no_snapshot_file_exists() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let files = vec![file_complexity("a.py", "a.py", &[("f", 5)])];
+
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &files)
+        .expect("should evaluate");
+
+    assert!(!result.should_run);
+    assert_eq!(result.active_snapshot_map, None);
+    assert!(result.watermark_success);
+    assert_eq!(result.watermark_messages, Vec::<String>::new());
+    assert!(result.snapshot_result);
+}
+
+#[test]
+fn snapshot_file_exists_not_ignored() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let files = vec![file_complexity("a.py", "a.py", &[("f", 5)])];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 0, &files).expect("should evaluate");
+
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &files)
+        .expect("should evaluate");
+
+    assert!(result.should_run);
+    let map = result.active_snapshot_map.expect("map");
+    assert_eq!(
+        map.get(&("a.py".to_string(), "a.py".to_string(), "f".to_string())),
+        Some(&5)
+    );
+}
+
+#[test]
+fn snapshot_file_exists_ignored() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let files = vec![file_complexity("a.py", "a.py", &[("f", 5)])];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 0, &files).expect("should evaluate");
+
+    let result = evaluate_snapshot(false, true, path.to_str().unwrap(), 15, &files)
+        .expect("should evaluate");
+
+    assert!(!result.should_run);
+    assert_eq!(result.active_snapshot_map, None);
+}
+
+#[test]
+fn snapshot_create_generates_file() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let files = vec![
+        file_complexity("a.py", "a.py", &[("high", 20)]),
+        file_complexity("b.py", "b.py", &[("low", 2)]),
+    ];
+
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &files).expect("should evaluate");
+
+    let stored = load_snapshot_file_shared(path.to_str().unwrap()).expect("should load");
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].file_name, "a.py");
+    assert_eq!(stored[0].functions[0].name, "high");
+}
+
+#[test]
+fn watermark_passes_when_no_regressions() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let baseline = vec![file_complexity("a.py", "a.py", &[("f", 20)])];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &baseline).expect("should evaluate");
+
+    let current = vec![file_complexity("a.py", "a.py", &[("f", 20)])];
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &current)
+        .expect("should evaluate");
+
+    assert!(result.watermark_success);
+    assert_eq!(result.watermark_messages, Vec::<String>::new());
+}
+
+#[test]
+fn watermark_reports_new_violation() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let baseline = vec![file_complexity("a.py", "a.py", &[("f", 5)])];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &baseline).expect("should evaluate");
+
+    let current = vec![file_complexity(
+        "a.py",
+        "a.py",
+        &[("f", 20), ("new_fn", 25)],
+    )];
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &current)
+        .expect("should evaluate");
+
+    assert!(!result.watermark_success);
+    assert_eq!(
+        result.watermark_messages,
+        vec![
+            "a.py/a.py:f exceeds 15 but was not part of the snapshot.",
+            "a.py/a.py:new_fn exceeds 15 but was not part of the snapshot."
+        ]
+    );
+}
+
+#[test]
+fn watermark_reports_increased_complexity() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let baseline = vec![file_complexity("a.py", "a.py", &[("f", 18)])];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &baseline).expect("should evaluate");
+
+    let current = vec![file_complexity("a.py", "a.py", &[("f", 25)])];
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &current)
+        .expect("should evaluate");
+
+    assert!(!result.watermark_success);
+    assert_eq!(
+        result.watermark_messages,
+        vec!["a.py/a.py:f increased from 18 to 25."]
+    );
+}
+
+#[test]
+fn watermark_without_snapshot_file() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let files = vec![file_complexity("a.py", "a.py", &[("f", 20)])];
+
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &files)
+        .expect("should evaluate");
+
+    assert!(!result.should_run);
+    assert!(result.watermark_success);
+}
+
+#[test]
+fn snapshot_result_neutral_when_not_running() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let files = vec![file_complexity("a.py", "a.py", &[("f", 5)])];
+
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &files)
+        .expect("should evaluate");
+
+    assert!(result.snapshot_result);
+}
+
+#[test]
+fn partial_run_preserves_unanalyzed_files() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let both = vec![
+        file_complexity("a.py", "a.py", &[("f", 20)]),
+        file_complexity("b.py", "b.py", &[("g", 20)]),
+    ];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &both).expect("should evaluate");
+
+    let only_a = vec![file_complexity("a.py", "a.py", &[("f", 20)])];
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &only_a)
+        .expect("should evaluate");
+
+    assert!(result.watermark_success);
+    let stored = load_snapshot_file_shared(path.to_str().unwrap()).expect("should load");
+    let names: Vec<&str> = stored.iter().map(|f| f.file_name.as_str()).collect();
+    assert_eq!(names, vec!["a.py", "b.py"]);
+}
+
+#[test]
+fn partial_run_keeps_analyzed_file_position() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let all = vec![
+        file_complexity("a.py", "a.py", &[("f", 20)]),
+        file_complexity("b.py", "b.py", &[("g", 20)]),
+        file_complexity("c.py", "c.py", &[("h", 20)]),
+    ];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &all).expect("should evaluate");
+
+    let only_b = vec![file_complexity("b.py", "b.py", &[("g", 25)])];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &only_b).expect("should evaluate");
+
+    let stored = load_snapshot_file_shared(path.to_str().unwrap()).expect("should load");
+    let names: Vec<&str> = stored.iter().map(|f| f.file_name.as_str()).collect();
+    assert_eq!(names, vec!["a.py", "b.py", "c.py"]);
+    assert_eq!(stored[1].functions[0].complexity, 25);
+}
+
+#[test]
+fn repeated_partial_runs_keep_snapshot_byte_identical() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let both = vec![
+        file_complexity("a.py", "a.py", &[("f", 20)]),
+        file_complexity("b.py", "b.py", &[("g", 20)]),
+    ];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &both).expect("should evaluate");
+
+    let only_b = vec![file_complexity("b.py", "b.py", &[("g", 20)])];
+    evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &only_b).expect("should evaluate");
+    let first_content = fs::read_to_string(&path).expect("should read");
+
+    evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &only_b).expect("should evaluate");
+
+    assert_eq!(
+        fs::read_to_string(&path).expect("should read"),
+        first_content
+    );
+}
+
+#[test]
+fn new_file_appends_at_end() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let ab = vec![
+        file_complexity("a.py", "a.py", &[("f", 20)]),
+        file_complexity("b.py", "b.py", &[("g", 20)]),
+    ];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &ab).expect("should evaluate");
+
+    let ac = vec![
+        file_complexity("a.py", "a.py", &[("f", 20)]),
+        file_complexity("c.py", "c.py", &[("h", 20)]),
+    ];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &ac).expect("should evaluate");
+
+    let stored = load_snapshot_file_shared(path.to_str().unwrap()).expect("should load");
+    let names: Vec<&str> = stored.iter().map(|f| f.file_name.as_str()).collect();
+    assert_eq!(names, vec!["a.py", "b.py", "c.py"]);
+}
+
+#[test]
+fn duplicate_snapshot_entries_collapse_in_place() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let abc = vec![
+        file_complexity("a.py", "a.py", &[("f", 20)]),
+        file_complexity("b.py", "b.py", &[("g", 20)]),
+        file_complexity("c.py", "c.py", &[("h", 20)]),
+    ];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &abc).expect("should evaluate");
+
+    let stored = load_snapshot_file_shared(path.to_str().unwrap()).expect("should load");
+    let duplicated = vec![
+        stored[0].clone(),
+        stored[1].clone(),
+        stored[1].clone(),
+        stored[2].clone(),
+    ];
+    create_snapshot_file_shared(path.to_str().unwrap(), 0, duplicated).expect("should write");
+
+    let only_b = vec![file_complexity("b.py", "b.py", &[("g", 20)])];
+    evaluate_snapshot(false, false, path.to_str().unwrap(), 0, &only_b).expect("should evaluate");
+
+    let stored = load_snapshot_file_shared(path.to_str().unwrap()).expect("should load");
+    let names: Vec<&str> = stored.iter().map(|f| f.file_name.as_str()).collect();
+    assert_eq!(names, vec!["a.py", "b.py", "c.py"]);
+    assert_eq!(stored[1].functions[0].complexity, 20);
+}
+
+#[test]
+fn partial_run_removes_improved_function() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    let both = vec![
+        file_complexity("a.py", "a.py", &[("f", 20)]),
+        file_complexity("b.py", "b.py", &[("g", 20)]),
+    ];
+    evaluate_snapshot(true, false, path.to_str().unwrap(), 15, &both).expect("should evaluate");
+
+    let improved_a = vec![file_complexity("a.py", "a.py", &[("f", 2)])];
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &improved_a)
+        .expect("should evaluate");
+
+    assert!(result.watermark_success);
+    let stored = load_snapshot_file_shared(path.to_str().unwrap()).expect("should load");
+    let names: Vec<&str> = stored.iter().map(|f| f.file_name.as_str()).collect();
+    assert_eq!(names, vec!["b.py"]);
+}
+
+#[test]
+fn build_snapshot_map_collects_all_functions() {
+    let files = vec![file_complexity("a.py", "a.py", &[("f", 3), ("g", 7)])];
+
+    let map = build_snapshot_map(&files);
+
+    assert_eq!(map.len(), 2);
+    assert_eq!(
+        map.get(&("a.py".to_string(), "a.py".to_string(), "g".to_string())),
+        Some(&7)
+    );
+}
+
+#[test]
+fn merge_snapshot_files_replaces_in_place_and_appends() {
+    let snapshot = vec![
+        file_complexity("a.py", "a.py", &[("f", 20)]),
+        file_complexity("b.py", "b.py", &[("g", 20)]),
+    ];
+    let current = vec![
+        file_complexity("a.py", "a.py", &[("f", 25)]),
+        file_complexity("c.py", "c.py", &[("h", 20)]),
+    ];
+
+    let merged = merge_snapshot_files(snapshot, &current);
+
+    let names: Vec<&str> = merged.iter().map(|f| f.file_name.as_str()).collect();
+    assert_eq!(names, vec!["a.py", "b.py", "c.py"]);
+    assert_eq!(merged[0].functions[0].complexity, 25);
+}
+
+#[test]
+fn corrupt_snapshot_propagates_error() {
+    let dir = tempdir().expect("tempdir should work");
+    let path = snapshot_path(&dir);
+    fs::write(&path, json!([{"path": "broken"}]).to_string()).expect("should write");
+    let files = vec![file_complexity("a.py", "a.py", &[("f", 5)])];
+
+    let result = evaluate_snapshot(false, false, path.to_str().unwrap(), 15, &files);
+
+    assert!(result.is_err());
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,7 +20,6 @@ mod python_deps {
     pub use crate::classes::FunctionComplexity;
     pub use pyo3::exceptions::{PyIOError, PyValueError};
     pub use pyo3::prelude::*;
-    pub use std::fs::read_to_string;
 }
 
 #[cfg(feature = "python")]
@@ -225,13 +224,12 @@ pub fn output_json(
     .map_err(export_error_to_py_error)
 }
 
-#[cfg(feature = "python")]
-#[pyfunction]
-pub fn create_snapshot_file(
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn create_snapshot_file_shared(
     snapshot_file_path: &str,
     max_complexity: u64,
     files_complexities: Vec<FileComplexity>,
-) -> PyResult<()> {
+) -> Result<(), ExportError> {
     let files_snapshot: Vec<FileComplexity> = files_complexities
         .into_iter()
         .filter_map(|file_complexity| {
@@ -253,15 +251,15 @@ pub fn create_snapshot_file(
         .collect();
 
     let json_string = serde_json::to_string_pretty(&files_snapshot)
-        .map_err(|e| PyValueError::new_err(format!("Failed to serialize JSON: {}", e)))?;
+        .map_err(|e| ExportError::Serialize(format!("Failed to serialize JSON: {}", e)))?;
     let mut file = File::create(snapshot_file_path).map_err(|e| {
-        PyIOError::new_err(format!(
+        ExportError::Io(format!(
             "Failed to create snapshot file at {}: {}",
             snapshot_file_path, e
         ))
     })?;
     file.write_all(json_string.as_bytes()).map_err(|e| {
-        PyIOError::new_err(format!(
+        ExportError::Io(format!(
             "Failed to write snapshot file at {}: {}",
             snapshot_file_path, e
         ))
@@ -270,17 +268,35 @@ pub fn create_snapshot_file(
     Ok(())
 }
 
-#[cfg(feature = "python")]
-#[pyfunction]
-pub fn load_snapshot_file(snapshot_file_path: &str) -> PyResult<Vec<FileComplexity>> {
-    let snapshot_content = read_to_string(snapshot_file_path).map_err(|e| {
-        PyIOError::new_err(format!(
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn load_snapshot_file_shared(
+    snapshot_file_path: &str,
+) -> Result<Vec<FileComplexity>, ExportError> {
+    let snapshot_content = std::fs::read_to_string(snapshot_file_path).map_err(|e| {
+        ExportError::Io(format!(
             "Failed to read snapshot file {}: {}",
             snapshot_file_path, e
         ))
     })?;
     serde_json::from_str(snapshot_content.as_str())
-        .map_err(|e| PyValueError::new_err(format!("Failed to parse snapshot JSON: {}", e)))
+        .map_err(|e| ExportError::Serialize(format!("Failed to parse snapshot JSON: {}", e)))
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+pub fn create_snapshot_file(
+    snapshot_file_path: &str,
+    max_complexity: u64,
+    files_complexities: Vec<FileComplexity>,
+) -> PyResult<()> {
+    create_snapshot_file_shared(snapshot_file_path, max_complexity, files_complexities)
+        .map_err(export_error_to_py_error)
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+pub fn load_snapshot_file(snapshot_file_path: &str) -> PyResult<Vec<FileComplexity>> {
+    load_snapshot_file_shared(snapshot_file_path).map_err(export_error_to_py_error)
 }
 
 #[cfg(feature = "python")]


### PR DESCRIPTION
## What

Ports `utils/snapshot.py` — snapshot creation/loading, watermark evaluation, and the order-preserving partial-run merge — to Rust, as step 10 of the CLI migration in issue #224.

## Why

The snapshot module is the CLI's regression gate (`SnapshotEvaluation`). Heavy I/O already lived in Rust but was PyO3-bound; this change extracts it and ports the evaluation pipeline. Per the issue's new deprecation policy, legacy snapshot support is not ported — the next major release drops old-version compat.

## Changes

- `src/utils.rs` — `create_snapshot_file_shared` / `load_snapshot_file_shared` extracted (`any(python, cli)`), pyfunctions as thin wrappers; signatures unchanged
- `src/cli/utils/snapshot.rs` — `SnapshotEvaluation`, `evaluate_snapshot`, `merge_snapshot_files` (order-preserving: replace-in-place, keep stale in position, append new, dedupe), `handle_snapshot_watermark` (verbatim messages), `build_snapshot_map`, `format_function_location`
- `refactor(cli): drop legacy cache migration` — per the deprecation policy: `migrate_legacy_cache_entry`/`remove_legacy_cache_files`/legacy-name pattern removed from `cache.rs` (Step 5 retroactive); legacy snapshot handling not ported
- Console display (`handle_snapshot`) deferred to Step 13 (output module)
- Tests: `src/tests/cli/snapshot.rs` — 18 tests mirroring `test_snapshot.py` (partial-run ordering, byte-identical rewrites, watermark messages, error propagation); 154 Rust tests total

Issue: #224