### PR TITLE
feat(cli): port git diff computation to rust (step 11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser"]
 python = [
     "serde",
     "pyo3",

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -156,6 +156,7 @@ impl ExitReport {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum DiffStatus {
     Regressed,
     Improved,
@@ -164,11 +165,12 @@ pub enum DiffStatus {
     Removed,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DiffEntry {
-    file_path: String,
-    func_name: String,
-    old_complexity: Option<u64>,
-    new_complexity: Option<u64>,
+    pub file_path: String,
+    pub func_name: String,
+    pub old_complexity: Option<u64>,
+    pub new_complexity: Option<u64>,
 }
 
 impl DiffEntry {
@@ -188,11 +190,11 @@ impl DiffEntry {
         }
     }
 
-    pub fn delta(&self) -> Option<u64> {
+    pub fn delta(&self) -> Option<i64> {
         match (self.old_complexity, self.new_complexity) {
             (None, ..) => None,
             (.., None) => None,
-            (Some(old), Some(new)) => Some(new - old),
+            (Some(old), Some(new)) => Some(new as i64 - old as i64),
         }
     }
 }

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,5 +1,6 @@
 pub mod cache;
 pub mod config;
+pub mod diff;
 pub mod gitlab;
 pub mod paths;
 pub mod sarif;

--- a/src/cli/utils/diff.rs
+++ b/src/cli/utils/diff.rs
@@ -1,0 +1,263 @@
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::classes::FileComplexity;
+use crate::cli::types::{DiffEntry, DiffStatus};
+
+const GIT_TIMEOUT: Duration = Duration::from_secs(15);
+const GIT_ROOT_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn compute_diff(
+    current_files: &[FileComplexity],
+    git_ref: &str,
+    invocation_path: &str,
+) -> Vec<DiffEntry> {
+    let mut entries = Vec::new();
+
+    for file in current_files {
+        let path_from_root = resolve_git_path(&file.path, git_ref, invocation_path);
+        let current_map: HashMap<String, u64> = file
+            .functions
+            .iter()
+            .map(|function| (function.name.clone(), function.complexity))
+            .collect();
+
+        let Some(old_content) = file_content_at_ref(git_ref, &path_from_root, invocation_path)
+        else {
+            let mut names: Vec<&String> = current_map.keys().collect();
+            names.sort();
+            for name in names {
+                entries.push(DiffEntry {
+                    file_path: file.path.clone(),
+                    func_name: name.clone(),
+                    old_complexity: None,
+                    new_complexity: current_map.get(name).copied(),
+                });
+            }
+            continue;
+        };
+
+        let Some(old_map) = analyse_content_to_map(Some(&old_content)) else {
+            continue;
+        };
+
+        let mut all_names: Vec<String> =
+            old_map.keys().chain(current_map.keys()).cloned().collect();
+        all_names.sort();
+        all_names.dedup();
+
+        for name in all_names {
+            entries.push(DiffEntry {
+                file_path: file.path.clone(),
+                func_name: name.clone(),
+                old_complexity: old_map.get(&name).copied(),
+                new_complexity: current_map.get(&name).copied(),
+            });
+        }
+    }
+
+    entries
+}
+
+pub fn compute_staged_diff(git_ref: &str, invocation_path: &str) -> Option<Vec<DiffEntry>> {
+    let root = git_root(invocation_path)?;
+
+    let mut entries = Vec::new();
+    for path_from_root in staged_python_files(git_ref, &root) {
+        let old_content = file_content_at_ref(git_ref, &path_from_root, &root);
+        let new_content = file_content_at_index(&path_from_root, &root);
+
+        let old_map = analyse_content_to_map(old_content.as_deref());
+        let new_map = analyse_content_to_map(new_content.as_deref());
+
+        if old_map.is_none() && new_map.is_none() {
+            continue;
+        }
+
+        let old_map = old_map.unwrap_or_default();
+        let new_map = new_map.unwrap_or_default();
+
+        let mut names: Vec<String> = old_map.keys().chain(new_map.keys()).cloned().collect();
+        names.sort();
+        names.dedup();
+
+        for name in names {
+            entries.push(DiffEntry {
+                file_path: path_from_root.clone(),
+                func_name: name.clone(),
+                old_complexity: old_map.get(&name).copied(),
+                new_complexity: new_map.get(&name).copied(),
+            });
+        }
+    }
+
+    Some(entries)
+}
+
+pub fn has_regressions(entries: &[DiffEntry], max_complexity: u64) -> bool {
+    entries.iter().any(|entry| match entry.status() {
+        DiffStatus::Regressed => entry.new_complexity.is_some_and(|c| c > max_complexity),
+        DiffStatus::New => entry.new_complexity.is_some_and(|c| c > max_complexity),
+        _ => false,
+    })
+}
+
+pub fn resolve_diff_flags(
+    diff: Option<String>,
+    diff_only: Option<String>,
+    staged: bool,
+) -> (Option<String>, Option<String>) {
+    let mut diff = diff;
+    if staged && diff.is_none() && diff_only.is_none() {
+        diff = Some("HEAD".to_string());
+    }
+    if diff_only.is_some() && diff.is_some() {
+        diff = None;
+    }
+    (diff, diff_only)
+}
+
+fn git_root(cwd: &str) -> Option<String> {
+    let (success, output) = run_git(cwd, &["rev-parse", "--show-toplevel"], GIT_ROOT_TIMEOUT)?;
+    let root = output.trim();
+    if success && !root.is_empty() {
+        Some(root.to_string())
+    } else {
+        None
+    }
+}
+
+fn file_content_at_ref(git_ref: &str, path_from_root: &str, cwd: &str) -> Option<String> {
+    let argument = format!("{}:{}", git_ref, path_from_root);
+    let (success, output) = run_git(cwd, &["show", &argument], GIT_TIMEOUT)?;
+    if success { Some(output) } else { None }
+}
+
+fn file_content_at_index(path_from_root: &str, cwd: &str) -> Option<String> {
+    let argument = format!(":{}", path_from_root);
+    let (success, output) = run_git(cwd, &["show", &argument], GIT_TIMEOUT)?;
+    if success { Some(output) } else { None }
+}
+
+fn staged_python_files(git_ref: &str, cwd: &str) -> Vec<String> {
+    let (success, output) = run_git(
+        cwd,
+        &[
+            "diff",
+            "--name-only",
+            "--cached",
+            "--no-renames",
+            "--diff-filter=ACMRD",
+            git_ref,
+            "--",
+            "*.py",
+        ],
+        GIT_TIMEOUT,
+    )
+    .unwrap_or((false, String::new()));
+    if !success {
+        return Vec::new();
+    }
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn git_tracked_paths(cwd: &str) -> Vec<String> {
+    let (success, output) =
+        run_git(cwd, &["ls-files", "--full-name"], GIT_TIMEOUT).unwrap_or((false, String::new()));
+    if success {
+        output.lines().map(str::to_string).collect()
+    } else {
+        Vec::new()
+    }
+}
+
+fn resolve_git_path(file_path: &str, git_ref: &str, invocation_path: &str) -> String {
+    let normalized = file_path.replace('\\', "/");
+    let parts: Vec<&str> = normalized.split('/').collect();
+
+    for i in 0..parts.len() {
+        let candidate = parts[i..].join("/");
+        if file_content_at_ref(git_ref, &candidate, invocation_path).is_some() {
+            return candidate;
+        }
+    }
+
+    let basename = parts.last().copied().unwrap_or("");
+    let tracked_paths = git_tracked_paths(invocation_path);
+    let matches: Vec<&String> = tracked_paths
+        .iter()
+        .filter(|tracked| {
+            tracked.as_str() == basename || tracked.ends_with(&format!("/{}", basename))
+        })
+        .collect();
+    if matches.len() == 1 {
+        matches[0].clone()
+    } else {
+        normalized
+    }
+}
+
+fn analyse_content_to_map(content: Option<&str>) -> Option<HashMap<String, u64>> {
+    let content = content?;
+    let parsed = ruff_python_parser::parse_module(content).ok()?;
+    let ast_body = parsed.into_suite();
+    let (functions, _) = crate::cognitive_complexity::function_level_cognitive_complexity_shared(
+        &ast_body, content, false, false, false,
+    );
+    Some(
+        functions
+            .into_iter()
+            .map(|function| (function.name, function.complexity))
+            .collect(),
+    )
+}
+
+fn run_git(cwd: &str, args: &[&str], timeout: Duration) -> Option<(bool, String)> {
+    let mut child = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let stdout = child.stdout.take()?;
+    let stdout_handle = thread::spawn(move || {
+        let mut buffer = Vec::new();
+        let mut reader = stdout;
+        let _ = reader.read_to_end(&mut buffer);
+        buffer
+    });
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => return None,
+        }
+    };
+
+    let output = stdout_handle.join().ok()?;
+    let output = String::from_utf8(output).ok()?;
+    Some((status.success(), output))
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/diff.rs"]
+mod tests;

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 mod shared_deps {
     pub use crate::classes::{FunctionComplexity, LineComplexity};
     pub use crate::refactor_plans::{
@@ -13,7 +13,7 @@ mod shared_deps {
 #[cfg(feature = "python")]
 use crate::classes::CodeComplexity;
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 use shared_deps::*;
 
 #[cfg(feature = "python")]
@@ -54,7 +54,7 @@ pub fn code_complexity(
     })
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn function_level_cognitive_complexity_shared(
     ast_body: &ast::Suite,
     code: &str,
@@ -133,13 +133,13 @@ pub fn function_level_cognitive_complexity_shared(
     (functions, complexity)
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn is_ignored(f: &ast::StmtFunctionDef, code: &str, no_ignore: bool) -> bool {
     let start_line = get_line_number(usize::from(f.range.start()), code);
     !no_ignore && has_noqa_complexipy(start_line, code)
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn analyze_function(
     node: &Stmt,
     f: &ast::StmtFunctionDef,
@@ -168,13 +168,13 @@ fn analyze_function(
     }
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 struct RecursionFinder<'a> {
     name: &'a str,
     found: Option<usize>,
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 impl<'a> ast::visitor::Visitor<'a> for RecursionFinder<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         if self.found.is_some() {
@@ -204,14 +204,14 @@ impl<'a> ast::visitor::Visitor<'a> for RecursionFinder<'a> {
     }
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn detect_direct_recursion(body: &[Stmt], name: &str, code: &str) -> Option<u64> {
     let mut finder = RecursionFinder { name, found: None };
     ast::visitor::walk_body(&mut finder, body);
     finder.found.map(|offset| get_line_number(offset, code))
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn empty_result() -> ComplexityResult {
     ComplexityResult {
         complexity: 0,
@@ -220,33 +220,33 @@ fn empty_result() -> ComplexityResult {
     }
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn push_line(result: &mut ComplexityResult, line: u64, complexity: u64) {
     result
         .line_complexities
         .push(LineComplexity { line, complexity });
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn absorb(result: &mut ComplexityResult, child: ComplexityResult) {
     result.complexity += child.complexity;
     result.line_complexities.extend(child.line_complexities);
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn absorb_with_regions(result: &mut ComplexityResult, child: ComplexityResult) {
     result.complexity += child.complexity;
     result.line_complexities.extend(child.line_complexities);
     result.regions.extend(child.regions);
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn finalize_region(result: &mut ComplexityResult, mut region: ComplexityRegion) {
     region.total += sum_region_child_totals(&region.children);
     result.regions.push(region);
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn count_line_bool_ops(
     result: &mut ComplexityResult,
     exprs: Vec<ast::Expr>,
@@ -261,7 +261,7 @@ fn count_line_bool_ops(
     push_line(result, line, complexity);
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn collect_suite(
     suite: &ast::Suite,
     nesting_level: u64,
@@ -278,7 +278,7 @@ fn collect_suite(
     result
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn sum_region_child_totals(children: &[ComplexityRegion]) -> u64 {
     children
         .iter()
@@ -287,7 +287,7 @@ fn sum_region_child_totals(children: &[ComplexityRegion]) -> u64 {
         .sum()
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn push_bool_region(
     regions: &mut Vec<ComplexityRegion>,
     line_start: u64,
@@ -309,7 +309,7 @@ fn push_bool_region(
     }
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn loop_complexity(
     control: ast::Expr,
     body: &ast::Suite,
@@ -358,7 +358,7 @@ fn loop_complexity(
     result
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn statement_cognitive_complexity_shared(
     statement: &Stmt,
     nesting_level: u64,

--- a/src/refactor_plans.rs
+++ b/src/refactor_plans.rs
@@ -1,10 +1,10 @@
 pub use crate::classes::{LineComplexity, RefactorPlan};
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 use crate::rules::RuleRegistry;
 use std::sync::OnceLock;
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum RegionKind {
     #[default]
@@ -17,7 +17,7 @@ pub enum RegionKind {
     With,
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 #[derive(Clone, Default)]
 pub struct ComplexityRegion {
     pub kind: RegionKind,
@@ -33,14 +33,14 @@ pub struct ComplexityRegion {
     pub children: Vec<ComplexityRegion>,
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub struct ComplexityResult {
     pub complexity: u64,
     pub line_complexities: Vec<LineComplexity>,
     pub regions: Vec<ComplexityRegion>,
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn build_refactor_plans(
     function_complexity: u64,
     regions: &[ComplexityRegion],

--- a/src/tests/cli/diff.rs
+++ b/src/tests/cli/diff.rs
@@ -1,0 +1,377 @@
+//! Wired in from `src/cli/utils/diff.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::tempdir;
+
+use crate::classes::FileComplexity;
+use crate::cli::types::{DiffEntry, DiffStatus};
+use crate::cli::utils::diff::{
+    compute_diff, compute_staged_diff, has_regressions, resolve_diff_flags,
+};
+
+const SIMPLE: &str = "def simple(x):\n    return x + 1\n";
+
+const WITH_IF: &str = "def with_if(x):\n    if x:\n        return 1\n    return 0\n";
+
+fn file_complexity(path: &str, file_name: &str, functions: &[(&str, u64)]) -> FileComplexity {
+    use crate::classes::FunctionComplexity;
+    FileComplexity {
+        path: path.to_string(),
+        file_name: file_name.to_string(),
+        functions: functions
+            .iter()
+            .map(|(name, complexity)| FunctionComplexity {
+                name: name.to_string(),
+                complexity: *complexity,
+                line_start: 1,
+                line_end: 2,
+                line_complexities: vec![],
+                refactor_plans: vec![],
+                additional_refactor_plans: 0,
+            })
+            .collect(),
+        complexity: 0,
+    }
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("git should run");
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+fn init_repo(dir: &Path) {
+    git(dir, &["init", "-q"]);
+    git(dir, &["config", "user.email", "test@example.com"]);
+    git(dir, &["config", "user.name", "Test"]);
+}
+
+fn commit_all(dir: &Path, message: &str) {
+    git(dir, &["add", "-A"]);
+    git(dir, &["commit", "-q", "-m", message]);
+}
+
+fn entry(file_path: &str, func_name: &str, old: Option<u64>, new: Option<u64>) -> DiffEntry {
+    DiffEntry {
+        file_path: file_path.to_string(),
+        func_name: func_name.to_string(),
+        old_complexity: old,
+        new_complexity: new,
+    }
+}
+
+#[test]
+fn status_new() {
+    assert_eq!(entry("a.py", "f", None, Some(5)).status(), DiffStatus::New);
+}
+
+#[test]
+fn status_removed() {
+    assert_eq!(
+        entry("a.py", "f", Some(5), None).status(),
+        DiffStatus::Removed
+    );
+}
+
+#[test]
+fn status_regressed() {
+    assert_eq!(
+        entry("a.py", "f", Some(3), Some(5)).status(),
+        DiffStatus::Regressed
+    );
+}
+
+#[test]
+fn status_improved() {
+    assert_eq!(
+        entry("a.py", "f", Some(5), Some(3)).status(),
+        DiffStatus::Improved
+    );
+}
+
+#[test]
+fn status_unchanged() {
+    assert_eq!(
+        entry("a.py", "f", Some(5), Some(5)).status(),
+        DiffStatus::Unchanged
+    );
+}
+
+#[test]
+fn delta_change_is_signed() {
+    assert_eq!(entry("a.py", "f", Some(3), Some(5)).delta(), Some(2));
+    assert_eq!(entry("a.py", "f", Some(5), Some(3)).delta(), Some(-2));
+    assert_eq!(entry("a.py", "f", Some(5), Some(5)).delta(), Some(0));
+    assert_eq!(entry("a.py", "f", None, Some(5)).delta(), None);
+    assert_eq!(entry("a.py", "f", Some(5), None).delta(), None);
+}
+
+#[test]
+fn compute_diff_marks_new_file_functions() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    fs::write(dir.path().join("README.md"), "placeholder").expect("should write");
+    commit_all(dir.path(), "initial");
+
+    let current = vec![file_complexity(
+        "src/example.py",
+        "example.py",
+        &[("simple", 2)],
+    )];
+    let entries = compute_diff(&current, "HEAD", dir.path().to_str().unwrap());
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].status(), DiffStatus::New);
+    assert_eq!(entries[0].old_complexity, None);
+    assert_eq!(entries[0].new_complexity, Some(2));
+}
+
+#[test]
+fn compute_diff_reports_regressed_and_improved() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    let src = dir.path().join("src");
+    fs::create_dir(&src).expect("should create");
+    fs::write(src.join("a.py"), WITH_IF).expect("should write");
+    fs::write(src.join("b.py"), WITH_IF).expect("should write");
+    commit_all(dir.path(), "initial");
+
+    let current = vec![
+        file_complexity("src/a.py", "a.py", &[("with_if", 5)]),
+        file_complexity("src/b.py", "b.py", &[("with_if", 0)]),
+    ];
+    let entries = compute_diff(&current, "HEAD", dir.path().to_str().unwrap());
+
+    let regressed = entries
+        .iter()
+        .find(|e| e.file_path == "src/a.py")
+        .expect("a entry");
+    assert_eq!(regressed.status(), DiffStatus::Regressed);
+    assert_eq!(regressed.old_complexity, Some(1));
+    assert_eq!(regressed.new_complexity, Some(5));
+
+    let improved = entries
+        .iter()
+        .find(|e| e.file_path == "src/b.py")
+        .expect("b entry");
+    assert_eq!(improved.status(), DiffStatus::Improved);
+    assert_eq!(improved.old_complexity, Some(1));
+    assert_eq!(improved.new_complexity, Some(0));
+}
+
+#[test]
+fn compute_diff_reports_removed_function() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    let src = dir.path().join("src");
+    fs::create_dir(&src).expect("should create");
+    fs::write(
+        src.join("a.py"),
+        "def keep(x):\n    return x\ndef gone(x):\n    return x\n",
+    )
+    .expect("should write");
+    commit_all(dir.path(), "initial");
+
+    let current = vec![file_complexity("src/a.py", "a.py", &[("keep", 0)])];
+    let entries = compute_diff(&current, "HEAD", dir.path().to_str().unwrap());
+
+    let removed = entries
+        .iter()
+        .find(|e| e.func_name == "gone")
+        .expect("gone entry");
+    assert_eq!(removed.status(), DiffStatus::Removed);
+    assert_eq!(removed.old_complexity, Some(0));
+    assert_eq!(removed.new_complexity, None);
+
+    let kept = entries
+        .iter()
+        .find(|e| e.func_name == "keep")
+        .expect("keep entry");
+    assert_eq!(kept.status(), DiffStatus::Unchanged);
+}
+
+#[test]
+fn compute_diff_git_error_skips_file() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    fs::write(dir.path().join("a.py"), SIMPLE).expect("should write");
+    commit_all(dir.path(), "initial");
+
+    let current = vec![file_complexity("a.py", "a.py", &[("simple", 2)])];
+    let entries = compute_diff(&current, "NONEXISTENT_REF", dir.path().to_str().unwrap());
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].status(), DiffStatus::New);
+}
+
+#[test]
+fn compute_diff_unparseable_old_content_skips_file() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    fs::write(dir.path().join("broken.py"), "def broken(:\n").expect("should write");
+    commit_all(dir.path(), "initial");
+
+    let current = vec![file_complexity("broken.py", "broken.py", &[("broken", 1)])];
+    let entries = compute_diff(&current, "HEAD", dir.path().to_str().unwrap());
+
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn resolve_git_path_strips_leading_components() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    let src = dir.path().join("src");
+    fs::create_dir(&src).expect("should create");
+    fs::write(src.join("example.py"), SIMPLE).expect("should write");
+    commit_all(dir.path(), "initial");
+
+    let current = vec![file_complexity(
+        "proj/src/example.py",
+        "example.py",
+        &[("simple", 2)],
+    )];
+    let entries = compute_diff(&current, "HEAD", dir.path().to_str().unwrap());
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].old_complexity, Some(0));
+}
+
+#[test]
+fn compute_staged_diff_returns_none_outside_repo() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = compute_staged_diff("HEAD", dir.path().to_str().unwrap());
+
+    assert_eq!(result, None);
+}
+
+#[test]
+fn compute_staged_diff_reports_new_staged_file() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    fs::write(dir.path().join("existing.py"), SIMPLE).expect("should write");
+    commit_all(dir.path(), "initial");
+
+    fs::write(dir.path().join("new.py"), WITH_IF).expect("should write");
+    git(dir.path(), &["add", "new.py"]);
+
+    let entries = compute_staged_diff("HEAD", dir.path().to_str().unwrap()).expect("should diff");
+    let new_entry = entries
+        .iter()
+        .find(|e| e.file_path == "new.py")
+        .expect("new entry");
+    assert_eq!(new_entry.status(), DiffStatus::New);
+    assert_eq!(new_entry.new_complexity, Some(1));
+}
+
+#[test]
+fn compute_staged_diff_reports_modified_file() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    fs::write(dir.path().join("a.py"), SIMPLE).expect("should write");
+    commit_all(dir.path(), "initial");
+
+    fs::write(
+        dir.path().join("a.py"),
+        "def simple(x):\n    if x:\n        return 1\n    return 0\n",
+    )
+    .expect("should write");
+    git(dir.path(), &["add", "a.py"]);
+
+    let entries = compute_staged_diff("HEAD", dir.path().to_str().unwrap()).expect("should diff");
+    let entry = entries
+        .iter()
+        .find(|e| e.file_path == "a.py")
+        .expect("entry");
+    assert_eq!(entry.old_complexity, Some(0));
+    assert_eq!(entry.new_complexity, Some(1));
+    assert_eq!(entry.status(), DiffStatus::Regressed);
+}
+
+#[test]
+fn compute_staged_diff_reports_deleted_file() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    fs::write(dir.path().join("gone.py"), WITH_IF).expect("should write");
+    commit_all(dir.path(), "initial");
+
+    fs::remove_file(dir.path().join("gone.py")).expect("should remove");
+    git(dir.path(), &["add", "-A"]);
+
+    let entries = compute_staged_diff("HEAD", dir.path().to_str().unwrap()).expect("should diff");
+    let entry = entries
+        .iter()
+        .find(|e| e.file_path == "gone.py")
+        .expect("entry");
+    assert_eq!(entry.status(), DiffStatus::Removed);
+    assert_eq!(entry.old_complexity, Some(1));
+    assert_eq!(entry.new_complexity, None);
+}
+
+#[test]
+fn compute_staged_diff_no_staged_files_returns_empty() {
+    let dir = tempdir().expect("tempdir should work");
+    init_repo(dir.path());
+    fs::write(dir.path().join("a.py"), SIMPLE).expect("should write");
+    commit_all(dir.path(), "initial");
+
+    let entries = compute_staged_diff("HEAD", dir.path().to_str().unwrap()).expect("should diff");
+
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn has_regressions_ratchet() {
+    assert!(has_regressions(&[entry("a.py", "f", Some(2), Some(6))], 5));
+    assert!(!has_regressions(&[entry("a.py", "f", Some(2), Some(5))], 5));
+    assert!(!has_regressions(&[entry("a.py", "f", Some(2), Some(4))], 5));
+    assert!(has_regressions(&[entry("a.py", "f", Some(8), Some(10))], 5));
+    assert!(has_regressions(&[entry("a.py", "f", None, Some(6))], 5));
+    assert!(!has_regressions(&[entry("a.py", "f", None, Some(5))], 5));
+    assert!(!has_regressions(&[entry("a.py", "f", Some(5), None)], 5));
+}
+
+#[test]
+fn resolve_diff_flags_staged_defaults_to_head() {
+    assert_eq!(
+        resolve_diff_flags(None, None, true),
+        (Some("HEAD".to_string()), None)
+    );
+    assert_eq!(
+        resolve_diff_flags(Some("dev".to_string()), None, true),
+        (Some("dev".to_string()), None)
+    );
+    assert_eq!(
+        resolve_diff_flags(None, Some("dev".to_string()), true),
+        (None, Some("dev".to_string()))
+    );
+}
+
+#[test]
+fn resolve_diff_flags_diff_only_wins() {
+    assert_eq!(
+        resolve_diff_flags(Some("dev".to_string()), Some("main".to_string()), false),
+        (None, Some("main".to_string()))
+    );
+}
+
+#[test]
+fn resolve_diff_flags_plain_passthrough() {
+    assert_eq!(
+        resolve_diff_flags(Some("dev".to_string()), None, false),
+        (Some("dev".to_string()), None)
+    );
+    assert_eq!(
+        resolve_diff_flags(None, Some("dev".to_string()), false),
+        (None, Some("dev".to_string()))
+    );
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 use regex::Regex;
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 use ruff_python_ast::{self as ast, Stmt};
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 use std::sync::OnceLock;
 
 #[cfg(any(feature = "python", feature = "cli"))]
@@ -315,7 +315,7 @@ pub fn get_repo_name(url: &str) -> PyResult<String> {
         .to_string())
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn is_decorator(statement: Stmt) -> bool {
     let mut ans = false;
     if let Stmt::FunctionDef(f) = statement
@@ -328,7 +328,7 @@ pub fn is_decorator(statement: Stmt) -> bool {
     ans
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn count_bool_ops(expr: ast::Expr, nesting_level: u64) -> u64 {
     let mut complexity: u64 = 0;
 
@@ -404,7 +404,7 @@ pub fn count_bool_ops(expr: ast::Expr, nesting_level: u64) -> u64 {
     complexity
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn count_comprehension(
     elements: &[ast::Expr],
     generators: &[ast::Comprehension],
@@ -429,7 +429,7 @@ fn count_comprehension(
     complexity
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 fn count_different_childs_type(expr: ast::Expr, prev_pr: ast::Expr) -> u64 {
     let mut complexity: u64 = 0;
 
@@ -468,14 +468,14 @@ fn count_different_childs_type(expr: ast::Expr, prev_pr: ast::Expr) -> u64 {
     complexity
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn get_line_number(byte_index: usize, code: &str) -> u64 {
     let before_slice = &code[..byte_index];
     let newline_count = before_slice.chars().filter(|&c| c == '\n').count();
     (newline_count + 1) as u64
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn get_column_number(byte_index: usize, code: &str) -> u64 {
     let before_slice = &code[..byte_index];
     let column_start = match before_slice.rfind('\n') {
@@ -490,7 +490,7 @@ pub fn get_column_number(byte_index: usize, code: &str) -> u64 {
 /// Returns `Some("# complexipy: ignore")` or `Some("# noqa: complexipy")`
 /// when the line contains the corresponding pattern (case-insensitive).
 /// Returns `None` if neither marker is found.
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn extract_comment_marker(line: &str) -> Option<String> {
     static IGNORE_RE: OnceLock<Regex> = OnceLock::new();
     static NOQA_RE: OnceLock<Regex> = OnceLock::new();
@@ -512,7 +512,7 @@ pub fn extract_comment_marker(line: &str) -> Option<String> {
 ///
 /// Returns `Some(comment_text)` when a marker is found that would
 /// trigger suppression, `None` otherwise.
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn find_noqa_comment(line_number: u64, code: &str) -> Option<String> {
     if line_number == 0 {
         return None;
@@ -574,7 +574,7 @@ pub fn find_noqa_comment(line_number: u64, code: &str) -> Option<String> {
     None
 }
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 pub fn has_noqa_complexipy(line_number: u64, code: &str) -> bool {
     find_noqa_comment(line_number, code).is_some()
 }


### PR DESCRIPTION
## What

Ports `utils/diff.py` — git diff computation, staged comparison, and ratchet regression detection — to Rust, as step 11 of the CLI migration in issue #224.

## Why

This is the largest step so far (~470 Python lines): git plumbing, content re-analysis, and the ratchet logic. The issue's open decision (git2 vs shell-out) was resolved via clarification: shell out to git, mirroring Python's subprocess semantics byte-for-byte.

## Changes

- `feat(cargo)` — cli feature gains `ruff_python_parser`, `ruff_python_ast`, `regex` (shared analysis now runs under the cli feature)
- `src/cognitive_complexity.rs`, `src/utils.rs`, `src/refactor_plans.rs` — shared analysis gating extended to `cli`
- `src/cli/types.rs` — `DiffEntry` activated: pub fields, `delta()` → `Option<i64>` (Python allows negative deltas), test derives
- `src/cli/utils/diff.rs` — `compute_diff`, `compute_staged_diff` (None outside a repo), `has_regressions` (ratchet), `resolve_diff_flags` (staged→HEAD, diff-only wins), git helpers via `std::process::Command` with timeouts and threaded pipe draining (no deadlock on large `git show` output), `resolve_git_path` (progressive prefix strip + basename lookup)
- Console rendering (`format_diff`, styles, summary) deferred to Step 13, per the Step 10 precedent
- Tests: `src/tests/cli/diff.rs` — 21 tests with real git repos (tempdir + init/commit): status/delta, new/regressed/improved/removed/unchanged, staged scenarios, ratchet, flag resolution, path resolution

Issue: #224