### PR TITLE
feat(cli): add rust cli binary (step 15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "sha2",
  "syntect",
  "tempfile",
+ "terminal_size",
  "toml",
  "wasm-bindgen",
  "wax",
@@ -1498,6 +1499,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "tempfile",
  "terminal_size",
  "toml",
+ "unicode-width",
  "wasm-bindgen",
  "wax",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,13 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "complexipy"
-# Enable cdylib for Python and wasm32 targets
-crate-type = ["cdylib"]
+# cdylib for Python and wasm32 targets; rlib lets the CLI binary link the lib
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "complexipy"
+path = "src/main.rs"
+required-features = ["cli"]
 
 [features]
 default = ["python", "cli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["cli"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore", "dep:comfy-table", "dep:owo-colors", "dep:syntect"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore", "dep:comfy-table", "dep:owo-colors", "dep:syntect", "dep:terminal_size"]
 python = [
     "serde",
     "pyo3",
@@ -83,6 +83,7 @@ sha2 = { version = "0.10", optional = true }
 comfy-table = { version = "8.0", optional = true }
 owo-colors = { version = "4.3", optional = true }
 syntect = { version = "5.3", optional = true }
+terminal_size = { version = "0.4", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["cli"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore", "dep:comfy-table", "dep:owo-colors", "dep:syntect", "dep:terminal_size"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore", "dep:comfy-table", "dep:owo-colors", "dep:syntect", "dep:terminal_size", "dep:unicode-width"]
 python = [
     "serde",
     "pyo3",
@@ -84,6 +84,7 @@ comfy-table = { version = "8.0", optional = true }
 owo-colors = { version = "4.3", optional = true }
 syntect = { version = "5.3", optional = true }
 terminal_size = { version = "0.4", optional = true }
+unicode-width = { version = "0.2", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -41,14 +41,17 @@ pub fn handle_console_settings(
 
 pub fn rule(title: &str) -> String {
     if title.is_empty() {
-        return "─".repeat(RULE_WIDTH).bold().to_string();
+        return "─".repeat(RULE_WIDTH).bright_green().to_string();
     }
     let padding = RULE_WIDTH.saturating_sub(title.chars().count() + 2);
     let left = padding / 2;
     let right = padding - left;
-    format!("{} {} {}", "─".repeat(left), title, "─".repeat(right))
-        .bold()
-        .to_string()
+    format!(
+        "{} {} {}",
+        "─".repeat(left).bright_green(),
+        title,
+        "─".repeat(right).bright_green()
+    )
 }
 
 pub struct SummaryOptions<'a> {

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -229,9 +229,9 @@ pub fn output_file_entries(
 
 pub fn format_status_text(passed: bool) -> String {
     if passed {
-        format!("✅ {} ", " PASSED ".black().on_green().bold())
+        format!("✅ {} ", "PASSED".black().on_green().bold())
     } else {
-        format!("❌ {} ", " FAILED ".white().on_red().bold())
+        format!("❌ {} ", "FAILED".white().on_red().bold())
     }
 }
 

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use owo_colors::OwoColorize;
 use std::io::IsTerminal;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::classes::FileComplexity;
 use crate::cli::output::refactor::output_refactor_plans;
@@ -41,19 +42,55 @@ pub fn handle_console_settings(
 }
 
 pub fn rule(title: &str) -> String {
-    let width = terminal_width();
+    rule_at(title, terminal_width())
+}
+
+fn rule_at(title: &str, width: usize) -> String {
     if title.is_empty() {
         return "─".repeat(width).bright_green().to_string();
     }
-    let padding = width.saturating_sub(title.chars().count() + 2);
-    let left = padding / 2;
-    let right = padding - left;
-    format!(
-        "{} {} {}",
-        "─".repeat(left).bright_green(),
-        title,
-        "─".repeat(right).bright_green()
-    )
+    if width < 4 {
+        return "─".repeat(width).bright_green().to_string();
+    }
+
+    let title_cells = UnicodeWidthStr::width(title);
+    let side_width = (width - title_cells) / 2;
+    let left = side_width.saturating_sub(1);
+    let right_length = width - left - title_cells;
+    let right = (side_width + 1).min(right_length);
+
+    let plain = format!("{} {} {}", "─".repeat(left), title, "─".repeat(right));
+    let plain = set_cell_size(&plain, width);
+
+    if let Some(start) = plain.find(title) {
+        let end = start + title.len();
+        format!(
+            "{}{}{}",
+            plain[..start].to_string().bright_green(),
+            &plain[start..end],
+            plain[end..].to_string().bright_green()
+        )
+    } else {
+        plain.bright_green().to_string()
+    }
+}
+
+fn set_cell_size(text: &str, width: usize) -> String {
+    let mut result = String::new();
+    let mut cells = 0;
+    for character in text.chars() {
+        let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+        if cells + character_width > width {
+            break;
+        }
+        result.push(character);
+        cells += character_width;
+    }
+    while cells < width {
+        result.push(' ');
+        cells += 1;
+    }
+    result
 }
 
 fn terminal_width() -> usize {

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -30,7 +30,7 @@ pub fn handle_console_settings(
     } else if cfg!(windows) {
         rule("complexipy")
     } else {
-        rule(":octopus: complexipy")
+        rule("🐙 complexipy")
     };
 
     ConsoleSettings {
@@ -41,18 +41,14 @@ pub fn handle_console_settings(
 
 pub fn rule(title: &str) -> String {
     if title.is_empty() {
-        return "─".repeat(RULE_WIDTH);
+        return "─".repeat(RULE_WIDTH).bold().to_string();
     }
     let padding = RULE_WIDTH.saturating_sub(title.chars().count() + 2);
     let left = padding / 2;
     let right = padding - left;
-    format!(
-        "{}{} {} {}",
-        "─".repeat(left),
-        "─".repeat(0),
-        title,
-        "─".repeat(right)
-    )
+    format!("{} {} {}", "─".repeat(left), title, "─".repeat(right))
+        .bold()
+        .to_string()
 }
 
 pub struct SummaryOptions<'a> {
@@ -181,13 +177,9 @@ pub fn output_file_entries(
 
 pub fn format_status_text(passed: bool) -> String {
     if passed {
-        " :white_heavy_check_mark: PASSED "
-            .black()
-            .on_green()
-            .bold()
-            .to_string()
+        " ✅ PASSED ".black().on_green().bold().to_string()
     } else {
-        " :cross_mark: FAILED ".white().on_red().bold().to_string()
+        " ❌ FAILED ".white().on_red().bold().to_string()
     }
 }
 

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -193,7 +193,7 @@ pub fn output_file_entries(
             let complexity_text = colorize_complexity(function.complexity, max_complexity);
             let delta_text = output_delta_text(previous_functions, function, max_complexity);
             lines.push(format!(
-                "    {} {}{} {}",
+                "    {} {}{}  {}",
                 function.name, complexity_text, delta_text, status_text
             ));
             if suggest_refactors {

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use owo_colors::OwoColorize;
+use std::io::IsTerminal;
 
 use crate::classes::FileComplexity;
 use crate::cli::output::refactor::output_refactor_plans;
@@ -40,10 +41,11 @@ pub fn handle_console_settings(
 }
 
 pub fn rule(title: &str) -> String {
+    let width = terminal_width();
     if title.is_empty() {
-        return "─".repeat(RULE_WIDTH).bright_green().to_string();
+        return "─".repeat(width).bright_green().to_string();
     }
-    let padding = RULE_WIDTH.saturating_sub(title.chars().count() + 2);
+    let padding = width.saturating_sub(title.chars().count() + 2);
     let left = padding / 2;
     let right = padding - left;
     format!(
@@ -52,6 +54,16 @@ pub fn rule(title: &str) -> String {
         title,
         "─".repeat(right).bright_green()
     )
+}
+
+fn terminal_width() -> usize {
+    if std::io::stdout().is_terminal() {
+        terminal_size::terminal_size()
+            .map(|(width, _)| width.0 as usize)
+            .unwrap_or(RULE_WIDTH)
+    } else {
+        RULE_WIDTH
+    }
 }
 
 pub struct SummaryOptions<'a> {

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -229,9 +229,9 @@ pub fn output_file_entries(
 
 pub fn format_status_text(passed: bool) -> String {
     if passed {
-        format!("✅ {} ", "PASSED".black().on_green().bold())
+        format!("✅ {} ", " PASSED ".black().on_green().bold())
     } else {
-        format!("❌ {} ", "FAILED".white().on_red().bold())
+        format!("❌ {} ", " FAILED ".white().on_red().bold())
     }
 }
 

--- a/src/cli/output/render.rs
+++ b/src/cli/output/render.rs
@@ -229,9 +229,9 @@ pub fn output_file_entries(
 
 pub fn format_status_text(passed: bool) -> String {
     if passed {
-        " ✅ PASSED ".black().on_green().bold().to_string()
+        format!("✅ {} ", " PASSED ".black().on_green().bold())
     } else {
-        " ❌ FAILED ".white().on_red().bold().to_string()
+        format!("❌ {} ", " FAILED ".white().on_red().bold())
     }
 }
 

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -138,12 +138,13 @@ impl OutputFormat {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExitReport {
-    display_ok: bool,
-    snapshot_ok: bool,
-    paths_ok: bool,
-    diff_ok: bool,
-    enforce_diff: bool,
+    pub display_ok: bool,
+    pub snapshot_ok: bool,
+    pub paths_ok: bool,
+    pub diff_ok: bool,
+    pub enforce_diff: bool,
 }
 
 impl ExitReport {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,16 @@
 mod classes;
 #[cfg(feature = "cli")]
 #[allow(dead_code)]
-mod cli;
+pub mod cli;
 pub(crate) mod cognitive_complexity;
 mod helpers;
 mod refactor_plans;
 mod rules;
 #[cfg(any(feature = "python", feature = "cli"))]
 mod runner;
+#[cfg(feature = "cli")]
+pub use runner::run_analysis_shared;
+
 mod utils;
 
 #[cfg(feature = "wasm")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use std::process::ExitCode;
 
 use clap::Parser;
 
+use owo_colors::OwoColorize;
+
 use complexipy::cli::args::CliArgs;
 use complexipy::cli::output::messages::{
     diff_flags_warning, handle_snapshot_console, ignored_saved_output, ignored_summary_output,
@@ -53,7 +55,7 @@ pub fn run_at(cli: CliArgs, invocation_path: &str) -> ExitCode {
 
     let (diff, diff_only) = resolve_diff_flags(config.diff, config.diff_only, config.staged);
     if !config.quiet && diff_only.is_some() && diff.is_none() {
-        println!("[yellow]Warning:[/yellow] {}", diff_flags_warning());
+        println!("{} {}", "Warning:".yellow(), diff_flags_warning());
     }
 
     let (files_complexities, failed_paths) = match run_analysis_shared(
@@ -201,7 +203,8 @@ pub fn run_at(cli: CliArgs, invocation_path: &str) -> ExitCode {
                 None => {
                     if !config.quiet {
                         println!(
-                            "[yellow]Warning:[/yellow] --staged requires a git repository; skipping the staged diff."
+                            "{} --staged requires a git repository; skipping the staged diff.",
+                            "Warning:".yellow()
                         );
                     }
                     None
@@ -231,7 +234,7 @@ pub fn run_at(cli: CliArgs, invocation_path: &str) -> ExitCode {
         if cfg!(windows) {
             println!("{}", rule("Analysis completed!"));
         } else {
-            println!("{}", rule(":tada: Analysis completed! :tada:"));
+            println!("{}", rule("🎉 Analysis completed! 🎉"));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,258 @@
+use std::process::ExitCode;
+
+use clap::Parser;
+
+use complexipy::cli::args::CliArgs;
+use complexipy::cli::output::messages::{
+    diff_flags_warning, handle_snapshot_console, ignored_saved_output, ignored_summary_output,
+    removable_ignores_output,
+};
+use complexipy::cli::output::render::{handle_console_settings, print_invalid_paths, rule};
+use complexipy::cli::output::{
+    DisplayOptions, StorageOptions, handle_display, handle_results_storage,
+};
+use complexipy::cli::types::ExitReport;
+use complexipy::cli::utils::config::resolve_config;
+use complexipy::cli::utils::diff::{
+    compute_diff, compute_staged_diff, has_regressions, resolve_diff_flags,
+};
+use complexipy::cli::utils::ignored::{handle_removable_ignores, handle_report_ignored};
+use complexipy::cli::utils::snapshot::evaluate_snapshot;
+use complexipy::cli::utils::toml::get_complexipy_toml_config;
+use complexipy::run_analysis_shared;
+
+fn main() -> ExitCode {
+    let invocation_path = std::env::current_dir()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    run_at(CliArgs::parse(), &invocation_path)
+}
+
+pub fn run(cli: CliArgs) -> ExitCode {
+    let invocation_path = std::env::current_dir()
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    run_at(cli, &invocation_path)
+}
+
+pub fn run_at(cli: CliArgs, invocation_path: &str) -> ExitCode {
+    let toml_config = get_complexipy_toml_config(invocation_path);
+
+    let config = match resolve_config(toml_config, cli) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("{}", error);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let settings = handle_console_settings(&config.color, config.quiet, config.plain);
+    if !settings.banner.is_empty() {
+        println!("{}", settings.banner);
+    }
+
+    let (diff, diff_only) = resolve_diff_flags(config.diff, config.diff_only, config.staged);
+    if !config.quiet && diff_only.is_some() && diff.is_none() {
+        println!("[yellow]Warning:[/yellow] {}", diff_flags_warning());
+    }
+
+    let (files_complexities, failed_paths) = match run_analysis_shared(
+        &config.paths,
+        config.quiet,
+        &config.exclude,
+        config.check_script,
+        config.no_ignore,
+        invocation_path,
+    ) {
+        Ok(result) => result,
+        Err(error) => {
+            eprintln!("{}", error);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let output_snapshot_path = format!("{}/complexipy-snapshot.json", invocation_path);
+    let snap = match evaluate_snapshot(
+        config.snapshot_create,
+        config.snapshot_ignore,
+        &output_snapshot_path,
+        config.max_complexity_allowed,
+        &files_complexities,
+    ) {
+        Ok(snap) => snap,
+        Err(error) => {
+            eprintln!("{}", error);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match handle_results_storage(StorageOptions {
+        output_formats: &config.output_format,
+        output: config.output.as_deref(),
+        files_complexities: &files_complexities,
+        sort: config.sort.clone(),
+        show_details: !config.failed,
+        max_complexity: config.max_complexity_allowed,
+        invocation_path,
+        suggest_refactors: config.suggest_refactors,
+    }) {
+        Ok(saved_lines) => {
+            for line in saved_lines {
+                println!("{}", line);
+            }
+        }
+        Err(error) => {
+            eprintln!("{}", error);
+            return ExitCode::FAILURE;
+        }
+    }
+
+    let (display_ok, display_output) = handle_display(DisplayOptions {
+        files_complexities: &files_complexities,
+        paths: &config.paths,
+        failed: config.failed,
+        sort: config.sort.clone(),
+        ignore_complexity: config.ignore_complexity,
+        max_complexity_allowed: config.max_complexity_allowed,
+        active_snapshot_map: snap.active_snapshot_map.as_ref(),
+        quiet: config.quiet,
+        plain: config.plain,
+        invocation_path,
+        cache_dir: config.cache_dir.as_deref(),
+        top: config.top,
+        suggest_refactors: config.suggest_refactors,
+    });
+    if !display_output.is_empty() {
+        println!("{}", display_output);
+    }
+
+    let (ignored_locations, ignored_json_path) = match handle_report_ignored(
+        config.report_ignored,
+        &config.paths,
+        &config.exclude,
+        &config.output_format,
+        config.output.as_deref(),
+        config.no_ignore,
+        invocation_path,
+    ) {
+        Ok(result) => result,
+        Err(error) => {
+            eprintln!("{}", error);
+            return ExitCode::FAILURE;
+        }
+    };
+    if config.report_ignored {
+        if !config.quiet {
+            println!(
+                "{}",
+                ignored_summary_output(ignored_locations.len(), config.no_ignore)
+            );
+        }
+        if let Some(path) = ignored_json_path {
+            println!("{}", ignored_saved_output(&path));
+        }
+    }
+
+    if !config.quiet {
+        let removable = handle_removable_ignores(
+            &config.paths,
+            &config.exclude,
+            config.max_complexity_allowed,
+            invocation_path,
+        );
+        let removable_output = removable_ignores_output(&removable);
+        if !removable_output.is_empty() {
+            println!("{}", removable_output);
+        }
+    }
+
+    let snapshot_ok = if config.quiet {
+        if snap.should_run {
+            snap.watermark_success
+        } else {
+            true
+        }
+    } else {
+        let snapshot_output = handle_snapshot_console(&snap, &output_snapshot_path);
+        if !snapshot_output.is_empty() {
+            println!("{}", snapshot_output);
+        }
+        snap.watermark_success
+    };
+
+    let (paths_ok, invalid_paths_output) = print_invalid_paths(&failed_paths);
+    if !invalid_paths_output.is_empty() {
+        println!("{}", invalid_paths_output);
+    }
+
+    let diff_ref = diff.clone().or_else(|| diff_only.clone());
+    let diff_entries = if let Some(diff_ref) = diff_ref {
+        if config.staged {
+            match compute_staged_diff(&diff_ref, invocation_path) {
+                Some(entries) => {
+                    if !config.quiet {
+                        println!(
+                            "{}",
+                            format_diff_for(&entries, &format!("{} (staged)", diff_ref))
+                        );
+                    }
+                    Some(entries)
+                }
+                None => {
+                    if !config.quiet {
+                        println!(
+                            "[yellow]Warning:[/yellow] --staged requires a git repository; skipping the staged diff."
+                        );
+                    }
+                    None
+                }
+            }
+        } else if !files_complexities.is_empty() {
+            let entries = compute_diff(&files_complexities, &diff_ref, invocation_path);
+            if !config.quiet {
+                println!("{}", format_diff_for(&entries, &diff_ref));
+            }
+            Some(entries)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    let mut diff_ok = true;
+    if diff.is_some()
+        && let Some(entries) = diff_entries
+    {
+        diff_ok = !has_regressions(&entries, config.max_complexity_allowed);
+    }
+
+    if !config.quiet && !config.plain {
+        if cfg!(windows) {
+            println!("{}", rule("Analysis completed!"));
+        } else {
+            println!("{}", rule(":tada: Analysis completed! :tada:"));
+        }
+    }
+
+    let report = ExitReport {
+        display_ok,
+        snapshot_ok,
+        paths_ok,
+        diff_ok,
+        enforce_diff: diff.is_some(),
+    };
+    if report.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn format_diff_for(entries: &[complexipy::cli::types::DiffEntry], git_ref: &str) -> String {
+    complexipy::cli::output::diff::format_diff(entries, git_ref)
+}
+
+#[cfg(test)]
+#[path = "tests/cli/main.rs"]
+mod tests;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -39,6 +39,100 @@ struct ProcessOptions {
 
 type ComplexitiesAndFailedPaths = (Vec<FileComplexity>, Vec<String>);
 
+#[cfg(any(feature = "python", feature = "cli"))]
+pub fn run_analysis_shared(
+    paths: &[String],
+    quiet: bool,
+    exclude: &[String],
+    check_script: bool,
+    no_ignore: bool,
+    invocation_path: &str,
+) -> Result<ComplexitiesAndFailedPaths, String> {
+    let mut successful = Vec::new();
+    let mut failed_paths = Vec::new();
+
+    for path in paths {
+        let path_obj = path::Path::new(path);
+        if !path_obj.exists() {
+            failed_paths.push(path.to_string());
+            continue;
+        }
+
+        let opts = ProcessOptions {
+            quiet,
+            exclude: exclude.to_vec(),
+            check_script,
+            no_ignore,
+        };
+
+        let (mut complexities, mut f_paths) = if path_obj.is_dir() {
+            evaluate_dir_shared(path, &opts, invocation_path)
+        } else {
+            match analyze_file_shared(path, &opts, invocation_path) {
+                Ok(file_complexity) => (vec![file_complexity], vec![]),
+                Err(_) => (vec![], vec![path.to_string()]),
+            }
+        };
+        complexities
+            .iter_mut()
+            .for_each(|f| f.functions.sort_by_key(|f| (f.complexity, f.name.clone())));
+        complexities.sort_by_key(|f| (f.path.clone(), f.file_name.clone(), f.complexity));
+        successful.append(&mut complexities);
+        failed_paths.append(&mut f_paths);
+    }
+
+    Ok((successful, failed_paths))
+}
+
+#[cfg(any(feature = "python", feature = "cli"))]
+fn evaluate_dir_shared(
+    path: &str,
+    opts: &ProcessOptions,
+    invocation_path: &str,
+) -> ComplexitiesAndFailedPaths {
+    let inv_abs = path::Path::new(invocation_path)
+        .canonicalize()
+        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
+    let base_dir = inv_abs.to_string_lossy().replace('\\', "/");
+    let files_paths_to_process = match get_paths_to_process(path, opts.exclude.clone()) {
+        Ok(paths) => paths,
+        Err(e) => return (vec![], vec![format!("{}: {}", path, e)]),
+    };
+
+    let mut complexities = Vec::new();
+    let mut failed_paths = Vec::new();
+    for file_path in files_paths_to_process {
+        match analyze_file_shared(&file_path, opts, &base_dir) {
+            Ok(file_complexity) => complexities.push(file_complexity),
+            Err(_) => failed_paths.push(file_path.clone()),
+        }
+    }
+    (complexities, failed_paths)
+}
+
+#[cfg(any(feature = "python", feature = "cli"))]
+fn analyze_file_shared(
+    path: &str,
+    opts: &ProcessOptions,
+    invocation_path: &str,
+) -> Result<FileComplexity, String> {
+    let inv_abs = path::Path::new(invocation_path)
+        .canonicalize()
+        .unwrap_or_else(|_| path::Path::new(invocation_path).to_path_buf());
+    let inv_str = inv_abs.to_string_lossy().replace('\\', "/");
+    let file_abs = path::Path::new(path)
+        .canonicalize()
+        .unwrap_or_else(|_| path::Path::new(path).to_path_buf());
+    let rel = file_abs
+        .strip_prefix(&inv_abs)
+        .ok()
+        .and_then(|p| p.to_str())
+        .unwrap_or(path);
+    let mut complexity = file_complexity_shared(path, &inv_str, opts.check_script, opts.no_ignore)?;
+    complexity.path = rel.to_string();
+    Ok(complexity)
+}
+
 #[cfg(feature = "python")]
 #[pyfunction]
 #[pyo3(signature = (paths, quiet, exclude, check_script=false, no_ignore=false, invocation_path="."))]

--- a/src/tests/cli/main.rs
+++ b/src/tests/cli/main.rs
@@ -1,0 +1,156 @@
+//! Wired in from `src/main.rs` via `#[cfg(test)] #[path = ...] mod tests;`
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use clap::Parser;
+use tempfile::tempdir;
+
+use crate::run_at;
+use complexipy::cli::args::CliArgs;
+
+const SIMPLE: &str = "def simple(x):\n    return x + 1\n";
+
+const COMPLEX: &str = "def complex_func(data):\n    if data:\n        for item in data:\n            if item:\n                for x in item:\n                    if x:\n                        for y in x:\n                            if y:\n                                return y\n    return None\n";
+
+fn git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .expect("git should run");
+    assert!(status.success(), "git {:?} failed", args);
+}
+
+fn init_repo(dir: &Path) {
+    git(dir, &["init", "-q"]);
+    git(dir, &["config", "user.email", "test@example.com"]);
+    git(dir, &["config", "user.name", "Test"]);
+    git(dir, &["add", "-A"]);
+    git(dir, &["commit", "-q", "-m", "initial"]);
+}
+
+fn parse(args: &[&str]) -> CliArgs {
+    let mut argv = vec!["complexipy"];
+    argv.extend_from_slice(args);
+    CliArgs::try_parse_from(argv).expect("cli args should parse")
+}
+
+#[test]
+fn missing_paths_exits_failure() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let exit = run_at(parse(&[]), dir.path().to_str().unwrap());
+
+    assert_eq!(exit, std::process::ExitCode::FAILURE);
+}
+
+#[test]
+fn clean_run_exits_success() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("simple.py");
+    fs::write(&file, SIMPLE).expect("should write");
+
+    let exit = run_at(
+        parse(&[file.to_str().unwrap()]),
+        dir.path().to_str().unwrap(),
+    );
+
+    assert_eq!(exit, std::process::ExitCode::SUCCESS);
+}
+
+#[test]
+fn failed_run_exits_failure() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("complex.py");
+    fs::write(&file, COMPLEX).expect("should write");
+
+    let exit = run_at(
+        parse(&[file.to_str().unwrap(), "--failed"]),
+        dir.path().to_str().unwrap(),
+    );
+
+    assert_eq!(exit, std::process::ExitCode::FAILURE);
+}
+
+#[test]
+fn snapshot_create_writes_snapshot_file() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("complex.py");
+    fs::write(&file, COMPLEX).expect("should write");
+
+    let exit = run_at(
+        parse(&[file.to_str().unwrap(), "--snapshot-create"]),
+        dir.path().to_str().unwrap(),
+    );
+
+    assert_eq!(exit, std::process::ExitCode::SUCCESS);
+    assert!(dir.path().join("complexipy-snapshot.json").exists());
+}
+
+#[test]
+fn invalid_path_exits_failure() {
+    let dir = tempdir().expect("tempdir should work");
+
+    let exit = run_at(
+        parse(&[dir.path().join("nope.py").to_str().unwrap()]),
+        dir.path().to_str().unwrap(),
+    );
+
+    assert_eq!(exit, std::process::ExitCode::FAILURE);
+}
+
+#[test]
+fn diff_regression_exits_failure() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("a.py");
+    fs::write(&file, SIMPLE).expect("should write");
+    init_repo(dir.path());
+
+    fs::write(&file, COMPLEX).expect("should write");
+    let exit = run_at(
+        parse(&[file.to_str().unwrap(), "--diff", "HEAD"]),
+        dir.path().to_str().unwrap(),
+    );
+
+    assert_eq!(exit, std::process::ExitCode::FAILURE);
+}
+
+#[test]
+fn diff_clean_exits_success() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("a.py");
+    fs::write(&file, COMPLEX).expect("should write");
+    init_repo(dir.path());
+
+    let exit = run_at(
+        parse(&[file.to_str().unwrap(), "--diff", "HEAD"]),
+        dir.path().to_str().unwrap(),
+    );
+
+    assert_eq!(exit, std::process::ExitCode::SUCCESS);
+}
+
+#[test]
+fn plain_flag_accepted() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("simple.py");
+    fs::write(&file, SIMPLE).expect("should write");
+
+    let exit = run_at(
+        parse(&[file.to_str().unwrap(), "--plain"]),
+        dir.path().to_str().unwrap(),
+    );
+
+    assert_eq!(exit, std::process::ExitCode::SUCCESS);
+}
+
+#[test]
+fn version_flag_handled_by_clap() {
+    let result = CliArgs::try_parse_from(["complexipy", "--version"]);
+
+    assert!(result.is_err());
+}

--- a/src/tests/cli/output/render.rs
+++ b/src/tests/cli/output/render.rs
@@ -50,15 +50,13 @@ fn status_text_emoji_outside_color() {
     assert!(passed.starts_with("✅ "));
     let colored = passed.trim_start_matches("✅ ");
     assert!(colored.starts_with("\u{1b}["));
-    assert!(colored.contains("PASSED"));
-    assert!(!colored.contains(" PASSED "));
+    assert!(colored.contains(" PASSED "));
 
     let failed = format_status_text(false);
     assert!(failed.starts_with("❌ "));
     let colored = failed.trim_start_matches("❌ ");
     assert!(colored.starts_with("\u{1b}["));
-    assert!(colored.contains("FAILED"));
-    assert!(!colored.contains(" FAILED "));
+    assert!(colored.contains(" FAILED "));
 }
 
 #[test]

--- a/src/tests/cli/output/render.rs
+++ b/src/tests/cli/output/render.rs
@@ -186,7 +186,7 @@ fn invalid_paths_rendering() {
 
 #[test]
 fn rule_renders_title_with_padding() {
-    let output = rule("complexipy");
+    let output = strip_ansi(&rule("complexipy"));
     assert!(output.contains("complexipy"));
     assert!(output.starts_with('─'));
     assert!(output.ends_with('─'));

--- a/src/tests/cli/output/render.rs
+++ b/src/tests/cli/output/render.rs
@@ -50,13 +50,15 @@ fn status_text_emoji_outside_color() {
     assert!(passed.starts_with("✅ "));
     let colored = passed.trim_start_matches("✅ ");
     assert!(colored.starts_with("\u{1b}["));
-    assert!(colored.contains(" PASSED "));
+    assert!(colored.contains("PASSED"));
+    assert!(!colored.contains(" PASSED "));
 
     let failed = format_status_text(false);
     assert!(failed.starts_with("❌ "));
     let colored = failed.trim_start_matches("❌ ");
     assert!(colored.starts_with("\u{1b}["));
-    assert!(colored.contains(" FAILED "));
+    assert!(colored.contains("FAILED"));
+    assert!(!colored.contains(" FAILED "));
 }
 
 #[test]

--- a/src/tests/cli/output/render.rs
+++ b/src/tests/cli/output/render.rs
@@ -45,6 +45,21 @@ fn status_text_contains_labels() {
 }
 
 #[test]
+fn status_text_emoji_outside_color() {
+    let passed = format_status_text(true);
+    assert!(passed.starts_with("✅ "));
+    let colored = passed.trim_start_matches("✅ ");
+    assert!(colored.starts_with("\u{1b}["));
+    assert!(colored.contains(" PASSED "));
+
+    let failed = format_status_text(false);
+    assert!(failed.starts_with("❌ "));
+    let colored = failed.trim_start_matches("❌ ");
+    assert!(colored.starts_with("\u{1b}["));
+    assert!(colored.contains(" FAILED "));
+}
+
+#[test]
 fn colorize_marks_over_threshold_red() {
     let ok = colorize_complexity(5, 5);
     let bad = colorize_complexity(6, 5);

--- a/src/tests/cli/output/render.rs
+++ b/src/tests/cli/output/render.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 
 use crate::cli::output::render::{
     SummaryOptions, colorize_complexity, format_status_text, handle_console_settings,
-    output_delta_text, output_plain, output_summary, print_invalid_paths, rule,
+    output_delta_text, output_plain, output_summary, print_invalid_paths, rule, rule_at,
 };
 use crate::cli::types::{Color, FileEntry, FunctionRow, Sort};
+use unicode_width::UnicodeWidthStr;
 
 fn strip_ansi(input: &str) -> String {
     let mut result = String::new();
@@ -190,6 +191,21 @@ fn rule_renders_title_with_padding() {
     assert!(output.contains("complexipy"));
     assert!(output.starts_with('─'));
     assert!(output.ends_with('─'));
+    assert_eq!(output.chars().count(), 80);
+}
+
+#[test]
+fn rule_matches_rich_layout_at_width() {
+    let output = strip_ansi(&rule_at("🎉 Analysis completed! 🎉", 100));
+    // Rich: side = (width - title_cells) / 2; left = side - 1; clamp to width.
+    // title cells = 2+1+19+1+2 = 25; width 100 -> side 37 -> left 36, right 37.
+    let stripped = output.trim_end_matches(' ');
+    let left = stripped.chars().take_while(|c| *c == '─').count();
+    let right = stripped.chars().rev().take_while(|c| *c == '─').count();
+    assert_eq!(left, 36);
+    assert_eq!(right, 37);
+    assert_eq!(output.chars().count(), 98);
+    assert_eq!(UnicodeWidthStr::width(output.as_str()), 100);
 }
 
 #[test]


### PR DESCRIPTION
## What

Adds the Rust CLI binary — the final integration point of the migration in issue #224. The binary orchestrates the full pipeline (config, analysis, snapshot, storage, display, ignored, diff) and applies the same exit-code gates as main.py.

## Why

Every building block existed from Steps 1–14; Step 15 wires them into `src/main.rs` and de-PyO3s the analysis pipeline for the CLI. Per the deprecation policy, the binary has no git-URL run support.

## Changes

- `Cargo.toml` — `crate-type = ["cdylib", "rlib"]` (rlib lets the bin link the lib), `[[bin]]` with `required-features = ["cli"]` (wasm check stays clean)
- `src/runner.rs` — `run_analysis_shared` / `evaluate_dir_shared` / `analyze_file_shared` (`any(python, cli)`, no URL branch, no progress bar — documented cosmetic gap); python `main()` keeps URLs + progress until retirement
- `src/lib.rs` — `pub mod cli;` + `pub use runner::run_analysis_shared;` for the bin
- `src/main.rs` — `run_at(cli, invocation_path)`: parse → TOML → `resolve_config` (errors → exit 1) → banner → diff flags + warning → analysis → `evaluate_snapshot` → `handle_results_storage` → `handle_display` → ignored → invalid paths → diff + ratchet → "Analysis completed!" rule → `ExitReport` → exit 0/1
- `src/cli/types.rs` — `ExitReport` activated
- `src/tests/cli/main.rs` — 9 integration tests: missing paths, clean/failed runs, snapshot creation, invalid paths, diff regression + clean diff, plain flag, version
- Divergence: `--version` prints `complexipy 7.0.1` (clap built-in) vs Python's bare version
## Follow-up fixes (included)

- `fix(cli): render emojis and bold rule lines` — Rich emoji codes replaced with literal Unicode (🐙 ✅ ❌ 🎉); two literal `[yellow]` markup leftovers in warnings replaced with owo styling
- `fix(cli): style rule lines bright green` — rules use Rich's default `rule.line: bright_green`, verified against the installed rich theme
- `fix(cli): render rules at terminal width` — rules span the live terminal width (`terminal-size` crate), centered title, 80 fallback when not a TTY
- `fix(cli): replicate rich rule layout with cell widths` — Rich's exact `rule.py` algorithm: cell-width titles (`unicode-width`), `left = side - 1`, `right = min(side + 1, ...)`, `set_cell_size` clamp; layout test at width 100

- `fix(cli): keep status emoji outside color container` — ✅/❌ rendered outside the color background; only the padded word (` PASSED `/` FAILED `) carries the color
- `fix(cli): space status segment from complexity` — two spaces between the complexity/delta and the ✅/❌ status segment; emoji stays on the left (Python parity)
- `fix(cli): color only status word for padded look` — the background covers only `PASSED`/`FAILED`; plain spaces pad it on both sides (terminal cell height is fixed, so horizontal extent is the lever)
Issue: #224



