### PR TITLE
feat(cli): port ignored locations orchestration to rust (step 12)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore"]
 python = [
     "serde",
     "pyo3",

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
-#[cfg(any(feature = "python", feature = "wasm"))]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
 #[cfg_attr(
-    any(feature = "python", feature = "wasm"),
+    any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
 #[derive(Clone)]
@@ -23,7 +23,7 @@ pub struct LineComplexity {
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
 #[cfg_attr(
-    any(feature = "python", feature = "wasm"),
+    any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
 #[derive(Clone)]
@@ -39,7 +39,7 @@ pub struct CodeSuggestion {
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
 #[cfg_attr(
-    any(feature = "python", feature = "wasm"),
+    any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -53,7 +53,7 @@ pub enum RuleCategory {
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
 #[cfg_attr(
-    any(feature = "python", feature = "wasm"),
+    any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -68,7 +68,7 @@ pub enum Applicability {
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
 #[cfg_attr(
-    any(feature = "python", feature = "wasm"),
+    any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
 #[derive(Clone)]
@@ -99,7 +99,7 @@ pub struct RefactorPlan {
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
 #[cfg_attr(
-    any(feature = "python", feature = "wasm"),
+    any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
 #[derive(Clone)]
@@ -118,12 +118,15 @@ pub struct FunctionComplexity {
     pub additional_refactor_plans: u64,
 }
 
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 #[cfg_attr(
     feature = "python",
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
-#[cfg_attr(feature = "python", derive(Serialize, Deserialize, Clone))]
+#[cfg_attr(
+    any(feature = "python", feature = "wasm", feature = "cli"),
+    derive(Serialize, Deserialize, Clone)
+)]
 pub struct FileComplexity {
     pub path: String,
     pub file_name: String,
@@ -137,7 +140,7 @@ pub struct FileComplexity {
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
 #[cfg_attr(
-    any(feature = "python", feature = "wasm"),
+    any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
 #[derive(Clone)]
@@ -148,12 +151,15 @@ pub struct CodeComplexity {
     pub version: String,
 }
 
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 #[cfg_attr(
     feature = "python",
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
-#[cfg_attr(feature = "python", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    any(feature = "python", feature = "wasm", feature = "cli"),
+    derive(Serialize, Deserialize)
+)]
 #[derive(Clone)]
 pub struct IgnoredLocation {
     pub path: String,
@@ -161,12 +167,15 @@ pub struct IgnoredLocation {
     pub comment: String,
 }
 
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]
 #[cfg_attr(
     feature = "python",
     pyclass(module = "complexipy", get_all, from_py_object)
 )]
-#[cfg_attr(feature = "python", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    any(feature = "python", feature = "wasm", feature = "cli"),
+    derive(Serialize, Deserialize)
+)]
 #[derive(Clone)]
 pub struct RemovableIgnore {
     pub path: String,

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -2,6 +2,7 @@ pub mod cache;
 pub mod config;
 pub mod diff;
 pub mod gitlab;
+pub mod ignored;
 pub mod paths;
 pub mod sarif;
 pub mod snapshot;

--- a/src/cli/utils/ignored.rs
+++ b/src/cli/utils/ignored.rs
@@ -1,0 +1,89 @@
+use std::fs;
+
+use crate::classes::{IgnoredLocation, RemovableIgnore};
+use crate::cli::types::OutputFormat;
+use crate::cli::utils::paths::resolve_output_paths;
+use crate::runner::{
+    collect_all_ignored_locations_shared, collect_removable_ignored_locations_shared,
+};
+use crate::utils::ExportError;
+
+pub fn handle_report_ignored(
+    report_ignored: bool,
+    paths: &[String],
+    exclude: &[String],
+    output_formats: &[OutputFormat],
+    output: Option<&str>,
+    _no_ignore: bool,
+    invocation_path: &str,
+) -> Result<(Vec<IgnoredLocation>, Option<String>), ExportError> {
+    if !report_ignored {
+        return Ok((Vec::new(), None));
+    }
+
+    let (ignored_locations, _) =
+        collect_all_ignored_locations_shared(paths, exclude, invocation_path)
+            .map_err(ExportError::Io)?;
+
+    let ignored_json_path =
+        if output_formats.contains(&OutputFormat::Json) && !ignored_locations.is_empty() {
+            let ignored_output_paths = resolve_output_paths(
+                &[OutputFormat::Json],
+                output,
+                std::path::Path::new(invocation_path),
+            )
+            .map_err(|e| ExportError::Io(e.to_string()))?;
+            let ignored_output_path = &ignored_output_paths[0].1;
+            let ignored_dir = std::path::Path::new(ignored_output_path)
+                .parent()
+                .unwrap_or(std::path::Path::new("."));
+            let ignored_json_path = ignored_dir.join("complexipy-ignored.json");
+
+            let ignored_data: Vec<serde_json::Value> = ignored_locations
+                .iter()
+                .map(|location| {
+                    serde_json::json!({
+                        "path": location.path,
+                        "line": location.line,
+                        "comment": location.comment,
+                    })
+                })
+                .collect();
+            let serialized = serde_json::to_string_pretty(&ignored_data).map_err(|e| {
+                ExportError::Serialize(format!("Failed to serialize ignored locations: {}", e))
+            })?;
+            fs::write(&ignored_json_path, format!("{}\n", serialized)).map_err(|e| {
+                ExportError::Io(format!(
+                    "Failed to write ignored locations to {}: {}",
+                    ignored_json_path.display(),
+                    e
+                ))
+            })?;
+
+            Some(ignored_json_path.to_string_lossy().into_owned())
+        } else {
+            None
+        };
+
+    Ok((ignored_locations, ignored_json_path))
+}
+
+pub fn handle_removable_ignores(
+    paths: &[String],
+    exclude: &[String],
+    max_complexity_allowed: u64,
+    invocation_path: &str,
+) -> Vec<RemovableIgnore> {
+    collect_removable_ignored_locations_shared(
+        paths,
+        exclude,
+        max_complexity_allowed,
+        invocation_path,
+    )
+    .map(|(removable_ignores, _)| removable_ignores)
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/ignored.rs"]
+mod tests;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,2 +1,2 @@
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "cli"))]
 pub mod exclude;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub(crate) mod cognitive_complexity;
 mod helpers;
 mod refactor_plans;
 mod rules;
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "cli"))]
 mod runner;
 mod utils;
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,18 +1,33 @@
 use crate::classes::{FileComplexity, IgnoredLocation, RemovableIgnore};
-use crate::cognitive_complexity::{code_complexity, function_level_cognitive_complexity_shared};
+use crate::cognitive_complexity::function_level_cognitive_complexity_shared;
 use crate::helpers::exclude::get_paths_to_process;
-use crate::utils::{collect_ignored_locations, filter_removable_ignores, get_repo_name};
-use indicatif::ProgressBar;
-use indicatif::ProgressStyle;
-use pyo3::exceptions::PyValueError;
-use pyo3::prelude::*;
-use regex::Regex;
+use crate::utils::{collect_ignored_locations, filter_removable_ignores};
 use ruff_python_parser::parse_module;
-use std::env;
 use std::path;
+
+#[cfg(feature = "python")]
+use crate::cognitive_complexity::code_complexity;
+#[cfg(feature = "python")]
+use crate::utils::get_repo_name;
+#[cfg(feature = "python")]
+use indicatif::ProgressBar;
+#[cfg(feature = "python")]
+use indicatif::ProgressStyle;
+#[cfg(feature = "python")]
+use pyo3::exceptions::PyValueError;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+#[cfg(feature = "python")]
+use regex::Regex;
+#[cfg(feature = "python")]
+use std::env;
+#[cfg(feature = "python")]
 use std::process;
+#[cfg(feature = "python")]
 use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(feature = "python")]
 use std::thread;
+#[cfg(feature = "python")]
 use tempfile::tempdir;
 
 struct ProcessOptions {
@@ -24,6 +39,7 @@ struct ProcessOptions {
 
 type ComplexitiesAndFailedPaths = (Vec<FileComplexity>, Vec<String>);
 
+#[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(signature = (paths, quiet, exclude, check_script=false, no_ignore=false, invocation_path="."))]
 pub fn main(
@@ -69,6 +85,7 @@ pub fn main(
     Ok((successful, failed_paths))
 }
 
+#[cfg(feature = "python")]
 fn process_path(
     path: &str,
     is_dir: bool,
@@ -165,6 +182,7 @@ fn process_path(
     Ok((file_complexities, failed_paths))
 }
 
+#[cfg(feature = "python")]
 fn evaluate_dir(
     path: &str,
     opts: &ProcessOptions,
@@ -232,6 +250,7 @@ fn evaluate_dir(
     (complexities, failed_paths)
 }
 
+#[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(signature = (file_path, base_path, check_script=false, no_ignore=false))]
 pub fn file_complexity(
@@ -268,21 +287,19 @@ pub fn file_complexity(
     })
 }
 
-#[pyfunction]
-#[pyo3(signature = (file_path, base_path))]
+#[cfg(any(feature = "python", feature = "cli"))]
 pub fn collect_file_ignored_locations(
     file_path: &str,
     base_path: &str,
-) -> PyResult<Vec<IgnoredLocation>> {
+) -> Result<Vec<IgnoredLocation>, String> {
     let path = path::Path::new(file_path);
     let relative_path = path
         .strip_prefix(base_path)
         .ok()
         .and_then(|p| p.to_str())
         .unwrap_or(file_path);
-    let code = std::fs::read_to_string(file_path).map_err(|e| {
-        PyValueError::new_err(format!("Failed to read file '{}': {}", file_path, e))
-    })?;
+    let code = std::fs::read_to_string(file_path)
+        .map_err(|e| format!("Failed to read file '{}': {}", file_path, e))?;
     let locations = collect_ignored_locations(&code);
     Ok(locations
         .into_iter()
@@ -294,6 +311,16 @@ pub fn collect_file_ignored_locations(
         .collect())
 }
 
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn collect_all_ignored_locations_shared(
+    paths: &[String],
+    exclude: &[String],
+    _invocation_path: &str,
+) -> Result<(Vec<IgnoredLocation>, Vec<String>), String> {
+    collect_locations(paths, exclude, collect_file_ignored_locations)
+}
+
+#[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(signature = (paths, exclude, invocation_path="."))]
 pub fn collect_all_ignored_locations(
@@ -301,12 +328,23 @@ pub fn collect_all_ignored_locations(
     exclude: Vec<String>,
     invocation_path: &str,
 ) -> PyResult<(Vec<IgnoredLocation>, Vec<String>)> {
-    let _invocation_dir = path::Path::new(invocation_path)
-        .canonicalize()
-        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
-    collect_locations(&paths, &exclude, collect_file_ignored_locations)
+    collect_all_ignored_locations_shared(&paths, &exclude, invocation_path)
+        .map_err(PyValueError::new_err)
 }
 
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn collect_removable_ignored_locations_shared(
+    paths: &[String],
+    exclude: &[String],
+    max_complexity_allowed: u64,
+    _invocation_path: &str,
+) -> Result<(Vec<RemovableIgnore>, Vec<String>), String> {
+    collect_locations(paths, exclude, |file_path, base_dir| {
+        collect_removable_ignores_from_file(file_path, base_dir, max_complexity_allowed)
+    })
+}
+
+#[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(signature = (paths, exclude, max_complexity_allowed, invocation_path="."))]
 pub fn collect_removable_ignored_locations(
@@ -315,12 +353,13 @@ pub fn collect_removable_ignored_locations(
     max_complexity_allowed: u64,
     invocation_path: &str,
 ) -> PyResult<(Vec<RemovableIgnore>, Vec<String>)> {
-    let _invocation_dir = path::Path::new(invocation_path)
-        .canonicalize()
-        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
-    collect_locations(&paths, &exclude, |file_path, base_dir| {
-        collect_removable_ignores_from_file(file_path, base_dir, max_complexity_allowed)
-    })
+    collect_removable_ignored_locations_shared(
+        &paths,
+        &exclude,
+        max_complexity_allowed,
+        invocation_path,
+    )
+    .map_err(PyValueError::new_err)
 }
 
 trait Located {
@@ -339,14 +378,15 @@ impl Located for RemovableIgnore {
     }
 }
 
+#[cfg(any(feature = "python", feature = "cli"))]
 fn collect_locations<T, F>(
     paths: &[String],
     exclude: &[String],
     collect_file: F,
-) -> PyResult<(Vec<T>, Vec<String>)>
+) -> Result<(Vec<T>, Vec<String>), String>
 where
     T: Located,
-    F: Fn(&str, &str) -> PyResult<Vec<T>> + Copy,
+    F: Fn(&str, &str) -> Result<Vec<T>, String> + Copy,
 {
     let mut all_locations = Vec::new();
     let mut failed_paths = Vec::new();
@@ -354,12 +394,7 @@ where
     for path_str in paths {
         let path_obj = path::Path::new(path_str);
 
-        if is_repo_url(path_str) {
-            match collect_from_url(path_str, exclude, collect_file) {
-                Ok(locs) => all_locations.extend(locs),
-                Err(_) => failed_paths.push(path_str.to_string()),
-            }
-        } else if path_obj.is_dir() {
+        if path_obj.is_dir() {
             let files = match get_paths_to_process(path_str, exclude.to_vec()) {
                 Ok(paths) => paths,
                 Err(e) => {
@@ -393,6 +428,7 @@ where
     Ok((all_locations, failed_paths))
 }
 
+#[cfg(feature = "python")]
 fn is_repo_url(path: &str) -> bool {
     static REPO_URL_RE: OnceLock<Regex> = OnceLock::new();
     let re = REPO_URL_RE.get_or_init(|| {
@@ -402,85 +438,24 @@ fn is_repo_url(path: &str) -> bool {
     re.is_match(path)
 }
 
-fn clone_repo_to_tempdir(url: &str) -> PyResult<(tempfile::TempDir, String)> {
-    let dir = tempdir()?;
-    let repo_name = get_repo_name(url)?;
-    env::set_current_dir(&dir)?;
-    let cloning_done = Arc::new(Mutex::new(false));
-    let cloning_done_clone = Arc::clone(&cloning_done);
-    let path_clone = url.to_owned();
-
-    thread::spawn(move || {
-        let _ = process::Command::new("git")
-            .args(["clone", &path_clone])
-            .output();
-        if let Ok(mut done) = cloning_done_clone.lock() {
-            *done = true;
-        }
-    });
-
-    loop {
-        match cloning_done.lock() {
-            Ok(done) if *done => break,
-            Ok(_) => {
-                thread::sleep(std::time::Duration::from_millis(100));
-            }
-            Err(_) => {
-                return Err(PyValueError::new_err("Failed to track cloning progress"));
-            }
-        }
-    }
-
-    let repo_path = dir.path().join(&repo_name).to_string_lossy().to_string();
-    Ok((dir, repo_path))
-}
-
-fn collect_from_url<T, F>(url: &str, exclude: &[String], collect_file: F) -> PyResult<Vec<T>>
-where
-    F: Fn(&str, &str) -> PyResult<Vec<T>>,
-{
-    let (dir, repo_path) = clone_repo_to_tempdir(url)?;
-    let files =
-        get_paths_to_process(&repo_path, exclude.to_vec()).map_err(PyValueError::new_err)?;
-    let base_dir = path::Path::new(&repo_path)
-        .canonicalize()
-        .unwrap_or_else(|_| path::Path::new(&repo_path).to_path_buf())
-        .parent()
-        .unwrap_or(path::Path::new("."))
-        .to_string_lossy()
-        .replace('\\', "/");
-
-    let mut locations = Vec::new();
-    for file_path in &files {
-        if let Ok(locs) = collect_file(file_path, &base_dir) {
-            locations.extend(locs);
-        }
-    }
-
-    dir.close()?;
-    Ok(locations)
-}
-
 fn collect_removable_ignores_from_file(
     file_path: &str,
     base_path: &str,
     max_complexity_allowed: u64,
-) -> PyResult<Vec<RemovableIgnore>> {
+) -> Result<Vec<RemovableIgnore>, String> {
     let path = path::Path::new(file_path);
     let relative_path = path
         .strip_prefix(base_path)
         .ok()
         .and_then(|p| p.to_str())
         .unwrap_or(file_path);
-    let code = std::fs::read_to_string(file_path).map_err(|e| {
-        PyValueError::new_err(format!("Failed to read file '{}': {}", file_path, e))
-    })?;
+    let code = std::fs::read_to_string(file_path)
+        .map_err(|e| format!("Failed to read file '{}': {}", file_path, e))?;
     let locations = collect_ignored_locations(&code);
     if locations.is_empty() {
         return Ok(vec![]);
     }
-    let parsed = parse_module(&code)
-        .map_err(|e| PyValueError::new_err(format!("Failed to parse code: {}", e)))?;
+    let parsed = parse_module(&code).map_err(|e| format!("Failed to parse code: {}", e))?;
     let ast_body = parsed.into_suite();
     let (functions, _) =
         function_level_cognitive_complexity_shared(&ast_body, &code, false, true, false);

--- a/src/tests/cli/ignored.rs
+++ b/src/tests/cli/ignored.rs
@@ -1,0 +1,136 @@
+//! Wired in from `src/cli/utils/ignored.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::fs;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+use crate::cli::types::OutputFormat;
+use crate::cli::utils::ignored::{handle_removable_ignores, handle_report_ignored};
+
+const SIMPLE_MARKED: &str = "def simple(x):  # complexipy: ignore\n    return x + 1\n";
+
+const COMPLEX_MARKED: &str = "def complex_fn(data):  # complexipy: ignore\n    if data:\n        for item in data:\n            if item:\n                return item\n    return None\n";
+
+fn marked_file(dir: &std::path::Path, name: &str, content: &str) -> String {
+    fs::write(dir.join(name), content).expect("should write");
+    dir.join(name).to_string_lossy().into_owned()
+}
+
+#[test]
+fn report_disabled_returns_empty() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = marked_file(dir.path(), "a.py", SIMPLE_MARKED);
+
+    let (locations, json_path) = handle_report_ignored(
+        false,
+        &[file],
+        &[],
+        &[OutputFormat::Json],
+        None,
+        false,
+        dir.path().to_str().unwrap(),
+    )
+    .expect("should succeed");
+
+    assert!(locations.is_empty());
+    assert_eq!(json_path, None);
+}
+
+#[test]
+fn report_writes_ignored_json_next_to_output() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = marked_file(dir.path(), "a.py", SIMPLE_MARKED);
+
+    let (locations, json_path) = handle_report_ignored(
+        true,
+        &[file],
+        &[],
+        &[OutputFormat::Json],
+        None,
+        false,
+        dir.path().to_str().unwrap(),
+    )
+    .expect("should succeed");
+
+    assert_eq!(locations.len(), 1);
+    assert_eq!(locations[0].line, 1);
+    assert_eq!(locations[0].comment, "# complexipy: ignore");
+
+    let expected_path = dir.path().join("complexipy-ignored.json");
+    assert_eq!(
+        json_path,
+        Some(expected_path.to_string_lossy().into_owned())
+    );
+    let content = fs::read_to_string(&expected_path).expect("should read");
+    assert!(content.ends_with('\n'));
+    let parsed: Vec<Value> = serde_json::from_str(&content).expect("should parse");
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0]["line"], 1);
+    assert_eq!(parsed[0]["comment"], "# complexipy: ignore");
+    assert!(parsed[0]["path"].as_str().expect("path").ends_with("a.py"));
+}
+
+#[test]
+fn report_without_json_format_writes_no_file() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = marked_file(dir.path(), "a.py", SIMPLE_MARKED);
+
+    let (locations, json_path) = handle_report_ignored(
+        true,
+        &[file],
+        &[],
+        &[OutputFormat::Csv],
+        None,
+        false,
+        dir.path().to_str().unwrap(),
+    )
+    .expect("should succeed");
+
+    assert_eq!(locations.len(), 1);
+    assert_eq!(json_path, None);
+    assert!(!dir.path().join("complexipy-ignored.json").exists());
+}
+
+#[test]
+fn report_without_comments_writes_no_file() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = marked_file(dir.path(), "a.py", "def plain(x):\n    return x\n");
+
+    let (locations, json_path) = handle_report_ignored(
+        true,
+        &[file],
+        &[],
+        &[OutputFormat::Json],
+        None,
+        false,
+        dir.path().to_str().unwrap(),
+    )
+    .expect("should succeed");
+
+    assert!(locations.is_empty());
+    assert_eq!(json_path, None);
+}
+
+#[test]
+fn removable_ignores_below_threshold() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = marked_file(dir.path(), "a.py", SIMPLE_MARKED);
+
+    let removable = handle_removable_ignores(&[file], &[], 15, dir.path().to_str().unwrap());
+
+    assert_eq!(removable.len(), 1);
+    assert_eq!(removable[0].function, "simple");
+    assert_eq!(removable[0].complexity, 0);
+    assert_eq!(removable[0].line, 1);
+}
+
+#[test]
+fn removable_ignores_above_threshold_excluded() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = marked_file(dir.path(), "a.py", COMPLEX_MARKED);
+
+    let removable = handle_removable_ignores(&[file], &[], 2, dir.path().to_str().unwrap());
+
+    assert!(removable.is_empty());
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::sync::OnceLock;
 
 #[cfg(any(feature = "python", feature = "cli"))]
 mod export_deps {
-    pub use crate::classes::FileComplexity;
+    pub use crate::classes::{FileComplexity, FunctionComplexity};
     pub use csv::Writer;
     pub use serde_json;
     pub use std::fs::File;
@@ -17,13 +17,15 @@ mod export_deps {
 #[cfg(feature = "python")]
 mod python_deps {
     pub use super::export_deps::*;
-    pub use crate::classes::FunctionComplexity;
     pub use pyo3::exceptions::{PyIOError, PyValueError};
     pub use pyo3::prelude::*;
 }
 
 #[cfg(feature = "python")]
 use python_deps::*;
+
+#[cfg(all(feature = "cli", not(feature = "python")))]
+use export_deps::*;
 
 #[cfg(any(feature = "python", feature = "cli"))]
 use std::fmt;
@@ -582,7 +584,7 @@ pub fn has_noqa_complexipy(line_number: u64, code: &str) -> bool {
 /// Collect ignored locations from code, only reporting markers that
 /// actually suppress a function definition (i.e., are adjacent to `def`
 /// or `@decorator` lines).
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "cli"))]
 pub fn collect_ignored_locations(code: &str) -> Vec<(u64, String)> {
     let mut results = Vec::new();
     let lines: Vec<&str> = code.lines().collect();
@@ -648,7 +650,7 @@ pub fn collect_ignored_locations(code: &str) -> Vec<(u64, String)> {
 ///
 /// Returns `(line, comment, function_name, complexity)` for each removable
 /// marker; the function's complexity is measured without the marker applied.
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "cli"))]
 pub fn filter_removable_ignores(
     locations: &[(u64, String)],
     functions: &[FunctionComplexity],


### PR DESCRIPTION
## What

Ports `utils/ignored.py` — the ignored-locations and removable-ignores orchestration — to Rust, as step 12 of the CLI migration in issue #224, including the de-PyO3 of the collector machinery and the URL-run drop per the deprecation policy.

## Why

The orchestration is thin (~80 Python lines), but the FFI collectors it calls were pyo3-bound in the python-gated `runner.rs`. This change opens the collector machinery to the cli feature and ports the orchestration. Per the deprecation policy, URL-run support is not ported to the CLI walker.

## Changes

- `src/runner.rs` — collectors de-PyO3'd: `collect_locations`, `collect_file_ignored_locations`, `collect_removable_ignores_from_file` → `Result<_, String>`; URL branch and `is_repo_url` dropped from the shared walker; `collect_from_url` removed (its only caller was the URL branch); `clone_repo_to_tempdir` removed (dead — the Python CLI's URL analysis lives inline in `process_path` and is unaffected); pyfunctions + analysis fns explicitly python-gated
- `src/classes.rs`, `src/helpers.rs`, `src/utils.rs`, `src/lib.rs` — gating opened to `cli` (FileComplexity, IgnoredLocation, RemovableIgnore, exclude helper, ignore-location helpers, runner module); serde derives extended
- `feat(cargo)` — `ignore` in the cli feature
- `src/cli/utils/ignored.rs` — `handle_report_ignored` (collect + `complexipy-ignored.json` export via Step 4's `resolve_output_paths`, returns data + written path) and `handle_removable_ignores` (data collection); console rendering deferred to Step 13
- `src/tests/cli/ignored.rs` — 6 tests: disabled, JSON write shape + trailing newline, no-json-format, no-comments, removable thresholds

Issue: #224