### PR TITLE
feat(cli): port public api to rust (step 14)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+pub mod api;
 pub mod args;
 pub mod output;
 pub mod types;

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -1,0 +1,52 @@
+use std::path::Path;
+
+use crate::classes::{CodeComplexity, FileComplexity};
+use crate::cognitive_complexity::code_complexity_shared;
+use crate::runner::file_complexity_shared;
+
+pub fn code_complexity(
+    code: &str,
+    check_script: bool,
+    no_ignore: bool,
+) -> Result<CodeComplexity, String> {
+    code_complexity_shared(code, check_script, no_ignore)
+}
+
+pub fn file_complexity(
+    file_path: &str,
+    check_script: bool,
+    no_ignore: bool,
+) -> Result<FileComplexity, String> {
+    let path = std::fs::canonicalize(file_path)
+        .map_err(|e| format!("Failed to resolve file '{}': {}", file_path, e))?;
+    let cwd = std::env::current_dir()
+        .map_err(|e| format!("Failed to resolve the current directory: {}", e))?;
+
+    let base_path = if path.starts_with(&cwd) {
+        cwd
+    } else {
+        path.parent()
+            .map(|parent| parent.to_path_buf())
+            .unwrap_or_else(|| Path::new(".").to_path_buf())
+    };
+
+    file_complexity_shared(
+        &to_posix(&path),
+        &to_posix(&base_path),
+        check_script,
+        no_ignore,
+    )
+}
+
+fn to_posix(path: &Path) -> String {
+    let value = path.to_string_lossy();
+    if cfg!(windows) {
+        value.replace('\\', "/")
+    } else {
+        value.into_owned()
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/cli/api.rs"]
+mod tests;

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -20,29 +20,19 @@ use shared_deps::*;
 mod python_deps {
     pub use pyo3::exceptions::PyValueError;
     pub use pyo3::prelude::*;
-    pub use ruff_python_parser::parse_module;
 }
 
 #[cfg(feature = "python")]
 use python_deps::*;
 
-#[cfg(feature = "python")]
-#[pyfunction]
-#[pyo3(signature = (code, check_script=false, no_ignore=false))]
-pub fn code_complexity(
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn code_complexity_shared(
     code: &str,
     check_script: bool,
     no_ignore: bool,
-) -> PyResult<CodeComplexity> {
-    let parsed = match parse_module(code) {
-        Ok(parsed) => parsed,
-        Err(e) => {
-            return Err(PyValueError::new_err(format!(
-                "Failed to parse code: {}",
-                e
-            )));
-        }
-    };
+) -> Result<CodeComplexity, String> {
+    let parsed = ruff_python_parser::parse_module(code)
+        .map_err(|e| format!("Failed to parse code: {}", e))?;
     let ast_body = parsed.into_suite();
     let (functions, complexity) =
         function_level_cognitive_complexity_shared(&ast_body, code, check_script, no_ignore, true);
@@ -52,6 +42,17 @@ pub fn code_complexity(
         #[cfg(feature = "wasm")]
         version: env!("CARGO_PKG_VERSION").to_string(),
     })
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(signature = (code, check_script=false, no_ignore=false))]
+pub fn code_complexity(
+    code: &str,
+    check_script: bool,
+    no_ignore: bool,
+) -> PyResult<CodeComplexity> {
+    code_complexity_shared(code, check_script, no_ignore).map_err(PyValueError::new_err)
 }
 
 #[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,8 +5,8 @@ use crate::utils::{collect_ignored_locations, filter_removable_ignores};
 use ruff_python_parser::parse_module;
 use std::path;
 
-#[cfg(feature = "python")]
-use crate::cognitive_complexity::code_complexity;
+#[cfg(any(feature = "python", feature = "cli"))]
+use crate::cognitive_complexity::code_complexity_shared;
 #[cfg(feature = "python")]
 use crate::utils::get_repo_name;
 #[cfg(feature = "python")]
@@ -250,6 +250,35 @@ fn evaluate_dir(
     (complexities, failed_paths)
 }
 
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn file_complexity_shared(
+    file_path: &str,
+    base_path: &str,
+    check_script: bool,
+    no_ignore: bool,
+) -> Result<FileComplexity, String> {
+    let path = path::Path::new(file_path);
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| format!("Invalid file name: {}", file_path))?;
+    let relative_path = path
+        .strip_prefix(base_path)
+        .ok()
+        .and_then(|p| p.to_str())
+        .unwrap_or(file_path);
+    let code = std::fs::read_to_string(file_path)
+        .map_err(|e| format!("Failed to read file '{}': {}", file_path, e))?;
+    let code_complexity = code_complexity_shared(&code, check_script, no_ignore)
+        .map_err(|e| format!("Failed to process file '{}': {}", file_path, e))?;
+    Ok(FileComplexity {
+        path: relative_path.to_string(),
+        file_name: file_name.to_string(),
+        complexity: code_complexity.complexity,
+        functions: code_complexity.functions,
+    })
+}
+
 #[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(signature = (file_path, base_path, check_script=false, no_ignore=false))]
@@ -259,32 +288,8 @@ pub fn file_complexity(
     check_script: bool,
     no_ignore: bool,
 ) -> PyResult<FileComplexity> {
-    let path = path::Path::new(file_path);
-    let file_name = path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .ok_or_else(|| PyValueError::new_err(format!("Invalid file name: {}", file_path)))?;
-    let relative_path = path
-        .strip_prefix(base_path)
-        .ok()
-        .and_then(|p| p.to_str())
-        .unwrap_or(file_path);
-    let code = std::fs::read_to_string(file_path)?;
-    let code_complexity = match code_complexity(&code, check_script, no_ignore) {
-        Ok(v) => v,
-        Err(e) => {
-            return Err(PyValueError::new_err(format!(
-                "Failed to process file '{}': {}",
-                file_path, e
-            )));
-        }
-    };
-    Ok(FileComplexity {
-        path: relative_path.to_string(),
-        file_name: file_name.to_string(),
-        complexity: code_complexity.complexity,
-        functions: code_complexity.functions,
-    })
+    file_complexity_shared(file_path, base_path, check_script, no_ignore)
+        .map_err(PyValueError::new_err)
 }
 
 #[cfg(any(feature = "python", feature = "cli"))]

--- a/src/tests/cli/api.rs
+++ b/src/tests/cli/api.rs
@@ -1,0 +1,108 @@
+//! Wired in from `src/cli/api.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use crate::cli::api::{code_complexity, file_complexity};
+
+const SIMPLE: &str = "def simple(x):\n    return x + 1\n";
+
+#[test]
+fn code_complexity_returns_total_and_functions() {
+    let result = code_complexity(SIMPLE, false, false).expect("should analyze");
+
+    assert_eq!(result.complexity, 0);
+    assert_eq!(result.functions.len(), 1);
+    assert_eq!(result.functions[0].name, "simple");
+    assert_eq!(result.functions[0].complexity, 0);
+}
+
+#[test]
+fn code_complexity_measures_nesting() {
+    let code = "def complex_func(data):\n    if data:\n        for item in data:\n            if item:\n                return item\n    return None\n";
+
+    let result = code_complexity(code, false, false).expect("should analyze");
+
+    assert_eq!(result.functions[0].complexity, 6);
+}
+
+#[test]
+fn code_complexity_check_script_reports_module() {
+    let code = "if True:\n    x = 1\n";
+
+    let result = code_complexity(code, true, false).expect("should analyze");
+
+    assert!(
+        result
+            .functions
+            .iter()
+            .any(|function| function.name == "<module>")
+    );
+}
+
+#[test]
+fn code_complexity_no_ignore_includes_suppressed() {
+    let code = "def marked(x):  # complexipy: ignore\n    if x:\n        return 1\n    return 0\n";
+
+    let ignored = code_complexity(code, false, false).expect("should analyze");
+    assert_eq!(ignored.functions.len(), 0);
+
+    let analyzed = code_complexity(code, false, true).expect("should analyze");
+    assert_eq!(analyzed.functions.len(), 1);
+    assert_eq!(analyzed.functions[0].complexity, 1);
+}
+
+#[test]
+fn code_complexity_syntax_error() {
+    let result = code_complexity("def broken(:\n", false, false);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn file_complexity_analyzes_file_in_cwd() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("mymodule.py");
+    fs::write(&file, SIMPLE).expect("should write");
+
+    let result = file_complexity(file.to_str().unwrap(), false, false).expect("should analyze");
+
+    assert_eq!(result.file_name, "mymodule.py");
+    assert_eq!(result.functions[0].name, "simple");
+    assert_eq!(result.functions[0].complexity, 0);
+}
+
+#[test]
+fn file_complexity_outside_cwd_uses_parent_base() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("outside.py");
+    fs::write(&file, SIMPLE).expect("should write");
+
+    // The tempdir is not the cwd, so base_path becomes the file's parent;
+    // the returned path is the file path itself (strip_prefix fails).
+    let result = file_complexity(file.to_str().unwrap(), false, false).expect("should analyze");
+
+    assert_eq!(result.file_name, "outside.py");
+    assert_eq!(result.functions[0].name, "simple");
+}
+
+#[test]
+fn file_complexity_missing_file() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let result = file_complexity(dir.path().join("nope.py").to_str().unwrap(), false, false);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn file_complexity_syntax_error() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("broken.py");
+    fs::write(&file, "def broken(:\n").expect("should write");
+
+    let result = file_complexity(file.to_str().unwrap(), false, false);
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## What

Ports `complexipy/api.py` — the two public API functions `code_complexity` and `file_complexity` — to Rust, as step 14 of the CLI migration in issue #224.

## Why

The issue's plan says the public API wrappers become direct Rust exports. The pyfunctions were PyO3-bound; this change extracts shared entry points the CLI can call and ports `file_complexity`'s base-path resolution.

## Changes

- `src/cognitive_complexity.rs` — `code_complexity_shared(code, check_script, no_ignore) -> Result<CodeComplexity, String>` (`any(python, cli)`); the pyfunction is a thin wrapper with identical messages
- `src/runner.rs` — `file_complexity_shared(file_path, base_path, check_script, no_ignore)`; the pyfunction is a thin wrapper
- `src/cli/api.rs` — `code_complexity` and `file_complexity` with Python's base-path semantics: canonicalized path, cwd, base = cwd when the file is under it (`starts_with`), else the file's parent; posix conversion
- `src/tests/cli/api.rs` — 9 tests: totals, check_script module entry, no_ignore, syntax errors, path resolution inside/outside cwd, missing file

Issue: #224