### PR TITLE
feat(cli): port output display to rust (step 13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +104,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +166,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -206,6 +237,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "comfy-table"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136c8c4c3823846e8ba6d4bda011b4e5d5827b8bb0ac26c31f9ab31abe9f54f2"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,12 +267,14 @@ version = "7.0.1"
 dependencies = [
  "blake2",
  "clap",
+ "comfy-table",
  "console_error_panic_hook",
  "csv",
  "globset",
  "ignore",
  "indicatif",
  "js-sys",
+ "owo-colors",
  "pyo3",
  "regex",
  "ruff_python_ast",
@@ -239,6 +283,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "sha2",
+ "syntect",
  "tempfile",
  "toml",
  "wasm-bindgen",
@@ -300,6 +345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +377,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -356,6 +433,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive-where"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +458,15 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -410,6 +502,28 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -641,10 +755,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -688,6 +823,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +841,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "number_prefix"
@@ -714,6 +865,57 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "phf"
@@ -754,6 +956,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "pori"
 version = "0.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +988,12 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -865,6 +1092,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +1165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1068,6 +1313,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,6 +1399,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1463,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1520,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1312,6 +1626,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -1508,6 +1828,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1851,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1696,6 +2038,15 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore", "dep:comfy-table", "dep:owo-colors", "dep:syntect"]
 python = [
     "serde",
     "pyo3",
@@ -75,6 +75,9 @@ toml = { version = "1.1.4", optional = true }
 clap = { version = "4.6.6", features = ["derive"], optional = true }
 blake2 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }
+comfy-table = { version = "8.0", optional = true }
+owo-colors = { version = "4.3", optional = true }
+syntect = { version = "5.3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -26,7 +26,7 @@ pub struct LineComplexity {
     any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CodeSuggestion {
     pub replacement: String,
     pub applicability: Applicability,
@@ -71,7 +71,7 @@ pub enum Applicability {
     any(feature = "python", feature = "wasm", feature = "cli"),
     derive(Serialize, Deserialize)
 )]
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RefactorPlan {
     pub kind: String,
     pub title: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
 pub mod args;
+pub mod output;
 pub mod types;
 pub mod utils;

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,0 +1,160 @@
+pub mod diff;
+pub mod messages;
+pub mod refactor;
+pub mod render;
+pub mod rows;
+
+use std::collections::HashMap;
+
+use crate::classes::FileComplexity;
+use crate::cli::output::render::{SummaryOptions, output_summary};
+use crate::cli::output::rows::has_success_functions;
+use crate::cli::types::{OutputFormat, Sort};
+use crate::cli::utils::cache::remember_previous_functions;
+use crate::cli::utils::gitlab::store_gitlab;
+use crate::cli::utils::paths::resolve_output_paths;
+use crate::cli::utils::sarif::store_sarif;
+use crate::utils::{ExportError, output_csv_shared, output_json_shared};
+
+pub struct DisplayOptions<'a> {
+    pub files_complexities: &'a [FileComplexity],
+    pub paths: &'a [String],
+    pub failed: bool,
+    pub sort: Sort,
+    pub ignore_complexity: bool,
+    pub max_complexity_allowed: u64,
+    pub active_snapshot_map: Option<&'a HashMap<(String, String, String), u64>>,
+    pub quiet: bool,
+    pub plain: bool,
+    pub invocation_path: &'a str,
+    pub cache_dir: Option<&'a str>,
+    pub top: Option<u64>,
+    pub suggest_refactors: bool,
+}
+
+pub fn handle_display(options: DisplayOptions) -> (bool, String) {
+    let DisplayOptions {
+        files_complexities,
+        paths,
+        failed,
+        sort,
+        ignore_complexity,
+        max_complexity_allowed,
+        active_snapshot_map,
+        quiet,
+        plain,
+        invocation_path,
+        cache_dir,
+        top,
+        suggest_refactors,
+    } = options;
+
+    let previous_functions = if !files_complexities.is_empty() {
+        remember_previous_functions(invocation_path, paths, files_complexities, cache_dir)
+    } else {
+        None
+    };
+
+    if quiet {
+        let has_success = has_success_functions(
+            files_complexities,
+            max_complexity_allowed,
+            active_snapshot_map,
+        );
+        return (has_success, String::new());
+    }
+
+    let effective_sort = if top.is_some() { Sort::Desc } else { sort };
+    let (has_success, output) = output_summary(SummaryOptions {
+        files: files_complexities,
+        failed_only: failed,
+        sort: effective_sort,
+        ignore_complexity,
+        max_complexity: max_complexity_allowed,
+        previous_functions: previous_functions.as_ref(),
+        snapshot_map: active_snapshot_map,
+        plain,
+        top,
+        suggest_refactors,
+        invocation_path,
+    });
+    (has_success, output)
+}
+
+pub struct StorageOptions<'a> {
+    pub output_formats: &'a [OutputFormat],
+    pub output: Option<&'a str>,
+    pub files_complexities: &'a [FileComplexity],
+    pub sort: Sort,
+    pub show_details: bool,
+    pub max_complexity: u64,
+    pub invocation_path: &'a str,
+    pub suggest_refactors: bool,
+}
+
+pub fn handle_results_storage(options: StorageOptions) -> Result<Vec<String>, ExportError> {
+    let StorageOptions {
+        output_formats,
+        output,
+        files_complexities,
+        sort,
+        show_details,
+        max_complexity,
+        invocation_path,
+        suggest_refactors,
+    } = options;
+
+    let output_paths = resolve_output_paths(
+        output_formats,
+        output,
+        std::path::Path::new(invocation_path),
+    )
+    .map_err(|error| ExportError::Io(error.to_string()))?;
+    let mut saved_lines = Vec::new();
+
+    for (output_format, output_path) in output_paths {
+        match output_format {
+            OutputFormat::Csv => output_csv_shared(
+                &output_path,
+                files_complexities.to_vec(),
+                sort_value(&sort),
+                show_details,
+                max_complexity,
+            )?,
+            OutputFormat::Json => output_json_shared(
+                &output_path,
+                files_complexities.to_vec(),
+                show_details,
+                max_complexity,
+                suggest_refactors,
+            )?,
+            OutputFormat::Gitlab => store_gitlab(
+                &output_path,
+                files_complexities,
+                max_complexity,
+                suggest_refactors,
+            )?,
+            OutputFormat::Sarif => store_sarif(
+                &output_path,
+                files_complexities,
+                max_complexity,
+                suggest_refactors,
+            )?,
+        }
+        saved_lines.push(format!("Results saved at {}", output_path));
+    }
+
+    Ok(saved_lines)
+}
+
+fn sort_value(sort: &Sort) -> &'static str {
+    match sort {
+        Sort::Asc => "asc",
+        Sort::Desc => "desc",
+        Sort::FileName => "file_name",
+    }
+}
+
+pub fn effective_sort_for_display(sort: Sort, top: Option<u64>) -> Sort {
+    if top.is_some() { Sort::Desc } else { sort }
+}

--- a/src/cli/output/diff.rs
+++ b/src/cli/output/diff.rs
@@ -1,0 +1,132 @@
+use comfy_table::{Cell, Table};
+use owo_colors::OwoColorize;
+
+use crate::cli::output::render::rule;
+use crate::cli::types::{DiffEntry, DiffStatus};
+
+pub fn format_diff(entries: &[DiffEntry], git_ref: &str) -> String {
+    let changed: Vec<&DiffEntry> = entries
+        .iter()
+        .filter(|entry| {
+            matches!(
+                entry.status(),
+                DiffStatus::Regressed
+                    | DiffStatus::Improved
+                    | DiffStatus::New
+                    | DiffStatus::Removed
+            )
+        })
+        .collect();
+
+    if changed.is_empty() {
+        return format!("No functions changed relative to {}.", git_ref);
+    }
+
+    let mut table = Table::new();
+    table.set_header(vec!["Status", "Location", "Change"]);
+    for entry in changed.iter().copied() {
+        table.add_row(vec![
+            Cell::new(status_style(&entry.status())),
+            Cell::new(format!("{}::{}", entry.file_path, entry.func_name)),
+            Cell::new(format_change(entry)),
+        ]);
+    }
+
+    format!(
+        "\n{}\n{}\n\nNet: {}",
+        rule(&format!("Complexity diff (vs {})", git_ref)),
+        table,
+        build_diff_summary(&changed)
+    )
+}
+
+fn status_style(status: &DiffStatus) -> String {
+    match status {
+        DiffStatus::Regressed => "REGRESSED".red().bold().to_string(),
+        DiffStatus::Improved => "IMPROVED".green().bold().to_string(),
+        DiffStatus::New => "NEW".yellow().bold().to_string(),
+        DiffStatus::Removed => "REMOVED".dimmed().to_string(),
+        DiffStatus::Unchanged => "UNCHANGED".to_string(),
+    }
+}
+
+fn format_change(entry: &DiffEntry) -> String {
+    match entry.status() {
+        DiffStatus::New => format!("{}  (new)", entry.new_complexity.unwrap_or_default())
+            .yellow()
+            .bold()
+            .to_string(),
+        DiffStatus::Removed => format!("{}  (removed)", entry.old_complexity.unwrap_or_default())
+            .dimmed()
+            .to_string(),
+        DiffStatus::Regressed => {
+            let delta = entry.delta().unwrap_or_default();
+            format!(
+                "{} \u{2192} {}  ({:+})",
+                entry.old_complexity.unwrap_or_default(),
+                entry.new_complexity.unwrap_or_default(),
+                delta
+            )
+            .red()
+            .to_string()
+        }
+        DiffStatus::Improved => {
+            let delta = entry.delta().unwrap_or_default();
+            format!(
+                "{} \u{2192} {}  ({:+})",
+                entry.old_complexity.unwrap_or_default(),
+                entry.new_complexity.unwrap_or_default(),
+                delta
+            )
+            .green()
+            .to_string()
+        }
+        DiffStatus::Unchanged => {
+            let delta = entry.delta().unwrap_or_default();
+            format!(
+                "{} \u{2192} {}  ({})",
+                entry.old_complexity.unwrap_or_default(),
+                entry.new_complexity.unwrap_or_default(),
+                delta
+            )
+        }
+    }
+}
+
+fn build_diff_summary(changed: &[&DiffEntry]) -> String {
+    let count_for = |status: DiffStatus| {
+        changed
+            .iter()
+            .filter(|entry| entry.status() == status)
+            .count()
+    };
+
+    let labels: [(DiffStatus, &str); 4] = [
+        (DiffStatus::Regressed, "regressed"),
+        (DiffStatus::Improved, "improved"),
+        (DiffStatus::New, "new"),
+        (DiffStatus::Removed, "removed"),
+    ];
+
+    let parts: Vec<String> = labels
+        .iter()
+        .filter_map(|(status, label)| {
+            let count = count_for(*status);
+            if count == 0 {
+                None
+            } else {
+                Some(format!("{} {}", count.to_string().green().bold(), label))
+            }
+        })
+        .collect();
+
+    if parts.is_empty() {
+        "no changes".to_string()
+    } else {
+        parts.join(", ")
+    }
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/output/diff.rs"]
+mod tests;

--- a/src/cli/output/messages.rs
+++ b/src/cli/output/messages.rs
@@ -1,0 +1,63 @@
+use owo_colors::OwoColorize;
+
+use crate::classes::RemovableIgnore;
+use crate::cli::utils::snapshot::SnapshotEvaluation;
+
+pub fn handle_snapshot_console(snap: &SnapshotEvaluation, output_snapshot_path: &str) -> String {
+    if !snap.should_run {
+        return String::new();
+    }
+
+    if snap.watermark_messages.is_empty() {
+        format!(
+            "Snapshot watermark passed. Baseline stored at {}",
+            output_snapshot_path
+        )
+    } else {
+        snap.watermark_messages
+            .iter()
+            .map(|message| format!("{}: {}", "Snapshot watermark".bold().red(), message))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+pub fn ignored_summary_output(location_count: usize, no_ignore: bool) -> String {
+    let mut output = if location_count == 0 {
+        "No ignore comments found.".to_string()
+    } else {
+        format!("Found {} suppressed location(s).", location_count)
+    };
+    if location_count > 0 && no_ignore {
+        output.push_str("\n(all markers ignored due to --no-ignore)");
+    }
+    output
+}
+
+pub fn ignored_saved_output(path: &str) -> String {
+    format!("Ignored locations saved at {}", path)
+}
+
+pub fn removable_ignores_output(removable: &[RemovableIgnore]) -> String {
+    if removable.is_empty() {
+        return String::new();
+    }
+    let mut lines = vec![
+        "\nThe following ignore comment(s) are no longer necessary (complexity is within the allowed limit) and can be removed:".to_string(),
+    ];
+    for ignore in removable {
+        lines.push(format!(
+            "{}:{}  function={} complexity={}  {}",
+            ignore.path, ignore.line, ignore.function, ignore.complexity, ignore.comment
+        ));
+    }
+    lines.join("\n")
+}
+
+pub fn diff_flags_warning() -> String {
+    "--diff and --diff-only both set. Using --diff-only (visual only, no enforcement).".to_string()
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/output/messages.rs"]
+mod tests;

--- a/src/cli/output/refactor.rs
+++ b/src/cli/output/refactor.rs
@@ -1,0 +1,314 @@
+use std::fs;
+
+use owo_colors::OwoColorize;
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{Color as SyntaxColor, ThemeSet};
+use syntect::parsing::SyntaxSet;
+
+use crate::classes::{Applicability, CodeSuggestion, RefactorPlan, RuleCategory};
+use crate::cli::types::FunctionRow;
+use crate::cli::utils::paths::normalize_path;
+
+pub fn output_refactor_plans(function: &FunctionRow, invocation_path: &str) -> String {
+    if function.refactor_plans.is_empty() {
+        return String::new();
+    }
+
+    let display_path = normalize_path(&function.path, &function.file_name);
+    let source_lines = read_source_lines(invocation_path, &function.path, &function.file_name);
+
+    let mut sections = vec![format!("\n      {}", "Refactor Suggestions:".bold())];
+    if function.refactor_plans.len() > 1 {
+        sections.push(format!(
+            "      {}",
+            "Each estimate is independent and assumes applying that suggestion alone -- they don't sum."
+                .dimmed()
+        ));
+    }
+    for (index, plan) in function.refactor_plans.iter().enumerate() {
+        sections.push(output_single_plan(
+            plan,
+            index + 1,
+            &display_path,
+            source_lines.as_deref(),
+        ));
+    }
+
+    if function.additional_refactor_plans > 0 {
+        let suffix = if function.additional_refactor_plans != 1 {
+            "s"
+        } else {
+            ""
+        };
+        sections.push(format!(
+            "\n      {}",
+            format!(
+                "... and {} more suggestion{}",
+                function.additional_refactor_plans, suffix
+            )
+            .dimmed()
+        ));
+    }
+
+    sections.join("\n")
+}
+
+fn read_source_lines(invocation_path: &str, path: &str, file_name: &str) -> Option<Vec<String>> {
+    let full_path = normalize_path(path, file_name);
+    let full_path = if !invocation_path.is_empty() && !full_path.starts_with('/') {
+        format!("{}/{}", invocation_path.trim_end_matches('/'), full_path)
+    } else {
+        full_path
+    };
+    fs::read_to_string(full_path)
+        .ok()
+        .map(|content| content.lines().map(str::to_string).collect())
+}
+
+fn output_single_plan(
+    plan: &RefactorPlan,
+    index: usize,
+    display_path: &str,
+    source_lines: Option<&[String]>,
+) -> String {
+    let category_icon = get_category_icon(&plan.category);
+    let category_name = get_category_name(&plan.category);
+    let applicability_icon = get_applicability_icon(&plan.applicability);
+    let applicability_name = get_applicability_name(&plan.applicability);
+
+    let mut sections = vec![format!(
+        "\n      [{}] {} {}",
+        index,
+        plan.rule_id.cyan().bold(),
+        plan.title
+    )];
+    sections.push(format!(
+        "          --> {}:{}:{}",
+        display_path, plan.line_start, plan.column_start
+    ));
+    let caret = output_caret_span(plan, source_lines);
+    if !caret.is_empty() {
+        sections.push(caret);
+    }
+    sections.push(format!(
+        "          Category: {} {} | Applicability: {} {}",
+        category_icon, category_name, applicability_icon, applicability_name
+    ));
+    let reduction_label = if plan.reduction_is_measured {
+        "Reduction"
+    } else {
+        "Estimated reduction"
+    };
+    let qualifier = if plan.reduction_is_measured { "" } else { "~" };
+    sections.push(format!(
+        "          Lines {}-{} -> {}: {} complexity ({} -> {})",
+        plan.line_start,
+        plan.line_end,
+        reduction_label,
+        format!("-{}{}", qualifier, plan.estimated_reduction).green(),
+        plan.current_complexity,
+        plan.estimated_complexity_after
+    ));
+
+    if !plan.description.is_empty() {
+        sections.push(format!("\n          {}", plan.description.dimmed()));
+    }
+    if !plan.explanation.is_empty() {
+        sections.push(format!("\n          {} {}", ">".bold(), plan.explanation));
+    }
+
+    if let Some(suggestion) = &plan.suggestion {
+        sections.push(output_suggestion(plan, suggestion, source_lines));
+    } else if let Some(help) = &plan.help {
+        sections.push(output_help(help));
+    }
+
+    let references = output_plan_references(&plan.doc_url, &plan.references);
+    if !references.is_empty() {
+        sections.push(references);
+    }
+
+    sections.join("\n")
+}
+
+pub fn get_category_icon(category: &RuleCategory) -> &'static str {
+    match category {
+        RuleCategory::Complexity => "\u{25b2}",
+        RuleCategory::Readability => "\u{25c6}",
+    }
+}
+
+pub fn get_category_name(category: &RuleCategory) -> &'static str {
+    match category {
+        RuleCategory::Complexity => "Complexity",
+        RuleCategory::Readability => "Readability",
+    }
+}
+
+pub fn get_applicability_icon(applicability: &Applicability) -> &'static str {
+    match applicability {
+        Applicability::MachineApplicable => "*",
+        Applicability::MaybeIncorrect => "!",
+        Applicability::Informational => "i",
+    }
+}
+
+pub fn get_applicability_name(applicability: &Applicability) -> &'static str {
+    match applicability {
+        Applicability::MachineApplicable => "Safe to apply",
+        Applicability::MaybeIncorrect => "Needs review",
+        Applicability::Informational => "Informational",
+    }
+}
+
+fn output_plan_references(doc_url: &str, references: &[String]) -> String {
+    if doc_url.is_empty() && references.is_empty() {
+        return String::new();
+    }
+    let mut lines = vec![format!("\n          {}", "References:".dimmed())];
+    if !doc_url.is_empty() {
+        lines.push(format!("            {}", doc_url.underline().blue()));
+    }
+    for reference in references {
+        lines.push(format!("            {}", reference.underline().blue()));
+    }
+    lines.join("\n")
+}
+
+fn output_suggestion(
+    plan: &RefactorPlan,
+    suggestion: &CodeSuggestion,
+    source_lines: Option<&[String]>,
+) -> String {
+    let applicability_icon = get_applicability_icon(&suggestion.applicability);
+    let applicability_name = get_applicability_name(&suggestion.applicability);
+
+    let mut sections = vec![format!(
+        "\n          {} {} {}",
+        "Suggestion:".bold(),
+        applicability_icon,
+        applicability_name
+    )];
+    if !suggestion.description.is_empty() {
+        sections.push(format!("          {}", suggestion.description.dimmed()));
+    }
+
+    if let Some(source_lines) = source_lines {
+        let original_start = plan.line_start as usize;
+        let original_end = (plan.line_end as usize).min(source_lines.len());
+        if original_start <= original_end && original_start >= 1 {
+            let original_code = source_lines[original_start - 1..original_end].join("\n");
+            if !original_code.is_empty() {
+                sections.push(format!("\n          {}", "Original:".dimmed()));
+                sections.push(output_code_snippet(&original_code, original_start));
+            }
+        }
+    }
+
+    if !suggestion.replacement.is_empty() {
+        sections.push(format!("\n          {}", "Replacement:".dimmed()));
+        sections.push(output_code_snippet(
+            &suggestion.replacement,
+            plan.line_start as usize,
+        ));
+    }
+
+    sections.join("\n")
+}
+
+fn output_caret_span(plan: &RefactorPlan, source_lines: Option<&[String]>) -> String {
+    let Some(source_lines) = source_lines else {
+        return String::new();
+    };
+    if plan.column_start == 0 {
+        return String::new();
+    }
+
+    let line_index = plan.line_start as usize - 1;
+    let Some(source_line) = source_lines.get(line_index) else {
+        return String::new();
+    };
+
+    let column_index = plan.column_start as usize - 1;
+    if column_index >= source_line.chars().count() {
+        return String::new();
+    }
+
+    let caret_width = source_line[column_index..].trim_end().chars().count();
+    if caret_width == 0 {
+        return String::new();
+    }
+
+    let gutter = format!("{:>5} | ", plan.line_start);
+    let blank_gutter = format!("{}| ", " ".repeat(gutter.len() - 2));
+
+    format!(
+        "          {}\n          {}{}\n          {}{}{}\n          {}",
+        blank_gutter,
+        gutter,
+        source_line,
+        blank_gutter,
+        " ".repeat(column_index),
+        "^".repeat(caret_width),
+        blank_gutter
+    )
+}
+
+fn output_help(help_text: &str) -> String {
+    format!("\n          {}\n          {}", "Help:".bold(), help_text)
+}
+
+fn output_code_snippet(code: &str, start_line: usize) -> String {
+    if code.is_empty() {
+        return String::new();
+    }
+
+    let syntax_set = SyntaxSet::load_defaults_newlines();
+    let theme_set = ThemeSet::load_defaults();
+    let syntax = syntax_set
+        .find_syntax_by_extension("py")
+        .unwrap_or_else(|| syntax_set.find_syntax_plain_text());
+    let theme = &theme_set.themes["base16-ocean.dark"];
+
+    let mut highlight = HighlightLines::new(syntax, theme);
+    let mut lines = Vec::new();
+    for (offset, line) in code.lines().enumerate() {
+        let regions = highlight
+            .highlight_line(line, &syntax_set)
+            .unwrap_or_default();
+        let mut rendered = String::new();
+        for (style, text) in regions {
+            let color = style.foreground;
+            rendered.push_str(&paint(text, color));
+        }
+        lines.push(format!(
+            "{:>12}{:>4} | {}",
+            "",
+            start_line + offset,
+            rendered
+        ));
+    }
+    lines.join("\n")
+}
+
+fn paint(text: &str, color: SyntaxColor) -> String {
+    if color.a == 0 {
+        return text.to_string();
+    }
+    text.color(owo_colors::Rgb(color.r, color.g, color.b))
+        .to_string()
+}
+
+#[cfg(test)]
+pub fn output_single_plan_for_test(
+    plan: &RefactorPlan,
+    index: usize,
+    display_path: &str,
+    source_lines: Option<&[String]>,
+) -> String {
+    output_single_plan(plan, index, display_path, source_lines)
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/output/refactor.rs"]
+mod tests;

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -1,0 +1,246 @@
+use std::collections::HashMap;
+
+use owo_colors::OwoColorize;
+
+use crate::classes::FileComplexity;
+use crate::cli::output::refactor::output_refactor_plans;
+use crate::cli::output::rows::{build_output_rows, truncate_top_n};
+use crate::cli::types::{FileEntry, FunctionRow, Sort};
+
+const RULE_WIDTH: usize = 80;
+
+pub struct ConsoleSettings {
+    pub banner: String,
+    pub color_enabled: bool,
+}
+
+pub fn handle_console_settings(
+    color: &crate::cli::types::Color,
+    quiet: bool,
+    plain: bool,
+) -> ConsoleSettings {
+    let color_enabled = match color {
+        crate::cli::types::Color::No => false,
+        crate::cli::types::Color::Yes => true,
+        crate::cli::types::Color::Auto => true,
+    };
+
+    let banner = if quiet || plain {
+        String::new()
+    } else if cfg!(windows) {
+        rule("complexipy")
+    } else {
+        rule(":octopus: complexipy")
+    };
+
+    ConsoleSettings {
+        banner,
+        color_enabled,
+    }
+}
+
+pub fn rule(title: &str) -> String {
+    if title.is_empty() {
+        return "─".repeat(RULE_WIDTH);
+    }
+    let padding = RULE_WIDTH.saturating_sub(title.chars().count() + 2);
+    let left = padding / 2;
+    let right = padding - left;
+    format!(
+        "{}{} {} {}",
+        "─".repeat(left),
+        "─".repeat(0),
+        title,
+        "─".repeat(right)
+    )
+}
+
+pub struct SummaryOptions<'a> {
+    pub files: &'a [FileComplexity],
+    pub failed_only: bool,
+    pub sort: Sort,
+    pub ignore_complexity: bool,
+    pub max_complexity: u64,
+    pub previous_functions: Option<&'a HashMap<(String, String, String), u64>>,
+    pub snapshot_map: Option<&'a HashMap<(String, String, String), u64>>,
+    pub plain: bool,
+    pub top: Option<u64>,
+    pub suggest_refactors: bool,
+    pub invocation_path: &'a str,
+}
+
+pub fn output_summary(options: SummaryOptions) -> (bool, String) {
+    let SummaryOptions {
+        files,
+        failed_only,
+        sort,
+        ignore_complexity,
+        max_complexity,
+        previous_functions,
+        snapshot_map,
+        plain,
+        top,
+        suggest_refactors,
+        invocation_path,
+    } = options;
+    let (mut file_entries, total_functions, all_pass) =
+        build_output_rows(files, failed_only, sort, max_complexity, snapshot_map);
+    let has_success = all_pass || ignore_complexity;
+
+    if let Some(top) = top {
+        file_entries = truncate_top_n(file_entries, top);
+    }
+
+    if plain {
+        return (has_success, output_plain(&file_entries));
+    }
+
+    let output = if failed_only && file_entries.is_empty() {
+        let plural = if files.len() > 1 { "s" } else { "" };
+        format!(
+            "No function{} were found with complexity greater than {}.",
+            plural, max_complexity
+        )
+    } else if total_functions == 0 {
+        "No files were found with functions. No complexity was calculated.".to_string()
+    } else {
+        output_file_entries(
+            &file_entries,
+            previous_functions,
+            max_complexity,
+            suggest_refactors,
+            invocation_path,
+        )
+    };
+
+    (has_success, output)
+}
+
+pub fn output_plain(file_entries: &[FileEntry]) -> String {
+    let mut lines = Vec::new();
+    for entry in file_entries {
+        for function in &entry.functions {
+            lines.push(format!(
+                "{} {} {}",
+                entry.path, function.name, function.complexity
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+pub fn output_file_entries(
+    file_entries: &[FileEntry],
+    previous_functions: Option<&HashMap<(String, String, String), u64>>,
+    max_complexity: u64,
+    suggest_refactors: bool,
+    invocation_path: &str,
+) -> String {
+    let mut sections = Vec::new();
+
+    for (index, entry) in file_entries.iter().enumerate() {
+        let mut lines = vec![entry.path.bold().to_string()];
+        for function in &entry.functions {
+            let status_text = format_status_text(function.passed);
+            let complexity_text = colorize_complexity(function.complexity, max_complexity);
+            let delta_text = output_delta_text(previous_functions, function, max_complexity);
+            lines.push(format!(
+                "    {} {}{} {}",
+                function.name, complexity_text, delta_text, status_text
+            ));
+            if suggest_refactors {
+                let plans = output_refactor_plans(function, invocation_path);
+                if !plans.is_empty() {
+                    lines.push(plans);
+                }
+            }
+        }
+        if index < file_entries.len() - 1 {
+            lines.push(String::new());
+        }
+        sections.push(lines.join("\n"));
+    }
+
+    let mut output = sections.join("\n");
+
+    if !file_entries.is_empty()
+        && file_entries
+            .iter()
+            .all(|entry| entry.functions.iter().all(|function| function.passed))
+    {
+        output.push_str(&format!(
+            "\n\n{}",
+            "All functions are within the allowed complexity."
+                .green()
+                .bold()
+        ));
+    }
+
+    output
+}
+
+pub fn format_status_text(passed: bool) -> String {
+    if passed {
+        " :white_heavy_check_mark: PASSED "
+            .black()
+            .on_green()
+            .bold()
+            .to_string()
+    } else {
+        " :cross_mark: FAILED ".white().on_red().bold().to_string()
+    }
+}
+
+pub fn output_delta_text(
+    previous_functions: Option<&HashMap<(String, String, String), u64>>,
+    function: &FunctionRow,
+    max_complexity: u64,
+) -> String {
+    let Some(previous_functions) = previous_functions else {
+        return String::new();
+    };
+
+    if function.complexity <= max_complexity {
+        return String::new();
+    }
+
+    let key = (
+        function.path.clone(),
+        function.file_name.clone(),
+        function.name.clone(),
+    );
+    let previous = previous_functions.get(&key);
+    match previous {
+        None => format!(" (new, \u{0394} = +{})", function.complexity),
+        Some(previous) if *previous != function.complexity => {
+            let delta = function.complexity as i64 - *previous as i64;
+            format!(" (last: {}, \u{0394} = {:+})", previous, delta)
+        }
+        Some(_) => String::new(),
+    }
+}
+
+pub fn colorize_complexity(complexity: u64, max_complexity: u64) -> String {
+    if complexity <= max_complexity {
+        complexity.to_string().green().to_string()
+    } else {
+        complexity.to_string().red().to_string()
+    }
+}
+
+pub fn print_invalid_paths(invalid_paths: &[String]) -> (bool, String) {
+    let has_success = invalid_paths.is_empty();
+    let mut lines = Vec::new();
+    for failed_path in invalid_paths {
+        lines.push(format!(
+            "{}: Failed to process {} - Please check file/folder exists or check syntax",
+            "error".bold().red(),
+            failed_path.bold().white()
+        ));
+    }
+    (has_success, lines.join("\n"))
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/output/render.rs"]
+mod tests;

--- a/src/cli/output/rows.rs
+++ b/src/cli/output/rows.rs
@@ -1,0 +1,143 @@
+use std::collections::HashMap;
+
+use crate::classes::{FileComplexity, FunctionComplexity};
+use crate::cli::types::{FileEntry, FunctionRow, Sort};
+use crate::cli::utils::paths::normalize_path;
+
+pub fn build_output_rows(
+    files: &[FileComplexity],
+    failed_only: bool,
+    sort: Sort,
+    max_complexity: u64,
+    snapshot_map: Option<&HashMap<(String, String, String), u64>>,
+) -> (Vec<FileEntry>, u64, bool) {
+    let mut file_entries = Vec::new();
+    let mut total_functions = 0u64;
+    let mut all_pass = true;
+
+    for file in files {
+        let sorted_functions = sort_functions(&file.functions, &sort);
+        let mut displayable_functions = Vec::new();
+
+        for function in sorted_functions {
+            total_functions += 1;
+            let passed = is_function_passing(
+                &function,
+                &file.path,
+                &file.file_name,
+                max_complexity,
+                snapshot_map,
+            );
+
+            if !passed {
+                all_pass = false;
+            }
+
+            if failed_only && passed {
+                continue;
+            }
+
+            displayable_functions.push(FunctionRow {
+                name: function.name.clone(),
+                complexity: function.complexity,
+                passed,
+                path: file.path.clone(),
+                file_name: file.file_name.clone(),
+                refactor_plans: function.refactor_plans.clone(),
+                additional_refactor_plans: function.additional_refactor_plans,
+            });
+        }
+
+        if !displayable_functions.is_empty() {
+            file_entries.push(FileEntry {
+                path: normalize_path(&file.path, &file.file_name),
+                functions: displayable_functions,
+            });
+        }
+    }
+
+    (file_entries, total_functions, all_pass)
+}
+
+pub fn sort_functions(functions: &[FunctionComplexity], sort: &Sort) -> Vec<FunctionComplexity> {
+    let mut sorted = functions.to_vec();
+    match sort {
+        Sort::FileName => sorted.sort_by_key(|function| function.name.to_lowercase()),
+        Sort::Asc => sorted.sort_by_key(|function| function.complexity),
+        Sort::Desc => {
+            sorted.sort_by_key(|function| function.complexity);
+            sorted.reverse();
+        }
+    }
+    sorted
+}
+
+pub fn is_function_passing(
+    function: &FunctionComplexity,
+    file_path: &str,
+    file_name: &str,
+    max_complexity: u64,
+    snapshot_map: Option<&HashMap<(String, String, String), u64>>,
+) -> bool {
+    if function.complexity <= max_complexity {
+        return true;
+    }
+    let Some(snapshot_map) = snapshot_map else {
+        return false;
+    };
+    let previous = snapshot_map.get(&(
+        file_path.to_string(),
+        file_name.to_string(),
+        function.name.clone(),
+    ));
+    previous.is_some_and(|previous| function.complexity <= *previous)
+}
+
+pub fn has_success_functions(
+    files: &[FileComplexity],
+    max_complexity: u64,
+    snapshot_map: Option<&HashMap<(String, String, String), u64>>,
+) -> bool {
+    files.iter().all(|file| {
+        file.functions.iter().all(|function| {
+            is_function_passing(
+                function,
+                &file.path,
+                &file.file_name,
+                max_complexity,
+                snapshot_map,
+            )
+        })
+    })
+}
+
+pub fn truncate_top_n(file_entries: Vec<FileEntry>, n: u64) -> Vec<FileEntry> {
+    let mut all_functions: Vec<(String, FunctionRow)> = Vec::new();
+    for entry in &file_entries {
+        for function in &entry.functions {
+            all_functions.push((entry.path.clone(), function.clone()));
+        }
+    }
+
+    all_functions.sort_by_key(|right| std::cmp::Reverse(right.1.complexity));
+    all_functions.truncate(n as usize);
+
+    let mut result: Vec<FileEntry> = Vec::new();
+    for (path, function) in all_functions {
+        if let Some(last) = result.last_mut()
+            && last.path == path
+        {
+            last.functions.push(function);
+        } else {
+            result.push(FileEntry {
+                path,
+                functions: vec![function],
+            });
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+#[path = "../../tests/cli/output/rows.rs"]
+mod tests;

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -156,7 +156,7 @@ impl ExitReport {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum DiffStatus {
     Regressed,
     Improved,
@@ -199,17 +199,19 @@ impl DiffEntry {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionRow {
-    name: String,
-    complexity: u64,
-    passed: bool,
-    path: String,
-    file_name: String,
-    refactor_plans: Vec<RefactorPlan>,
-    additional_refactor_plans: u64,
+    pub name: String,
+    pub complexity: u64,
+    pub passed: bool,
+    pub path: String,
+    pub file_name: String,
+    pub refactor_plans: Vec<RefactorPlan>,
+    pub additional_refactor_plans: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileEntry {
-    path: String,
-    functions: Vec<FunctionRow>,
+    pub path: String,
+    pub functions: Vec<FunctionRow>,
 }

--- a/src/tests/cli/output/diff.rs
+++ b/src/tests/cli/output/diff.rs
@@ -1,0 +1,97 @@
+//! Wired in from `src/cli/output/diff.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use crate::cli::output::diff::format_diff;
+use crate::cli::types::DiffEntry;
+
+fn strip_ansi(input: &str) -> String {
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            for next in chars.by_ref() {
+                if next == 'm' {
+                    break;
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+fn entry(file_path: &str, func_name: &str, old: Option<u64>, new: Option<u64>) -> DiffEntry {
+    DiffEntry {
+        file_path: file_path.to_string(),
+        func_name: func_name.to_string(),
+        old_complexity: old,
+        new_complexity: new,
+    }
+}
+
+#[test]
+fn no_entries_renders_no_changes() {
+    let output = format_diff(&[], "main");
+
+    assert_eq!(output, "No functions changed relative to main.");
+}
+
+#[test]
+fn unchanged_only_renders_no_changes() {
+    let entries = vec![entry("a.py", "f", Some(5), Some(5))];
+
+    let output = format_diff(&entries, "main");
+
+    assert_eq!(output, "No functions changed relative to main.");
+}
+
+#[test]
+fn table_contains_all_statuses() {
+    let entries = vec![
+        entry("a.py", "reg", Some(3), Some(6)),
+        entry("a.py", "imp", Some(6), Some(3)),
+        entry("b.py", "new_fn", None, Some(5)),
+        entry("b.py", "gone", Some(5), None),
+    ];
+
+    let output = strip_ansi(&format_diff(&entries, "main"));
+
+    assert!(output.contains("Complexity diff (vs main)"));
+    assert!(output.contains("a.py::reg"));
+    assert!(output.contains("a.py::imp"));
+    assert!(output.contains("b.py::new_fn"));
+    assert!(output.contains("b.py::gone"));
+    assert!(output.contains("3 \u{2192} 6  (+3)"));
+    assert!(output.contains("6 \u{2192} 3  (-3)"));
+    assert!(output.contains("(new)"));
+    assert!(output.contains("(removed)"));
+}
+
+#[test]
+fn summary_counts() {
+    let entries = vec![
+        entry("a.py", "r1", Some(3), Some(6)),
+        entry("a.py", "r2", Some(3), Some(6)),
+        entry("a.py", "i1", Some(6), Some(3)),
+        entry("b.py", "n1", None, Some(5)),
+        entry("b.py", "g1", Some(5), None),
+    ];
+
+    let output = strip_ansi(&format_diff(&entries, "main"));
+
+    assert!(output.contains("2 regressed"));
+    assert!(output.contains("1 improved"));
+    assert!(output.contains("1 new"));
+    assert!(output.contains("1 removed"));
+}
+
+#[test]
+fn status_ordering_in_summary() {
+    let entries = vec![entry("a.py", "f", Some(3), Some(6))];
+
+    let output = strip_ansi(&format_diff(&entries, "main"));
+
+    let net_index = output.find("Net:").expect("net line");
+    let summary = &output[net_index..];
+    assert!(summary.contains("1 regressed"));
+}

--- a/src/tests/cli/output/messages.rs
+++ b/src/tests/cli/output/messages.rs
@@ -1,0 +1,91 @@
+//! Wired in from `src/cli/output/messages.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use crate::classes::RemovableIgnore;
+use crate::cli::output::messages::{
+    diff_flags_warning, handle_snapshot_console, ignored_saved_output, ignored_summary_output,
+    removable_ignores_output,
+};
+use crate::cli::utils::snapshot::SnapshotEvaluation;
+
+fn evaluation(should_run: bool, messages: Vec<String>) -> SnapshotEvaluation {
+    SnapshotEvaluation {
+        should_run,
+        active_snapshot_map: None,
+        watermark_success: messages.is_empty(),
+        watermark_messages: messages,
+        snapshot_result: true,
+    }
+}
+
+#[test]
+fn snapshot_not_running_renders_empty() {
+    let snap = evaluation(false, vec![]);
+    assert_eq!(handle_snapshot_console(&snap, "snap.json"), "");
+}
+
+#[test]
+fn snapshot_pass_line() {
+    let snap = evaluation(true, vec![]);
+    assert_eq!(
+        handle_snapshot_console(&snap, "snap.json"),
+        "Snapshot watermark passed. Baseline stored at snap.json"
+    );
+}
+
+#[test]
+fn snapshot_messages_rendered() {
+    let snap = evaluation(true, vec!["a.py:f increased from 3 to 6.".to_string()]);
+    let output = handle_snapshot_console(&snap, "snap.json");
+
+    assert!(output.contains("Snapshot watermark"));
+    assert!(output.contains("a.py:f increased from 3 to 6."));
+}
+
+#[test]
+fn ignored_summary_variants() {
+    assert_eq!(
+        ignored_summary_output(0, false),
+        "No ignore comments found."
+    );
+    assert_eq!(
+        ignored_summary_output(3, false),
+        "Found 3 suppressed location(s)."
+    );
+    let with_flag = ignored_summary_output(2, true);
+    assert!(with_flag.contains("Found 2 suppressed location(s)."));
+    assert!(with_flag.contains("(all markers ignored due to --no-ignore)"));
+}
+
+#[test]
+fn ignored_saved_line() {
+    assert_eq!(
+        ignored_saved_output("/tmp/x/complexipy-ignored.json"),
+        "Ignored locations saved at /tmp/x/complexipy-ignored.json"
+    );
+}
+
+#[test]
+fn removable_ignores_block() {
+    let removable = vec![RemovableIgnore {
+        path: "a.py".to_string(),
+        line: 1,
+        comment: "# complexipy: ignore".to_string(),
+        function: "f".to_string(),
+        complexity: 2,
+    }];
+
+    let output = removable_ignores_output(&removable);
+
+    assert!(output.contains("no longer necessary"));
+    assert!(output.contains("a.py:1  function=f complexity=2  # complexipy: ignore"));
+
+    assert_eq!(removable_ignores_output(&[]), "");
+}
+
+#[test]
+fn diff_flags_warning_text() {
+    assert_eq!(
+        diff_flags_warning(),
+        "--diff and --diff-only both set. Using --diff-only (visual only, no enforcement)."
+    );
+}

--- a/src/tests/cli/output/refactor.rs
+++ b/src/tests/cli/output/refactor.rs
@@ -1,0 +1,165 @@
+//! Wired in from `src/cli/output/refactor.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use crate::classes::{Applicability, CodeSuggestion, RefactorPlan, RuleCategory};
+use crate::cli::output::refactor::{
+    get_applicability_icon, get_applicability_name, get_category_icon, get_category_name,
+    output_refactor_plans,
+};
+use crate::cli::types::FunctionRow;
+
+fn strip_ansi(input: &str) -> String {
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            for next in chars.by_ref() {
+                if next == 'm' {
+                    break;
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+fn plan() -> RefactorPlan {
+    RefactorPlan {
+        kind: "extract-method".to_string(),
+        title: "Extract method".to_string(),
+        line_start: 2,
+        line_end: 4,
+        column_start: 4,
+        current_complexity: 5,
+        estimated_reduction: 2,
+        estimated_complexity_after: 3,
+        reduction_is_measured: true,
+        rule_id: "C001".to_string(),
+        category: RuleCategory::Complexity,
+        applicability: Applicability::MachineApplicable,
+        description: "Extract the body".to_string(),
+        explanation: "Reduces nesting".to_string(),
+        references: vec!["https://example.com/ref".to_string()],
+        suggestion: Some(CodeSuggestion {
+            replacement: "return x".to_string(),
+            applicability: Applicability::MachineApplicable,
+            description: "Replace body".to_string(),
+            spliceable: true,
+        }),
+        help: None,
+        doc_url: "https://example.com/c001".to_string(),
+    }
+}
+
+fn row_with_plans() -> FunctionRow {
+    FunctionRow {
+        name: "f".to_string(),
+        complexity: 5,
+        passed: false,
+        path: "src/a.py".to_string(),
+        file_name: "a.py".to_string(),
+        refactor_plans: vec![plan()],
+        additional_refactor_plans: 1,
+    }
+}
+
+#[test]
+fn category_icons_and_names() {
+    assert_eq!(get_category_icon(&RuleCategory::Complexity), "\u{25b2}");
+    assert_eq!(get_category_name(&RuleCategory::Complexity), "Complexity");
+    assert_eq!(get_category_icon(&RuleCategory::Readability), "\u{25c6}");
+    assert_eq!(get_category_name(&RuleCategory::Readability), "Readability");
+}
+
+#[test]
+fn applicability_icons_and_names() {
+    assert_eq!(
+        get_applicability_icon(&Applicability::MachineApplicable),
+        "*"
+    );
+    assert_eq!(
+        get_applicability_name(&Applicability::MachineApplicable),
+        "Safe to apply"
+    );
+    assert_eq!(get_applicability_icon(&Applicability::MaybeIncorrect), "!");
+    assert_eq!(
+        get_applicability_name(&Applicability::MaybeIncorrect),
+        "Needs review"
+    );
+    assert_eq!(get_applicability_icon(&Applicability::Informational), "i");
+    assert_eq!(
+        get_applicability_name(&Applicability::Informational),
+        "Informational"
+    );
+}
+
+#[test]
+fn single_plan_output_structure() {
+    let output = strip_ansi(&output_refactor_plans(&row_with_plans(), ""));
+
+    assert!(output.contains("[1] C001 Extract method"));
+    assert!(output.contains("--> src/a.py:2:4"));
+    assert!(output.contains("Category: \u{25b2} Complexity | Applicability: * Safe to apply"));
+    assert!(output.contains("Lines 2-4 -> Reduction: -2 complexity (5 -> 3)"));
+    assert!(output.contains("Extract the body"));
+    assert!(output.contains("Reduces nesting"));
+    assert!(output.contains("Suggestion: * Safe to apply"));
+    assert!(output.contains("References:"));
+    assert!(output.contains("https://example.com/c001"));
+    assert!(output.contains("... and 1 more suggestion"));
+}
+
+#[test]
+fn unmeasured_reduction_uses_qualifier() {
+    let mut p = plan();
+    p.reduction_is_measured = false;
+    let mut r = row_with_plans();
+    r.refactor_plans = vec![p];
+
+    let output = strip_ansi(&output_refactor_plans(&r, ""));
+
+    assert!(output.contains("Estimated reduction"));
+    assert!(output.contains("-~2"));
+}
+
+#[test]
+fn no_plans_returns_empty() {
+    let mut r = row_with_plans();
+    r.refactor_plans = vec![];
+
+    assert_eq!(output_refactor_plans(&r, ""), "");
+}
+
+#[test]
+fn help_rendered_when_no_suggestion() {
+    let mut p = plan();
+    p.suggestion = None;
+    p.help = Some("See the docs".to_string());
+    let mut r = row_with_plans();
+    r.refactor_plans = vec![p];
+
+    let output = strip_ansi(&output_refactor_plans(&r, ""));
+
+    assert!(output.contains("Help:"));
+    assert!(output.contains("See the docs"));
+}
+
+#[test]
+fn caret_span_rendered_from_source() {
+    let p = plan();
+    let output = crate::cli::output::refactor::output_single_plan_for_test(
+        &p,
+        1,
+        "src/a.py",
+        Some(&[
+            "line one".to_string(),
+            "    if x:".to_string(),
+            "        return 1".to_string(),
+            "    return 0".to_string(),
+        ]),
+    );
+
+    assert!(output.contains("2 | "));
+    assert!(output.contains("^"));
+}

--- a/src/tests/cli/output/render.rs
+++ b/src/tests/cli/output/render.rs
@@ -1,0 +1,209 @@
+//! Wired in from `src/cli/output/render.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::collections::HashMap;
+
+use crate::cli::output::render::{
+    SummaryOptions, colorize_complexity, format_status_text, handle_console_settings,
+    output_delta_text, output_plain, output_summary, print_invalid_paths, rule,
+};
+use crate::cli::types::{Color, FileEntry, FunctionRow, Sort};
+
+fn strip_ansi(input: &str) -> String {
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            for next in chars.by_ref() {
+                if next == 'm' {
+                    break;
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    result
+}
+
+fn row(name: &str, complexity: u64, passed: bool, path: &str) -> FunctionRow {
+    FunctionRow {
+        name: name.to_string(),
+        complexity,
+        passed,
+        path: path.to_string(),
+        file_name: path.split('/').next_back().unwrap_or(path).to_string(),
+        refactor_plans: vec![],
+        additional_refactor_plans: 0,
+    }
+}
+
+#[test]
+fn status_text_contains_labels() {
+    assert!(format_status_text(true).contains("PASSED"));
+    assert!(format_status_text(false).contains("FAILED"));
+}
+
+#[test]
+fn colorize_marks_over_threshold_red() {
+    let ok = colorize_complexity(5, 5);
+    let bad = colorize_complexity(6, 5);
+    assert!(!ok.contains("\u{1b}[31m"));
+    assert!(bad.contains("\u{1b}[31m"));
+}
+
+#[test]
+fn delta_text_cases() {
+    let mut previous = HashMap::new();
+    let f_new = row("f", 10, false, "a.py");
+
+    assert_eq!(output_delta_text(None, &f_new, 5), "");
+    assert_eq!(
+        output_delta_text(Some(&previous), &f_new, 5),
+        " (new, \u{0394} = +10)"
+    );
+
+    previous.insert(("a.py".to_string(), "a.py".to_string(), "f".to_string()), 7);
+    assert_eq!(
+        output_delta_text(Some(&previous), &f_new, 5),
+        " (last: 7, \u{0394} = +3)"
+    );
+
+    previous.insert(
+        ("a.py".to_string(), "a.py".to_string(), "f".to_string()),
+        10,
+    );
+    assert_eq!(output_delta_text(Some(&previous), &f_new, 5), "");
+
+    let within = row("f", 3, true, "a.py");
+    assert_eq!(output_delta_text(Some(&previous), &within, 5), "");
+}
+
+#[test]
+fn plain_output_lines() {
+    let entries = vec![FileEntry {
+        path: "src/a.py".to_string(),
+        functions: vec![row("f", 5, true, "src/a.py")],
+    }];
+
+    let output = output_plain(&entries);
+
+    assert_eq!(output, "src/a.py f 5");
+}
+
+#[test]
+fn summary_no_files_message() {
+    let (has_success, output) = output_summary(SummaryOptions {
+        files: &[],
+        failed_only: false,
+        sort: Sort::Asc,
+        ignore_complexity: false,
+        max_complexity: 5,
+        previous_functions: None,
+        snapshot_map: None,
+        plain: false,
+        top: None,
+        suggest_refactors: false,
+        invocation_path: "",
+    });
+
+    assert!(has_success);
+    assert_eq!(
+        output,
+        "No files were found with functions. No complexity was calculated."
+    );
+}
+
+#[test]
+fn summary_failed_only_empty_message() {
+    let files = vec![crate::classes::FileComplexity {
+        path: "a.py".to_string(),
+        file_name: "a.py".to_string(),
+        functions: vec![crate::classes::FunctionComplexity {
+            name: "f".to_string(),
+            complexity: 2,
+            line_start: 1,
+            line_end: 2,
+            line_complexities: vec![],
+            refactor_plans: vec![],
+            additional_refactor_plans: 0,
+        }],
+        complexity: 0,
+    }];
+
+    let (_, output) = output_summary(SummaryOptions {
+        files: &files,
+        failed_only: true,
+        sort: Sort::Asc,
+        ignore_complexity: false,
+        max_complexity: 5,
+        previous_functions: None,
+        snapshot_map: None,
+        plain: false,
+        top: None,
+        suggest_refactors: false,
+        invocation_path: "",
+    });
+
+    assert_eq!(
+        output,
+        "No function were found with complexity greater than 5."
+    );
+}
+
+#[test]
+fn summary_plain_mode_skips_messages() {
+    let (_, output) = output_summary(SummaryOptions {
+        files: &[],
+        failed_only: true,
+        sort: Sort::Asc,
+        ignore_complexity: false,
+        max_complexity: 5,
+        previous_functions: None,
+        snapshot_map: None,
+        plain: true,
+        top: None,
+        suggest_refactors: false,
+        invocation_path: "",
+    });
+
+    assert_eq!(output, "");
+}
+
+#[test]
+fn invalid_paths_rendering() {
+    let (has_success, raw) = print_invalid_paths(&["nope.py".to_string()]);
+    let output = strip_ansi(&raw);
+
+    assert!(!has_success);
+    assert!(output.contains("error"));
+    assert!(output.contains("Failed to process nope.py"));
+    assert!(output.contains("Please check file/folder exists or check syntax"));
+
+    let (has_success, output) = print_invalid_paths(&[]);
+    assert!(has_success);
+    assert_eq!(output, "");
+}
+
+#[test]
+fn rule_renders_title_with_padding() {
+    let output = rule("complexipy");
+    assert!(output.contains("complexipy"));
+    assert!(output.starts_with('─'));
+    assert!(output.ends_with('─'));
+}
+
+#[test]
+fn console_settings_banner() {
+    let settings = handle_console_settings(&Color::Auto, false, false);
+    assert!(!settings.banner.is_empty());
+    assert!(settings.color_enabled);
+
+    let quiet = handle_console_settings(&Color::Auto, true, false);
+    assert_eq!(quiet.banner, "");
+
+    let plain = handle_console_settings(&Color::Auto, false, true);
+    assert_eq!(plain.banner, "");
+
+    let no_color = handle_console_settings(&Color::No, false, false);
+    assert!(!no_color.color_enabled);
+}

--- a/src/tests/cli/output/rows.rs
+++ b/src/tests/cli/output/rows.rs
@@ -1,0 +1,202 @@
+//! Wired in from `src/cli/output/rows.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::collections::HashMap;
+
+use crate::classes::{FileComplexity, FunctionComplexity};
+use crate::cli::output::rows::{
+    build_output_rows, has_success_functions, is_function_passing, sort_functions, truncate_top_n,
+};
+use crate::cli::types::Sort;
+
+fn function(name: &str, complexity: u64) -> FunctionComplexity {
+    FunctionComplexity {
+        name: name.to_string(),
+        complexity,
+        line_start: 1,
+        line_end: 2,
+        line_complexities: vec![],
+        refactor_plans: vec![],
+        additional_refactor_plans: 0,
+    }
+}
+
+fn file(path: &str, file_name: &str, functions: Vec<FunctionComplexity>) -> FileComplexity {
+    FileComplexity {
+        path: path.to_string(),
+        file_name: file_name.to_string(),
+        functions,
+        complexity: 0,
+    }
+}
+
+fn snapshot_map(entries: &[(&str, &str, &str, u64)]) -> HashMap<(String, String, String), u64> {
+    entries
+        .iter()
+        .map(|(path, file_name, name, complexity)| {
+            (
+                (path.to_string(), file_name.to_string(), name.to_string()),
+                *complexity,
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn sort_asc_by_complexity_stable() {
+    let functions = vec![
+        function("high", 9),
+        function("low", 1),
+        function("tie_a", 5),
+        function("tie_b", 5),
+    ];
+
+    let sorted = sort_functions(&functions, &Sort::Asc);
+
+    let names: Vec<&str> = sorted.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, vec!["low", "tie_a", "tie_b", "high"]);
+}
+
+#[test]
+fn sort_desc_by_complexity() {
+    let functions = vec![function("low", 1), function("high", 9)];
+
+    let sorted = sort_functions(&functions, &Sort::Desc);
+
+    let names: Vec<&str> = sorted.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, vec!["high", "low"]);
+}
+
+#[test]
+fn sort_file_name_by_lowercased_name() {
+    let functions = vec![
+        function("Zebra", 1),
+        function("apple", 9),
+        function("mango", 5),
+    ];
+
+    let sorted = sort_functions(&functions, &Sort::FileName);
+
+    let names: Vec<&str> = sorted.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(names, vec!["apple", "mango", "Zebra"]);
+}
+
+#[test]
+fn passing_within_threshold() {
+    let f = function("f", 5);
+    assert!(is_function_passing(&f, "a.py", "a.py", 5, None));
+    assert!(is_function_passing(&f, "a.py", "a.py", 10, None));
+}
+
+#[test]
+fn passing_above_threshold_without_snapshot_fails() {
+    let f = function("f", 10);
+    assert!(!is_function_passing(&f, "a.py", "a.py", 5, None));
+}
+
+#[test]
+fn passing_with_snapshot_allows_same_or_better() {
+    let f = function("f", 10);
+    let map = snapshot_map(&[("a.py", "a.py", "f", 12)]);
+    assert!(is_function_passing(&f, "a.py", "a.py", 5, Some(&map)));
+
+    let map = snapshot_map(&[("a.py", "a.py", "f", 10)]);
+    assert!(is_function_passing(&f, "a.py", "a.py", 5, Some(&map)));
+
+    let map = snapshot_map(&[("a.py", "a.py", "f", 8)]);
+    assert!(!is_function_passing(&f, "a.py", "a.py", 5, Some(&map)));
+}
+
+#[test]
+fn build_rows_filters_failed_only_and_tracks_totals() {
+    let files = vec![
+        file(
+            "src/a.py",
+            "a.py",
+            vec![
+                function("pass", 2),
+                function("fail", 10),
+                function("border", 5),
+            ],
+        ),
+        file("src/b.py", "b.py", vec![function("other", 1)]),
+    ];
+
+    let (entries, total, all_pass) = build_output_rows(&files, false, Sort::Asc, 5, None);
+
+    assert_eq!(total, 4);
+    assert!(!all_pass);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].functions.len(), 3);
+    assert_eq!(entries[0].path, "src/a.py");
+
+    let (entries, _, _) = build_output_rows(&files, true, Sort::Asc, 5, None);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].functions.len(), 1);
+    assert_eq!(entries[0].functions[0].name, "fail");
+}
+
+#[test]
+fn build_rows_all_pass_when_within_threshold() {
+    let files = vec![file("src/a.py", "a.py", vec![function("f", 2)])];
+
+    let (_, _, all_pass) = build_output_rows(&files, false, Sort::Asc, 5, None);
+
+    assert!(all_pass);
+}
+
+#[test]
+fn truncate_top_n_groups_by_path() {
+    let entries = vec![
+        crate::cli::types::FileEntry {
+            path: "a.py".to_string(),
+            functions: vec![
+                crate::cli::types::FunctionRow {
+                    name: "low".to_string(),
+                    complexity: 1,
+                    passed: true,
+                    path: "a.py".to_string(),
+                    file_name: "a.py".to_string(),
+                    refactor_plans: vec![],
+                    additional_refactor_plans: 0,
+                },
+                crate::cli::types::FunctionRow {
+                    name: "high".to_string(),
+                    complexity: 9,
+                    passed: false,
+                    path: "a.py".to_string(),
+                    file_name: "a.py".to_string(),
+                    refactor_plans: vec![],
+                    additional_refactor_plans: 0,
+                },
+            ],
+        },
+        crate::cli::types::FileEntry {
+            path: "b.py".to_string(),
+            functions: vec![crate::cli::types::FunctionRow {
+                name: "mid".to_string(),
+                complexity: 5,
+                passed: true,
+                path: "b.py".to_string(),
+                file_name: "b.py".to_string(),
+                refactor_plans: vec![],
+                additional_refactor_plans: 0,
+            }],
+        },
+    ];
+
+    let truncated = truncate_top_n(entries, 2);
+
+    assert_eq!(truncated.len(), 2);
+    assert_eq!(truncated[0].path, "a.py");
+    assert_eq!(truncated[0].functions[0].name, "high");
+    assert_eq!(truncated[1].path, "b.py");
+}
+
+#[test]
+fn has_success_functions_respects_snapshot() {
+    let files = vec![file("a.py", "a.py", vec![function("f", 10)])];
+    assert!(!has_success_functions(&files, 5, None));
+
+    let map = snapshot_map(&[("a.py", "a.py", "f", 12)]);
+    assert!(has_success_functions(&files, 5, Some(&map)));
+}


### PR DESCRIPTION
## What

Ports `utils/output.py` — the largest module (~692 lines) — to a dedicated Rust module tree, as step 13 of the CLI migration in issue #224, replacing Rich with comfy-table + owo-colors + syntect (user-confirmed decision).

## Why

The display pipeline, results-storage dispatch, refactor-plan rendering, and the console hub for every deferred display from Steps 10–12 land here. Per the maintainability goal, Step 13 gets its own `src/cli/output/` tree instead of growing `utils/`.

## Changes

- `feat(cargo)` — `comfy-table`, `owo-colors`, `syntect` in the cli feature
- `src/cli/output.rs` — facade: `handle_display` (cache → quiet shortcut → summary), `handle_results_storage` (paths + 4-writer dispatch), bundled option structs
- `src/cli/output/rows.rs` — pure data: `build_output_rows`, `sort_functions`, `is_function_passing`, `has_success_functions`, `truncate_top_n`
- `src/cli/output/render.rs` — summary/plain/entries, status + delta text, invalid paths, console settings, platform rule
- `src/cli/output/refactor.rs` — plan rendering cluster with syntect-highlighted snippets, caret spans, icons, references
- `src/cli/output/diff.rs` — Step 11's deferred `format_diff` (comfy-table) + status styles + net summary
- `src/cli/output/messages.rs` — Step 10/12 deferred console (snapshot watermark, ignored prints) + diff-flag warning
- `src/cli/types.rs` — `FunctionRow`/`FileEntry` activated; `src/classes.rs` derives
- Tests: `src/tests/cli/output/` — 39 tests (rows exhaustive, render strings, refactor edge cases, diff table, messages)
- Fidelity notes: syntect default theme approximates Rich's monokai; rules/emoji kept literal

Issue: #224