### PR TITLE
feat(cli): mirror python api surface and document removals (step 16)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,3 +105,5 @@ jobs:
             ${{ runner.os }}-cargo-
       - name: cargo test
         run: cargo test --features python
+      - name: cargo test cli-only
+        run: cargo test --no-default-features --features cli

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,3 +107,11 @@ jobs:
         run: cargo test --features python
       - name: cargo test cli-only
         run: cargo test --no-default-features --features cli
+      - name: cargo clippy
+        run: cargo clippy --features python --all-targets -- -D warnings
+      - name: cargo fmt
+        run: cargo fmt --check
+      - name: cargo check wasm
+        run: |-
+          rustup target add wasm32-unknown-unknown
+          cargo check --no-default-features --features wasm --target wasm32-unknown-unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ release section links to its GitHub release notes for the full details.
 
 ## Unreleased
 
+### Changed
+
+- The CLI is being rewritten in Rust. The port of the full command
+  pipeline (configuration, analysis, snapshot, export formats, diff and
+  ratchet gates) is complete and the Rust binary is now the foundation of
+  the next major release; the Python CLI remains the installed command
+  until the cutover. ([#224](https://github.com/rohaquinlop/complexipy/issues/224))
+
 ## [7.0.1] - 2026-08-12
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["cli"]
 
 [features]
 default = ["python", "cli"]
-cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore", "dep:comfy-table", "dep:owo-colors", "dep:syntect", "dep:terminal_size", "dep:unicode-width"]
+cli = ["dep:clap", "dep:toml", "serde", "dep:blake2", "csv", "dep:sha2", "regex", "ruff_python_ast", "ruff_python_parser", "ignore", "tempfile", "dep:comfy-table", "dep:owo-colors", "dep:syntect", "dep:terminal_size", "dep:unicode-width"]
 python = [
     "serde",
     "pyo3",

--- a/docs/es/migracion.md
+++ b/docs/es/migracion.md
@@ -34,3 +34,17 @@ Las siguientes flags de CLI y claves TOML se eliminaron. Usa sus reemplazos:
   comparación staged por defecto.
 - `failed = true` muestra solo las funciones por encima del umbral de
   complejidad.
+
+## Eliminado en la próxima versión mayor
+
+La CLI se está reescribiendo en Rust. Las siguientes características de
+compatibilidad con versiones antiguas se eliminan en la próxima versión
+mayor:
+
+- **Análisis por URL de Git** (`complexipy <repository-url>`) — solo rutas
+  locales.
+- **Migración de caché heredada** — el diseño anterior
+  `.complexipy_cache/<hash>.json` ya no se migra; los archivos heredados
+  existentes se ignoran y el historial de diferencias comienza vacío.
+- **Archivos de snapshot heredados** — los snapshots creados con versiones
+  antiguas ya no se detectan; vuelve a crearlos con `--snapshot-create`.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -23,6 +23,18 @@ instead:
 | `staged = true` | `[tool.complexipy.diff] staged = true` |
 | `details = "low"` | `failed = true` |
 
+## Removed in the next major release
+
+The CLI is being rewritten in Rust. The following old-version compatibility
+features are removed in the next major version:
+
+- **Git-URL analysis** (`complexipy <repository-url>`) — local paths only.
+- **Legacy cache migration** — the previous
+  `.complexipy_cache/<hash>.json` layout is no longer migrated; existing
+  legacy files are ignored and the delta history starts fresh.
+- **Legacy snapshot files** — snapshots created with older versions are no
+  longer detected; recreate them with `--snapshot-create`.
+
 ## What each replacement does
 
 - `--output-format <format>` selects the machine-readable output format

--- a/src/cognitive_complexity.rs
+++ b/src/cognitive_complexity.rs
@@ -10,7 +10,7 @@ mod shared_deps {
     pub use ruff_python_ast::{self as ast, Stmt};
 }
 
-#[cfg(feature = "python")]
+#[cfg(any(feature = "python", feature = "cli"))]
 use crate::classes::CodeComplexity;
 
 #[cfg(any(feature = "python", feature = "wasm", feature = "cli"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod classes;
+pub mod classes;
 #[cfg(feature = "cli")]
 #[allow(dead_code)]
 pub mod cli;
@@ -13,8 +13,31 @@ pub use runner::run_analysis_shared;
 
 mod utils;
 
+/// Stable public API — mirrors `complexipy/__init__.py`'s `__all__`.
+/// Names here are a compatibility promise; do not move or rename them
+/// without a major release.
+pub use classes::{
+    Applicability, CodeComplexity, CodeSuggestion, FileComplexity, FunctionComplexity,
+    IgnoredLocation, LineComplexity, RefactorPlan, RemovableIgnore, RuleCategory,
+};
+#[cfg(feature = "cli")]
+pub use cli::api::{code_complexity, file_complexity};
+#[cfg(feature = "cli")]
+pub use cli::types::{DiffEntry, DiffStatus};
+#[cfg(feature = "cli")]
+pub use cli::utils::diff::{compute_diff, has_regressions};
+#[cfg(any(feature = "python", feature = "cli"))]
+pub use runner::{
+    collect_all_ignored_locations_shared as collect_all_ignored_locations,
+    collect_removable_ignored_locations_shared as collect_removable_ignored_locations,
+};
+
 #[cfg(feature = "wasm")]
 mod wasm;
+
+#[cfg(test)]
+#[path = "tests/lib_surface.rs"]
+mod surface_tests;
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;

--- a/src/tests/lib_surface.rs
+++ b/src/tests/lib_surface.rs
@@ -1,0 +1,72 @@
+//! Wired in from `src/lib.rs` via `#[cfg(test)] #[path = ...] mod surface_tests;`
+
+use std::fs;
+
+use tempfile::tempdir;
+
+use crate::{
+    Applicability, CodeComplexity, CodeSuggestion, DiffEntry, DiffStatus, FileComplexity,
+    FunctionComplexity, IgnoredLocation, LineComplexity, RefactorPlan, RemovableIgnore,
+    RuleCategory, code_complexity, collect_all_ignored_locations,
+    collect_removable_ignored_locations, compute_diff, file_complexity, has_regressions,
+};
+
+#[test]
+fn stable_api_types_exist() {
+    let _ = std::mem::size_of::<Applicability>();
+    let _ = std::mem::size_of::<CodeComplexity>();
+    let _ = std::mem::size_of::<CodeSuggestion>();
+    let _ = std::mem::size_of::<DiffEntry>();
+    let _ = std::mem::size_of::<DiffStatus>();
+    let _ = std::mem::size_of::<FileComplexity>();
+    let _ = std::mem::size_of::<FunctionComplexity>();
+    let _ = std::mem::size_of::<IgnoredLocation>();
+    let _ = std::mem::size_of::<LineComplexity>();
+    let _ = std::mem::size_of::<RefactorPlan>();
+    let _ = std::mem::size_of::<RemovableIgnore>();
+    let _ = std::mem::size_of::<RuleCategory>();
+}
+
+#[test]
+fn stable_api_code_complexity_works() {
+    let result =
+        code_complexity("def f(x):\n    return x\n", false, false).expect("should analyze");
+    assert_eq!(result.functions.len(), 1);
+    assert_eq!(result.functions[0].name, "f");
+}
+
+#[test]
+fn stable_api_file_complexity_works() {
+    let dir = tempdir().expect("tempdir should work");
+    let file = dir.path().join("m.py");
+    fs::write(&file, "def f(x):\n    return x\n").expect("should write");
+
+    let result = file_complexity(file.to_str().unwrap(), false, false).expect("should analyze");
+    assert_eq!(result.functions[0].name, "f");
+}
+
+#[test]
+fn stable_api_diff_and_ratchet_work() {
+    let entry = DiffEntry {
+        file_path: "a.py".to_string(),
+        func_name: "f".to_string(),
+        old_complexity: Some(2),
+        new_complexity: Some(6),
+    };
+    assert_eq!(entry.status(), DiffStatus::Regressed);
+    assert!(has_regressions(&[entry], 5));
+
+    assert!(compute_diff(&[], "HEAD", ".").is_empty());
+}
+
+#[test]
+fn stable_api_collectors_work() {
+    let (locations, failed) = collect_all_ignored_locations(&[], &[], ".").expect("should run");
+    assert!(locations.is_empty());
+    assert!(failed.is_empty());
+
+    let (removable, failed) =
+        collect_removable_ignored_locations(&[], &[], 15, ".").expect("should run");
+    assert!(removable.is_empty());
+    assert!(failed.is_empty());
+}


### PR DESCRIPTION
## What

Final step of the CLI migration in issue #224: the Rust library gets its stable public surface mirroring `complexipy/__init__.py`'s `__all__`, and the deprecation-policy removals are documented EN + ES.

## Why

`__all__` is a compatibility promise; the Rust side needs the same deliberate surface. The Python `__init__.py` stays untouched until the major release cutover. The migration docs record what the next major removes.

## Changes

- `src/lib.rs` — stable re-export surface at the lib root with the compatibility-promise doc comment:
  - 12 types: `Applicability`, `CodeComplexity`, `CodeSuggestion`, `DiffEntry`, `DiffStatus`, `FileComplexity`, `FunctionComplexity`, `IgnoredLocation`, `LineComplexity`, `RefactorPlan`, `RemovableIgnore`, `RuleCategory`
  - 6 functions: `code_complexity`, `file_complexity`, `compute_diff`, `has_regressions`, plus the collectors re-exported under clean names (`collect_all_ignored_locations`, `collect_removable_ignored_locations`)
- `src/tests/lib_surface.rs` — 5 export-surface tests proving every `__all__` name resolves
- `docs/migration.md` + `docs/es/migracion.md` — "Removed in the next major release" section: Git-URL analysis, legacy cache migration (reworded: legacy files ignored, delta history starts fresh), legacy snapshot files (never migrated — recreation was always required)

This closes the 16-step port. The release-time cutover (command swap, Python CLI retirement) is the migration's remaining half.

- `docs(changelog): reference the rust cli port` — `CHANGELOG.md` gains an `Unreleased` entry noting the Rust port foundation and that the Python CLI remains the installed command until the cutover

Issue: #224
