### PR TITLE
fix(refactors): make machine suggestions faithful source replacements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,7 +202,7 @@ so `id` / `category` / `applicability` / `description` / `doc_url` can only ever
 from metadata; rules fill in the dynamic fields via `..metadata().new_plan()`.
 
 `RuleRegistry::analyze()` then, in order: collects plans over the region tree
-recursively, drops any plan with `estimated_reduction < 2` as noise, sorts by
+recursively, drops any plan with `estimated_reduction < 1` as noise, sorts by
 spliceable desc → `effectiveness` desc → reduction desc → line asc (a
 machine-applicable replacement beats a help-only plan of higher
 effectiveness), resolves overlapping line ranges by keeping the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,9 +203,11 @@ from metadata; rules fill in the dynamic fields via `..metadata().new_plan()`.
 
 `RuleRegistry::analyze()` then, in order: collects plans over the region tree
 recursively, drops any plan with `estimated_reduction < 2` as noise, sorts by
-`effectiveness` desc → reduction desc → line asc, resolves overlapping line ranges by
-keeping the higher-effectiveness/higher-reduction plan, and caps at 5 plans per
-function.
+spliceable desc → `effectiveness` desc → reduction desc → line asc (a
+machine-applicable replacement beats a help-only plan of higher
+effectiveness), resolves overlapping line ranges by keeping the
+higher-spliceable/higher-effectiveness/higher-reduction plan, and caps at 5
+plans per function.
 
 `effectiveness` in `RuleMetadata` is the single source of truth for ranking — the
 registry reads it via `effectiveness_by_rule_id()`, so there is no `match rule_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ release section links to its GitHub release notes for the full details.
   trailing comments are handled instead of being misplaceable by the
   replacement.
   ([#228](https://github.com/rohaquinlop/complexipy/issues/228), [#236](https://github.com/rohaquinlop/complexipy/issues/236))
+- The C007 preceding-statement guard no longer fails when blank or
+  comment-only lines sit between the outer and inner `if`: the indent
+  step detection now skips such lines, so the merge is still rejected
+  instead of producing a replacement that drops code.
+  ([#245](https://github.com/rohaquinlop/complexipy/issues/245))
+- The C002 loop-guards suggestion keeps statements that sit between the
+  chained `if`s: they now appear in the replacement between the
+  corresponding guards instead of being dropped.
+- The C005 extract-predicate suggestion keeps the statement keyword:
+  `while` conditions stay `while` loops, and `elif` conditions get help
+  text only instead of a broken standalone `if` replacement. The
+  predicate body indent now follows the file's indent step.
 
 ## [7.0.1] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ release section links to its GitHub release notes for the full details.
   `while` conditions stay `while` loops, and `elif` conditions get help
   text only instead of a broken standalone `if` replacement. The
   predicate body indent now follows the file's indent step.
+- C002 and C007 refuse machine suggestions when the shifted body holds a
+  multi-line string literal: dedenting would change the string's value.
+  The plans carry help text instead.
+- C002 loop guards strip a redundant top-level `not` from the guard
+  condition (`if not a:` becomes guard `if a:`), and C005 predicate names
+  get an underscore suffix when the source already defines the generated
+  name.
 
 ## [7.0.1] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@ release section links to its GitHub release notes for the full details.
   ([#245](https://github.com/rohaquinlop/complexipy/issues/245))
 - The C002 loop-guards suggestion keeps statements that sit between the
   chained `if`s: they now appear in the replacement between the
-  corresponding guards instead of being dropped.
+  corresponding guards instead of being dropped. Guard conditions are now
+  parenthesized (`if not (<cond>):`), so inverting conditions with `and`
+  or `or` no longer silently changes what the guard skips.
 - The C005 extract-predicate suggestion keeps the statement keyword:
   `while` conditions stay `while` loops, and `elif` conditions get help
   text only instead of a broken standalone `if` replacement. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ release section links to its GitHub release notes for the full details.
   condition (`if not a:` becomes guard `if a:`), and C005 predicate names
   get an underscore suffix when the source already defines the generated
   name.
+- C005 extract-predicate now emits a module-level helper whose parameters
+  are the condition's free variables (attribute bases included, builtins
+  excluded), so the helper is unit-testable. The snippet shows the
+  enclosing context at the statement's real indentation. Conditions that
+  bind a name (`:=`) or contain a lambda/comprehension get help text only.
 
 ## [7.0.1] - 2026-08-12
 

--- a/docs/es/changelog.md
+++ b/docs/es/changelog.md
@@ -25,6 +25,19 @@ GitHub con todos los detalles.
   comentarios en cabeceras multilínea y los comentarios finales se
   manejan en lugar de poder ser desplazados por el reemplazo.
   ([#228](https://github.com/rohaquinlop/complexipy/issues/228), [#236](https://github.com/rohaquinlop/complexipy/issues/236))
+- El guardián de la regla C007 ya no falla cuando hay líneas en blanco o
+  solo comentarios entre el `if` exterior y el interior: la detección del
+  paso de sangría ahora omite esas líneas, por lo que la fusión se sigue
+  rechazando en lugar de producir un reemplazo que elimina código.
+  ([#245](https://github.com/rohaquinlop/complexipy/issues/245))
+- La sugerencia de guards de bucle C002 conserva las sentencias que quedan
+  entre los `if` encadenados: ahora aparecen en el reemplazo entre los
+  guards correspondientes en lugar de eliminarse.
+- La sugerencia de extracción de predicado C005 conserva la palabra clave
+  de la sentencia: las condiciones `while` siguen siendo bucles `while`, y
+  las condiciones `elif` reciben solo texto de ayuda en lugar de un
+  reemplazo `if` independiente inválido. La sangría del cuerpo del
+  predicado ahora sigue el paso de sangría del archivo.
 
 ## [7.0.1] - 2026-08-12
 

--- a/docs/es/changelog.md
+++ b/docs/es/changelog.md
@@ -47,6 +47,12 @@ GitHub con todos los detalles.
   (`if not a:` se convierte en guard `if a:`), y los nombres de predicado
   de C005 reciben un sufijo de guion bajo cuando el código fuente ya define
   el nombre generado.
+- La extracción de predicado C005 ahora emite un helper a nivel de módulo
+  cuyos parámetros son las variables libres de la condición (bases de
+  atributos incluidas, builtins excluidas), de modo que el helper es
+  testeable por unidad. El fragmento muestra el contexto que lo rodea en la
+  indentación real de la sentencia. Las condiciones que vinculan un nombre
+  (`:=`) o contienen un lambda/comprensión reciben solo texto de ayuda.
 
 ## [7.0.1] - 2026-08-12
 

--- a/docs/es/changelog.md
+++ b/docs/es/changelog.md
@@ -32,7 +32,9 @@ GitHub con todos los detalles.
   ([#245](https://github.com/rohaquinlop/complexipy/issues/245))
 - La sugerencia de guards de bucle C002 conserva las sentencias que quedan
   entre los `if` encadenados: ahora aparecen en el reemplazo entre los
-  guards correspondientes en lugar de eliminarse.
+  guards correspondientes en lugar de eliminarse. Las condiciones de guarda
+  ahora se parentizan (`if not (<cond>):`), de modo que invertir condiciones
+  con `and` u `or` ya no cambia silenciosamente lo que omite la guarda.
 - La sugerencia de extracción de predicado C005 conserva la palabra clave
   de la sentencia: las condiciones `while` siguen siendo bucles `while`, y
   las condiciones `elif` reciben solo texto de ayuda en lugar de un

--- a/docs/es/changelog.md
+++ b/docs/es/changelog.md
@@ -40,6 +40,13 @@ GitHub con todos los detalles.
   las condiciones `elif` reciben solo texto de ayuda en lugar de un
   reemplazo `if` independiente inválido. La sangría del cuerpo del
   predicado ahora sigue el paso de sangría del archivo.
+- C002 y C007 rechazan sugerencias de máquina cuando el cuerpo desplazado
+  contiene un literal de cadena multilínea: quitar sangría cambiaría su
+  valor. Los planes llevan texto de ayuda en su lugar.
+- Los guards de bucle C002 eliminan un `not` redundante de la condición
+  (`if not a:` se convierte en guard `if a:`), y los nombres de predicado
+  de C005 reciben un sufijo de guion bajo cuando el código fuente ya define
+  el nombre generado.
 
 ## [7.0.1] - 2026-08-12
 

--- a/docs/es/refactoring-rules.md
+++ b/docs/es/refactoring-rules.md
@@ -316,6 +316,8 @@ Extrae condiciones booleanas complejas en funciones predicado con nombre.
 
 Esta regla se activa cuando una condición booleana contiene 2+ operadores lógicos (and, or, not).
 
+La sugerencia conserva la palabra clave de la sentencia: una condición `if` sigue siendo `if`, una condición `while` sigue siendo `while`. Las condiciones en líneas `elif` solo reciben texto de ayuda, porque una función extraída no puede colocarse dentro de una cadena if.
+
 #### Ejemplo
 
 **Antes:**
@@ -357,6 +359,8 @@ Combina sentencias `if` anidadas en un único `if` con las condiciones combinada
 #### ¿Cuándo se activa?
 
 Esta regla se activa cuando el cuerpo completo de una sentencia `if` es un único `if` anidado sin rama `else`, para una cadena de dos o más niveles de este tipo.
+
+La fusión se omite cuando hay alguna sentencia o comentario entre el `if` exterior y el interior, de modo que la sugerencia nunca elimina código.
 
 #### Ejemplo
 

--- a/docs/es/refactoring-rules.md
+++ b/docs/es/refactoring-rules.md
@@ -97,9 +97,9 @@ def process_items(items):
 def process_items(items):
     total = 0
     for item in items:
-        if not item.active:
+        if not (item.active):
             continue
-        if not item.ready:
+        if not (item.ready):
             continue
         total += item.value
     return total

--- a/docs/es/refactoring-rules.md
+++ b/docs/es/refactoring-rules.md
@@ -318,6 +318,8 @@ Esta regla se activa cuando una condición booleana contiene 2+ operadores lógi
 
 La sugerencia conserva la palabra clave de la sentencia: una condición `if` sigue siendo `if`, una condición `while` sigue siendo `while`. Las condiciones en líneas `elif` solo reciben texto de ayuda, porque una función extraída no puede colocarse dentro de una cadena if.
 
+El helper extraído se emite a nivel de módulo con las variables libres de la condición como parámetros (bases de atributos incluidas, builtins excluidas), de modo que es testeable por unidad. El fragmento muestra el contexto que lo rodea en la indentación real de la sentencia, con marcadores `...` para las sentencias omitidas. Las condiciones que vinculan un nombre con `:=` o contienen un lambda/comprensión reciben solo texto de ayuda.
+
 #### Ejemplo
 
 **Antes:**

--- a/docs/refactoring-rules.md
+++ b/docs/refactoring-rules.md
@@ -318,6 +318,8 @@ This rule triggers when a boolean condition contains 2+ logical operators (and, 
 
 The suggestion keeps the statement keyword: an `if` condition stays an `if`, a `while` condition stays a `while`. Conditions on `elif` lines only get help text, because an extracted function cannot be placed inside an if-chain.
 
+The extracted helper is emitted at module level with the condition's free variables as parameters (attribute bases included, builtins excluded), so it is unit-testable. The snippet shows the enclosing context at the statement's real indentation, with `...` placeholders for skipped statements. Conditions that bind a name with `:=` or contain a lambda/comprehension get help text only.
+
 #### Example
 
 **Before:**

--- a/docs/refactoring-rules.md
+++ b/docs/refactoring-rules.md
@@ -316,6 +316,8 @@ Extract complex boolean conditions into named predicate functions.
 
 This rule triggers when a boolean condition contains 2+ logical operators (and, or, not).
 
+The suggestion keeps the statement keyword: an `if` condition stays an `if`, a `while` condition stays a `while`. Conditions on `elif` lines only get help text, because an extracted function cannot be placed inside an if-chain.
+
 #### Example
 
 **Before:**
@@ -357,6 +359,8 @@ Merge nested if statements into a single if with combined conditions.
 #### When does it trigger?
 
 This rule triggers when an `if` statement's entire body is a single nested `if` with no `else` branch, for a chain of two or more such levels.
+
+The merge is skipped when any statement or comment sits between the outer and inner `if`, so the suggestion never drops code.
 
 #### Example
 

--- a/docs/refactoring-rules.md
+++ b/docs/refactoring-rules.md
@@ -97,9 +97,9 @@ def process_items(items):
 def process_items(items):
     total = 0
     for item in items:
-        if not item.active:
+        if not (item.active):
             continue
-        if not item.ready:
+        if not (item.ready):
             continue
         total += item.value
     return total

--- a/src/rules/complexity.rs
+++ b/src/rules/complexity.rs
@@ -510,10 +510,6 @@ impl RefactorRule for CollapsibleIfRule {
         }
 
         let outermost = chain[0];
-        let indent_step = detect_indent_step(
-            &lines[(outermost.line_start.saturating_sub(1)) as usize
-                ..((outermost.line_end as usize).min(lines.len()))],
-        );
 
         for (i, r) in chain.iter().enumerate() {
             if i == chain.len() - 1 {
@@ -524,7 +520,6 @@ impl RefactorRule for CollapsibleIfRule {
             let r_end = (r.line_end as usize).min(lines.len());
             let next_start = (next.line_start as usize).saturating_sub(1);
             let next_end = (next.line_end as usize).min(lines.len());
-            let pair_body_indent = get_indentation_from_str(lines[r_start]) + indent_step;
 
             let mut body_start = r_start + 1;
             if extract_condition_from_line(lines[r_start].trim_start()).is_none() {
@@ -538,17 +533,13 @@ impl RefactorRule for CollapsibleIfRule {
             }
 
             for line in &lines[body_start..next_start.min(lines.len())] {
-                let trimmed = line.trim_start();
-                let indent = get_indentation_from_str(line);
-                if !trimmed.is_empty() && indent == pair_body_indent {
+                if !line.trim_start().is_empty() {
                     return None;
                 }
             }
 
             for line in &lines[next_end..r_end] {
-                let trimmed = line.trim_start();
-                let indent = get_indentation_from_str(line);
-                if !trimmed.is_empty() && indent == pair_body_indent {
+                if !line.trim_start().is_empty() {
                     return None;
                 }
             }
@@ -693,12 +684,29 @@ fn generate_loop_guard_suggestion(
             .map(|line| (*line).to_string()),
     );
 
-    for (_, guard) in &guards {
+    for (i, (member, guard)) in guards.iter().enumerate() {
         result.push(format!("{}if not {}:", " ".repeat(loop_body_indent), guard));
         result.push(format!(
             "{}continue",
             " ".repeat(loop_body_indent + indent_step)
         ));
+
+        if i + 1 < guards.len() {
+            let next_start = (guards[i + 1].0.line_start.saturating_sub(1)) as usize;
+            let range_start = (member.line_start as usize).min(lines.len());
+            let shift = indent_step * (i + 1);
+            for line in &lines[range_start..next_start.min(lines.len())] {
+                let trimmed = line.trim_start();
+                if trimmed.is_empty() {
+                    result.push(String::new());
+                    continue;
+                }
+                let current_indent = get_indentation_from_str(line);
+                let shifted = current_indent.saturating_sub(shift);
+                let padding = " ".repeat(shifted);
+                result.push(format!("{}{}", padding, trimmed));
+            }
+        }
     }
 
     for line in &lines[(innermost_line_idx + 1)..innermost_end] {
@@ -730,22 +738,33 @@ fn generate_loop_guard_suggestion(
 }
 
 /// Detect the indentation step (spaces per level) from a block of code.
+/// Blank and comment-only lines carry no structural indent; pairing them
+/// against a body statement would report the body's full indent as the step.
 fn detect_indent_step(lines: &[&str]) -> usize {
-    for i in 1..lines.len() {
-        let prev_indent = get_indentation_from_str(lines[i - 1]);
-        let curr_indent = get_indentation_from_str(lines[i]);
-        if curr_indent > prev_indent {
-            return curr_indent - prev_indent;
+    let mut prev_indent: Option<usize> = None;
+    for line in lines {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
         }
+        let indent = get_indentation_from_str(line);
+        match prev_indent {
+            Some(prev) if indent > prev => return indent - prev,
+            _ => {}
+        }
+        prev_indent = Some(indent);
     }
     4
 }
 
 /// Generate a concrete suggestion for extracting a complex boolean condition
-/// into a named predicate function. The rewritten `if` replaces the original
-/// statement at its own indentation (nesting it inside the helper would make it
-/// unreachable after the `return`); the `...` stands in for the caller's body and
-/// keeps the snippet parseable on its own.
+/// into a named predicate function. The rewritten statement keeps the
+/// original keyword (`if` or `while`) and replaces the original statement at
+/// its own indentation (nesting it inside the helper would make it
+/// unreachable after the `return`); the `...` stands in for the caller's body
+/// and keeps the snippet parseable on its own. `elif` conditions return
+/// `None`: a `def` cannot sit inside an if-chain, so no faithful replacement
+/// exists.
 fn generate_predicate_suggestion(
     region: &ComplexityRegion,
     source: &str,
@@ -758,18 +777,27 @@ fn generate_predicate_suggestion(
     }
 
     let line = lines[start];
-    let condition = extract_condition_from_line(line.trim_start())?;
+    let trimmed = line.trim_start();
+    let keyword = if trimmed.starts_with("if ") {
+        "if"
+    } else if trimmed.starts_with("while ") {
+        "while"
+    } else {
+        return None;
+    };
+    let condition = extract_condition_from_line(trimmed)?;
     let base_indent = get_indentation_from_str(line);
+    let indent_step = detect_indent_step(&lines[start..]);
 
     let predicate_indent = " ".repeat(base_indent);
-    let body_indent = " ".repeat(base_indent + 4);
+    let body_indent = " ".repeat(base_indent + indent_step);
     let func_name = format!("_check_condition_L{}", region.line_start);
 
     let replacement = format!(
         "{predicate_indent}def {func_name}() -> bool:\n\
          {body_indent}return {condition}\n\
          \n\
-         {predicate_indent}if {func_name}():\n\
+         {predicate_indent}{keyword} {func_name}():\n\
          {body_indent}..."
     );
 

--- a/src/rules/complexity.rs
+++ b/src/rules/complexity.rs
@@ -2,6 +2,7 @@ use crate::classes::{Applicability, CodeSuggestion, RefactorPlan, RuleCategory};
 use crate::refactor_plans::{ComplexityRegion, RegionKind};
 use crate::rules::types::{RefactorRule, RuleMetadata};
 use crate::utils::count_bool_ops;
+use ruff_python_ast::visitor::{Visitor, walk_expr};
 use ruff_python_ast::{CmpOp, Expr};
 use ruff_python_parser::parse_expression;
 use std::sync::OnceLock;
@@ -786,12 +787,14 @@ fn detect_indent_step(lines: &[&str]) -> usize {
 
 /// Generate a concrete suggestion for extracting a complex boolean condition
 /// into a named predicate function. The rewritten statement keeps the
-/// original keyword (`if` or `while`) and replaces the original statement at
-/// its own indentation (nesting it inside the helper would make it
-/// unreachable after the `return`); the `...` stands in for the caller's body
-/// and keeps the snippet parseable on its own. `elif` conditions return
-/// `None`: a `def` cannot sit inside an if-chain, so no faithful replacement
-/// exists.
+/// original keyword (`if` or `while`) and the `...` stands in for the
+/// caller's body, keeping the snippet parseable on its own. The helper is
+/// emitted at module level with the condition's free variables as
+/// parameters, so it is importable and unit-testable; the call site passes
+/// the same names. `elif` conditions return `None`: a `def` cannot sit
+/// inside an if-chain, so no faithful replacement exists. Conditions that
+/// bind a name (`:=`) or hold a nested scope (lambda, comprehension) also
+/// return `None`: the parameter list could not be trusted.
 fn generate_predicate_suggestion(
     region: &ComplexityRegion,
     source: &str,
@@ -813,11 +816,10 @@ fn generate_predicate_suggestion(
         return None;
     };
     let condition = extract_condition_from_line(trimmed)?;
-    let base_indent = get_indentation_from_str(line);
+    let parameters = collect_free_names(&condition)?;
     let indent_step = detect_indent_step(&lines[start..]);
 
-    let predicate_indent = " ".repeat(base_indent);
-    let body_indent = " ".repeat(base_indent + indent_step);
+    let helper_body_indent = " ".repeat(indent_step);
     let mut func_name = format!("_check_condition_L{}", region.line_start);
     let mut def_pattern = format!("def {func_name}(");
     while lines.iter().any(|line| line.contains(&def_pattern)) {
@@ -825,12 +827,20 @@ fn generate_predicate_suggestion(
         def_pattern = format!("def {func_name}(");
     }
 
+    let parameters_text = parameters.join(", ");
+    let call_text = format!("{keyword} {func_name}({parameters_text}):");
+    let statement_context = match enclosing_header_indices(&lines, start) {
+        Some(headers) => render_statement_context(&headers, &lines, start, indent_step, &call_text),
+        None => format!(
+            "{call_text}\n\
+             {helper_body_indent}..."
+        ),
+    };
     let replacement = format!(
-        "{predicate_indent}def {func_name}() -> bool:\n\
-         {body_indent}return {condition}\n\
+        "def {func_name}({parameters_text}) -> bool:\n\
+         {helper_body_indent}return {condition}\n\
          \n\
-         {predicate_indent}{keyword} {func_name}():\n\
-         {body_indent}..."
+         {statement_context}"
     );
 
     Some(CodeSuggestion {
@@ -843,6 +853,265 @@ fn generate_predicate_suggestion(
 
 fn get_indentation_from_str(line: &str) -> usize {
     line.len() - line.trim_start().len()
+}
+
+const PYTHON_BUILTINS: &[&str] = &[
+    "__import__",
+    "abs",
+    "aiter",
+    "all",
+    "anext",
+    "any",
+    "ascii",
+    "bin",
+    "bool",
+    "breakpoint",
+    "bytearray",
+    "bytes",
+    "callable",
+    "chr",
+    "classmethod",
+    "compile",
+    "complex",
+    "delattr",
+    "dict",
+    "dir",
+    "divmod",
+    "enumerate",
+    "eval",
+    "exec",
+    "filter",
+    "float",
+    "format",
+    "frozenset",
+    "getattr",
+    "globals",
+    "hasattr",
+    "hash",
+    "help",
+    "hex",
+    "id",
+    "input",
+    "int",
+    "isinstance",
+    "issubclass",
+    "iter",
+    "len",
+    "list",
+    "locals",
+    "map",
+    "max",
+    "memoryview",
+    "min",
+    "next",
+    "object",
+    "oct",
+    "open",
+    "ord",
+    "pow",
+    "print",
+    "property",
+    "range",
+    "repr",
+    "reversed",
+    "round",
+    "set",
+    "setattr",
+    "slice",
+    "sorted",
+    "staticmethod",
+    "str",
+    "sum",
+    "super",
+    "tuple",
+    "type",
+    "vars",
+    "zip",
+];
+
+struct FreeNameCollector<'a> {
+    builtins: &'a [&'a str],
+    names: Vec<String>,
+    disqualified: bool,
+}
+
+impl<'a> Visitor<'a> for FreeNameCollector<'a> {
+    fn visit_expr(&mut self, expr: &'a Expr) {
+        match expr {
+            Expr::Named(_) | Expr::Lambda(_) => {
+                self.disqualified = true;
+                return;
+            }
+            Expr::ListComp(_) | Expr::SetComp(_) | Expr::DictComp(_) | Expr::Generator(_) => {
+                self.disqualified = true;
+                return;
+            }
+            Expr::Name(name) => {
+                let is_new = !self.builtins.contains(&name.id.as_str())
+                    && !self.names.iter().any(|n| n == name.id.as_str());
+                if is_new {
+                    self.names.push(name.id.to_string());
+                }
+            }
+            _ => {}
+        }
+        walk_expr(self, expr);
+    }
+}
+
+/// The condition's free variables, in first-use order, with builtins
+/// excluded. Returns `None` when the condition binds a name (`:=`) or holds
+/// a nested scope (lambda, comprehension) — the parameter list could not be
+/// trusted, so callers fall back to help text.
+fn collect_free_names(condition: &str) -> Option<Vec<String>> {
+    let parsed = parse_expression(condition).ok()?;
+    let expr = *parsed.into_syntax().body;
+    let mut collector = FreeNameCollector {
+        builtins: PYTHON_BUILTINS,
+        names: Vec::new(),
+        disqualified: false,
+    };
+    collector.visit_expr(&expr);
+    if collector.disqualified {
+        return None;
+    }
+    Some(collector.names)
+}
+
+/// Line indices (outermost first) of the block headers enclosing the
+/// condition line, from module level down to the enclosing block. Returns
+/// `None` when the chain cannot be traced to column 0 (module-level
+/// condition, or a broken chain such as a bare statement at a lesser
+/// indent) — callers render the bare call then.
+fn enclosing_header_indices(lines: &[&str], start: usize) -> Option<Vec<usize>> {
+    let mut headers = Vec::new();
+    let mut current_indent = get_indentation_from_str(lines[start]);
+    let mut expect_chain_opener = false;
+    let mut i = start;
+    while i > 0 {
+        i -= 1;
+        let line = lines[i];
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = get_indentation_from_str(line);
+        if indent > current_indent {
+            continue;
+        }
+        if trimmed.starts_with('@') {
+            continue;
+        }
+        if !line_opens_block(trimmed) {
+            return None;
+        }
+        if expect_chain_opener {
+            if indent != current_indent {
+                return None;
+            }
+            headers.push(i);
+            if !is_continuation_header(trimmed) {
+                expect_chain_opener = false;
+                if indent == 0 {
+                    headers.reverse();
+                    return Some(headers);
+                }
+            }
+            continue;
+        }
+        if indent == current_indent {
+            return None;
+        }
+        headers.push(i);
+        current_indent = indent;
+        if is_continuation_header(trimmed) {
+            expect_chain_opener = true;
+        } else if indent == 0 {
+            headers.reverse();
+            return Some(headers);
+        }
+    }
+    None
+}
+
+fn is_continuation_header(trimmed: &str) -> bool {
+    trimmed.starts_with("elif ")
+        || trimmed.starts_with("else:")
+        || trimmed.starts_with("except")
+        || trimmed.starts_with("finally:")
+        || trimmed.starts_with("case ")
+}
+
+fn line_opens_block(trimmed: &str) -> bool {
+    if !line_ends_with_statement_colon(trimmed) {
+        return false;
+    }
+    [
+        "def ",
+        "class ",
+        "async def ",
+        "if ",
+        "elif ",
+        "else:",
+        "for ",
+        "async for ",
+        "while ",
+        "with ",
+        "async with ",
+        "try:",
+        "except",
+        "finally:",
+        "match ",
+        "case ",
+    ]
+    .iter()
+    .any(|head| trimmed.starts_with(head))
+}
+
+fn directly_follows(lines: &[&str], item_idx: usize, prev_idx: usize) -> bool {
+    (prev_idx + 1..item_idx).all(|k| {
+        let trimmed = lines[k].trim_start();
+        trimmed.is_empty() || trimmed.starts_with('#')
+    })
+}
+
+/// Render the enclosing blocks around the call statement at their real
+/// indentation, using `...` placeholders for skipped statements. The result
+/// parses on its own: every placeholder is an Ellipsis expression statement.
+fn render_statement_context(
+    headers: &[usize],
+    lines: &[&str],
+    start: usize,
+    indent_step: usize,
+    call_text: &str,
+) -> String {
+    let call_indent = get_indentation_from_str(lines[start]);
+    let mut out = String::new();
+    let mut prev_idx: Option<usize> = None;
+    for &header_idx in headers {
+        let header_indent = get_indentation_from_str(lines[header_idx]);
+        if let Some(prev) = prev_idx {
+            let prev_indent = get_indentation_from_str(lines[prev]);
+            if header_indent == prev_indent {
+                out.push_str(&format!("{}...\n", " ".repeat(prev_indent + indent_step)));
+            } else if !directly_follows(lines, header_idx, prev) {
+                out.push_str(&format!("{}...\n", " ".repeat(header_indent)));
+            }
+        }
+        out.push_str(lines[header_idx]);
+        out.push('\n');
+        prev_idx = Some(header_idx);
+    }
+    if let Some(prev) = prev_idx {
+        let prev_indent = get_indentation_from_str(lines[prev]);
+        if call_indent > prev_indent && !directly_follows(lines, start, prev) {
+            out.push_str(&format!("{}...\n", " ".repeat(call_indent)));
+        }
+    }
+    out.push_str(&format!("{}{}\n", " ".repeat(call_indent), call_text));
+    out.push_str(&format!("{}...\n", " ".repeat(call_indent + indent_step)));
+    out.push_str(&format!("{}...\n", " ".repeat(call_indent)));
+    out
 }
 
 fn line_ends_with_statement_colon(line: &str) -> bool {

--- a/src/rules/complexity.rs
+++ b/src/rules/complexity.rs
@@ -546,27 +546,34 @@ impl RefactorRule for CollapsibleIfRule {
             }
         }
 
-        let suggestion = if conditions_extracted {
-            Some(generate_collapsible_if_suggestion_chain(
+        let mut suggestion = None;
+        let mut help = None;
+        if conditions_extracted {
+            match generate_collapsible_if_suggestion_chain(
                 outermost,
                 innermost,
                 &conditions,
                 &lines,
-            ))
+            ) {
+                Some(s) => suggestion = Some(s),
+                None => {
+                    help = Some(
+                        "Merge the nested if statements into a single `if <outer> and <inner>:` \
+                         block, adjusting the indentation of any multi-line string literals in \
+                         the body by hand — an automatic replacement would change their content."
+                            .to_string(),
+                    );
+                }
+            }
         } else {
-            None
-        };
-        let help = if conditions_extracted {
-            None
-        } else {
-            Some(
+            help = Some(
                 "Merge the nested if statements into a single `if <outer> and <inner>:` \
                  block. The exact condition text could not be extracted automatically \
                  (it may span multiple lines or contain content the parser could not \
                  confidently isolate) — combine the conditions with `and` manually."
                     .to_string(),
-            )
-        };
+            );
+        }
 
         let old_complexity = region.total;
         let boolean_count = if conditions_extracted {
@@ -670,6 +677,17 @@ fn generate_loop_guard_suggestion(
     let innermost_end = (innermost.line_end as usize).min(lines.len());
     let chain_start_idx = (guards[0].0.line_start.saturating_sub(1)) as usize;
 
+    for i in 0..guards.len().saturating_sub(1) {
+        let range_start = (guards[i].0.line_start as usize).min(lines.len());
+        let range_end = (guards[i + 1].0.line_start.saturating_sub(1)) as usize;
+        if contains_multiline_string(&lines[range_start..range_end.min(lines.len())]) {
+            return None;
+        }
+    }
+    if contains_multiline_string(&lines[(innermost_line_idx + 1)..innermost_end]) {
+        return None;
+    }
+
     // The body indent and step come from the first chain member's own line:
     // the header may span several lines, so its continuation lines cannot be
     // trusted to reveal the step. Header continuation lines fall into the
@@ -686,10 +704,14 @@ fn generate_loop_guard_suggestion(
     );
 
     for (i, (member, guard)) in guards.iter().enumerate() {
+        let guard_text = match strip_top_level_not(guard) {
+            Some(rest) => rest,
+            None => format!("not ({guard})"),
+        };
         result.push(format!(
-            "{}if not ({}):",
+            "{}if {}:",
             " ".repeat(loop_body_indent),
-            guard
+            guard_text
         ));
         result.push(format!(
             "{}continue",
@@ -796,7 +818,12 @@ fn generate_predicate_suggestion(
 
     let predicate_indent = " ".repeat(base_indent);
     let body_indent = " ".repeat(base_indent + indent_step);
-    let func_name = format!("_check_condition_L{}", region.line_start);
+    let mut func_name = format!("_check_condition_L{}", region.line_start);
+    let mut def_pattern = format!("def {func_name}(");
+    while lines.iter().any(|line| line.contains(&def_pattern)) {
+        func_name.push('_');
+        def_pattern = format!("def {func_name}(");
+    }
 
     let replacement = format!(
         "{predicate_indent}def {func_name}() -> bool:\n\
@@ -970,18 +997,72 @@ fn has_else_branch(region: &ComplexityRegion, lines: &[&str]) -> bool {
     }
 
     let base_indent = get_indentation_from_str(lines[start]);
+    let mut in_triple_string: Option<char> = None;
 
     for line in &lines[start..end] {
-        let trimmed = line.trim_start();
-        let current_indent = get_indentation_from_str(line);
+        if in_triple_string.is_none() {
+            let trimmed = line.trim_start();
+            let current_indent = get_indentation_from_str(line);
 
-        if current_indent == base_indent
-            && (trimmed.starts_with("else:") || trimmed.starts_with("elif "))
-        {
-            return true;
+            if current_indent == base_indent
+                && (trimmed.starts_with("else:") || trimmed.starts_with("elif "))
+            {
+                return true;
+            }
         }
+        update_triple_string_state(line, &mut in_triple_string);
     }
 
+    false
+}
+
+fn update_triple_string_state(line: &str, state: &mut Option<char>) {
+    let chars: Vec<char> = line.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if let Some(quote) = *state {
+            if chars[i] == '\\' {
+                i += 2;
+                continue;
+            }
+            if chars[i] == quote
+                && i + 2 < chars.len()
+                && chars[i + 1] == quote
+                && chars[i + 2] == quote
+            {
+                *state = None;
+                i += 3;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        match chars[i] {
+            '#' => break,
+            '\'' | '"' => {
+                if i + 2 < chars.len() && chars[i + 1] == chars[i] && chars[i + 2] == chars[i] {
+                    *state = Some(chars[i]);
+                    i += 3;
+                } else {
+                    i += 1;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+}
+
+/// True when any line in the slice lies inside a multi-line (triple-quoted)
+/// string. Dedenting such lines changes the string's value, so suggestions
+/// that shift a range must refuse when this returns true.
+fn contains_multiline_string(lines: &[&str]) -> bool {
+    let mut in_triple_string: Option<char> = None;
+    for line in lines {
+        if in_triple_string.is_some() {
+            return true;
+        }
+        update_triple_string_state(line, &mut in_triple_string);
+    }
     false
 }
 
@@ -990,17 +1071,21 @@ fn generate_collapsible_if_suggestion_chain(
     innermost: &ComplexityRegion,
     conditions: &[String],
     lines: &[&str],
-) -> CodeSuggestion {
+) -> Option<CodeSuggestion> {
     let outer_line_idx = (outermost.line_start.saturating_sub(1)) as usize;
     let inner_line_idx = (innermost.line_start.saturating_sub(1)) as usize;
     let inner_end = (innermost.line_end as usize).min(lines.len());
+
+    let body_start = inner_line_idx + 1;
+    if contains_multiline_string(&lines[body_start..inner_end]) {
+        return None;
+    }
 
     let outer_indent = get_indentation_from_str(lines[outer_line_idx]);
     let indent_step = detect_indent_step(&lines[outer_line_idx..inner_end]);
 
     let combined = combine_conditions_chain(conditions);
 
-    let body_start = inner_line_idx + 1;
     let chain_depth = conditions.len();
     let mut body_lines = Vec::new();
     for line in &lines[body_start..inner_end] {
@@ -1018,12 +1103,12 @@ fn generate_collapsible_if_suggestion_chain(
     let indent = " ".repeat(outer_indent);
     let replacement = format!("{}if {}:\n{}", indent, combined, body_lines.join("\n"));
 
-    CodeSuggestion {
+    Some(CodeSuggestion {
         replacement,
         applicability: Applicability::MachineApplicable,
         spliceable: true,
         description: format!("Merge nested conditions into `if {}:`", combined),
-    }
+    })
 }
 
 /// Combine multiple conditions with 'and', wrapping 'or' conditions in parens.
@@ -1116,6 +1201,23 @@ fn mask_nested(condition: &str) -> String {
 fn needs_parens_for_and(condition: &str) -> bool {
     let masked = mask_nested(condition);
     masked.contains(" or ") || masked.contains(" if ") || masked.contains(":=")
+}
+
+/// Returns the remainder of `condition` when it is a single top-level
+/// `not <expr>` whose `<expr>` holds no top-level `and`/`or`/conditional/
+/// walrus. The guard can then render as `if <expr>:` instead of the redundant
+/// `if not (not <expr>):`. Returns `None` for anything less certain.
+fn strip_top_level_not(condition: &str) -> Option<String> {
+    let masked = mask_nested(condition);
+    let rest_masked = masked.strip_prefix("not ")?;
+    if rest_masked.contains(" and ")
+        || rest_masked.contains(" or ")
+        || rest_masked.contains(" if ")
+        || rest_masked.contains(":=")
+    {
+        return None;
+    }
+    Some(condition[4..].to_string())
 }
 
 fn combine_conditions_chain(conditions: &[String]) -> String {

--- a/src/rules/complexity.rs
+++ b/src/rules/complexity.rs
@@ -45,8 +45,9 @@ impl RefactorRule for FlattenConditionRule {
                          at a lower indentation level."
                 .to_string(),
             help: Some(
-                "Invert the outer condition and return early. Move the main success path \
-                        one indentation level left. Repeat for inner nested conditions where safe."
+                "Invert the outer condition and exit early — `return` from the function, \
+                 or `continue`/`break` when the block sits inside a loop. Move the main \
+                 success path one indentation level left. Repeat for inner nested conditions where safe."
                     .to_string(),
             ),
             ..self.metadata().new_plan()
@@ -103,7 +104,7 @@ impl RefactorRule for LoopGuardsRule {
         let suggestion = generate_loop_guard_suggestion(region, source);
         let help = if suggestion.is_none() {
             Some(
-                "Add `if not <condition>: continue` guards at the top of the loop body \
+                "Add `if not (<condition>): continue` guards at the top of the loop body \
                  for each nested if condition, then dedent the remaining logic by one \
                  level per guard."
                     .to_string(),
@@ -685,7 +686,11 @@ fn generate_loop_guard_suggestion(
     );
 
     for (i, (member, guard)) in guards.iter().enumerate() {
-        result.push(format!("{}if not {}:", " ".repeat(loop_body_indent), guard));
+        result.push(format!(
+            "{}if not ({}):",
+            " ".repeat(loop_body_indent),
+            guard
+        ));
         result.push(format!(
             "{}continue",
             " ".repeat(loop_body_indent + indent_step)

--- a/src/rules/registry.rs
+++ b/src/rules/registry.rs
@@ -220,7 +220,7 @@ fn select_non_overlapping(
             let existing = &selected[idx];
             let eff_existing = effectiveness_of(&existing.rule_id);
             let spliceable_existing = spliceable_of(existing);
-            spliceable_plan > spliceable_existing
+            spliceable_plan & !spliceable_existing
                 || (spliceable_plan == spliceable_existing
                     && (eff_plan > eff_existing
                         || (eff_plan == eff_existing

--- a/src/rules/registry.rs
+++ b/src/rules/registry.rs
@@ -169,23 +169,30 @@ fn measure_reduction(
     Some(plan.current_complexity.saturating_sub(new_complexity))
 }
 
-/// Sorts by effectiveness/reduction/line, then keeps only non-overlapping
-/// plans (highest effectiveness/reduction wins any overlap), capped at 5.
-/// Split out from `RuleRegistry::analyze` so the selection logic can be unit
-/// tested directly against hand-built plans, without needing real rules to
-/// organically produce a given overlap shape.
+/// Sorts by spliceable/effectiveness/reduction/line, then keeps only
+/// non-overlapping plans (highest spliceable/effectiveness/reduction wins any
+/// overlap), capped at 5. A spliceable plan beats a help-only plan of higher
+/// effectiveness: the tool stands behind a faithful, measured replacement
+/// more than behind prose. Split out from `RuleRegistry::analyze` so the
+/// selection logic can be unit tested directly against hand-built plans,
+/// without needing real rules to organically produce a given overlap shape.
 fn select_non_overlapping(
     mut plans: Vec<RefactorPlan>,
     effectiveness: &HashMap<&str, u8>,
 ) -> (Vec<RefactorPlan>, u64) {
     let effectiveness_of = |rule_id: &str| *effectiveness.get(rule_id).unwrap_or(&1);
+    let spliceable_of =
+        |plan: &RefactorPlan| plan.suggestion.as_ref().is_some_and(|s| s.spliceable);
 
     plans.sort_by(|a, b| {
+        let spliceable_a = spliceable_of(a);
+        let spliceable_b = spliceable_of(b);
         let eff_a = effectiveness_of(&a.rule_id);
         let eff_b = effectiveness_of(&b.rule_id);
 
-        eff_b
-            .cmp(&eff_a)
+        spliceable_b
+            .cmp(&spliceable_a)
+            .then_with(|| eff_b.cmp(&eff_a))
             .then_with(|| b.estimated_reduction.cmp(&a.estimated_reduction))
             .then_with(|| a.line_start.cmp(&b.line_start))
     });
@@ -208,12 +215,16 @@ fn select_non_overlapping(
         }
 
         let eff_plan = effectiveness_of(&plan.rule_id);
+        let spliceable_plan = spliceable_of(&plan);
         let beats_all_overlaps = overlapping.iter().all(|&idx| {
             let existing = &selected[idx];
             let eff_existing = effectiveness_of(&existing.rule_id);
-            eff_plan > eff_existing
-                || (eff_plan == eff_existing
-                    && plan.estimated_reduction > existing.estimated_reduction)
+            let spliceable_existing = spliceable_of(existing);
+            spliceable_plan > spliceable_existing
+                || (spliceable_plan == spliceable_existing
+                    && (eff_plan > eff_existing
+                        || (eff_plan == eff_existing
+                            && plan.estimated_reduction > existing.estimated_reduction)))
         });
 
         if beats_all_overlaps {

--- a/src/tests/rules/complexity.rs
+++ b/src/tests/rules/complexity.rs
@@ -5,15 +5,165 @@
 //! private helpers through `super::` without widening their visibility.
 
 use super::{
-    collect_loop_if_chain, combine_conditions_chain, contains_multiline_string, detect_indent_step,
-    extract_condition_from_line, fallback_boolean_count, generate_collapsible_if_suggestion_chain,
-    generate_loop_guard_suggestion, has_else_branch, needs_parens_for_and, strip_top_level_not,
+    collect_free_names, collect_loop_if_chain, combine_conditions_chain, contains_multiline_string,
+    detect_indent_step, enclosing_header_indices, extract_condition_from_line,
+    fallback_boolean_count, generate_collapsible_if_suggestion_chain,
+    generate_loop_guard_suggestion, generate_predicate_suggestion, has_else_branch,
+    needs_parens_for_and, render_statement_context, strip_top_level_not,
 };
 use crate::refactor_plans::{ComplexityRegion, RegionKind};
 
 fn combine(parts: &[&str]) -> String {
     let owned: Vec<String> = parts.iter().map(|s| s.to_string()).collect();
     combine_conditions_chain(&owned)
+}
+
+#[test]
+fn collect_free_names_includes_attribute_bases_and_skips_builtins() {
+    assert_eq!(
+        collect_free_names("user.is_active and len(items) > 0"),
+        Some(vec!["user".to_string(), "items".to_string()])
+    );
+}
+
+#[test]
+fn collect_free_names_deduplicates_in_first_use_order() {
+    assert_eq!(
+        collect_free_names("a > 1 and a < 2 or b"),
+        Some(vec!["a".to_string(), "b".to_string()])
+    );
+}
+
+#[test]
+fn collect_free_names_includes_self() {
+    assert_eq!(
+        collect_free_names("self.x > 0 and self.y < 1"),
+        Some(vec!["self".to_string()])
+    );
+}
+
+#[test]
+fn collect_free_names_returns_none_for_walrus() {
+    assert_eq!(collect_free_names("(n := len(items)) > 3 and n < 10"), None);
+}
+
+#[test]
+fn collect_free_names_returns_none_for_lambda() {
+    assert_eq!(collect_free_names("(lambda x: x > 0)(v) and v < 10"), None);
+}
+
+#[test]
+fn collect_free_names_returns_none_for_comprehension() {
+    assert_eq!(
+        collect_free_names("all(x > 0 for x in items) and items"),
+        None
+    );
+}
+
+#[test]
+fn collect_free_names_returns_empty_for_literal_only_conditions() {
+    assert_eq!(collect_free_names("1 < 2 and 3 < 4"), Some(vec![]));
+}
+
+#[test]
+fn enclosing_header_indices_finds_the_function_chain() {
+    let source = "def sample(a, b):\n    if a and b or a:\n        return 1\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    assert_eq!(enclosing_header_indices(&lines, 1), Some(vec![0]));
+}
+
+#[test]
+fn enclosing_header_indices_collects_nested_blocks() {
+    let source = "def f(items):\n    for item in items:\n        if item.active and item.ready:\n            pass\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    assert_eq!(enclosing_header_indices(&lines, 2), Some(vec![0, 1]));
+}
+
+#[test]
+fn enclosing_header_indices_skips_decorators() {
+    let source = "@deco\ndef f(x):\n    if x and x > 0:\n        pass\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    assert_eq!(enclosing_header_indices(&lines, 2), Some(vec![1]));
+}
+
+#[test]
+fn enclosing_header_indices_returns_none_for_module_level_conditions() {
+    let source = "if a and b:\n    pass\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    assert_eq!(enclosing_header_indices(&lines, 0), None);
+}
+
+#[test]
+fn enclosing_header_indices_returns_none_for_a_broken_chain() {
+    let source = "x = 1\n    def f():\n        if a and b:\n            pass\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    assert_eq!(enclosing_header_indices(&lines, 2), None);
+}
+
+#[test]
+fn enclosing_header_indices_collects_else_chains() {
+    let source = "if a:\n    pass\nelse:\n    if b and c:\n        pass\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    assert_eq!(enclosing_header_indices(&lines, 3), Some(vec![0, 2]));
+}
+
+#[test]
+fn enclosing_header_indices_collects_elif_chains() {
+    let source = "def f(x, y):\n    if x > 0:\n        pass\n    elif y > 0:\n        if y > 1 and y < 9:\n            pass\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    assert_eq!(enclosing_header_indices(&lines, 4), Some(vec![0, 1, 3]));
+}
+
+#[test]
+fn predicate_suggestion_shows_the_enclosing_function_context() {
+    let source = "def sample(a, b):\n    if a and b or a:\n        return 1\n    return 0\n";
+    let region = ComplexityRegion {
+        kind: RegionKind::BooleanCondition,
+        line_start: 2,
+        line_end: 2,
+        ..Default::default()
+    };
+
+    let suggestion = generate_predicate_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "def _check_condition_L2(a, b) -> bool:\n    return a and b or a\n\ndef sample(a, b):\n    if _check_condition_L2(a, b):\n        ...\n    ...\n"
+    );
+}
+
+#[test]
+fn predicate_suggestion_falls_back_to_a_bare_call_at_module_level() {
+    let source = "if a and b or a:\n    pass\n";
+    let region = ComplexityRegion {
+        kind: RegionKind::BooleanCondition,
+        line_start: 1,
+        line_end: 1,
+        ..Default::default()
+    };
+
+    let suggestion = generate_predicate_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "def _check_condition_L1(a, b) -> bool:\n    return a and b or a\n\nif _check_condition_L1(a, b):\n    ..."
+    );
+}
+
+#[test]
+fn render_statement_context_places_a_placeholder_for_skipped_statements() {
+    let source = "def wait_until(items, limit):\n    i = 0\n    while i < len(items) and i < limit:\n        i += 1\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    let context = render_statement_context(
+        &[0],
+        &lines,
+        2,
+        4,
+        "while _check_condition_L3(i, items, limit):",
+    );
+
+    assert_eq!(
+        context,
+        "def wait_until(items, limit):\n    ...\n    while _check_condition_L3(i, items, limit):\n        ...\n    ...\n"
+    );
 }
 
 #[test]

--- a/src/tests/rules/complexity.rs
+++ b/src/tests/rules/complexity.rs
@@ -5,14 +5,39 @@
 //! private helpers through `super::` without widening their visibility.
 
 use super::{
-    collect_loop_if_chain, combine_conditions_chain, extract_condition_from_line,
-    fallback_boolean_count, generate_loop_guard_suggestion, needs_parens_for_and,
+    collect_loop_if_chain, combine_conditions_chain, detect_indent_step,
+    extract_condition_from_line, fallback_boolean_count,
+    generate_loop_guard_suggestion, needs_parens_for_and,
 };
 use crate::refactor_plans::{ComplexityRegion, RegionKind};
 
 fn combine(parts: &[&str]) -> String {
     let owned: Vec<String> = parts.iter().map(|s| s.to_string()).collect();
     combine_conditions_chain(&owned)
+}
+
+#[test]
+fn detect_indent_step_pairs_structural_lines() {
+    let lines = ["if a:", "    stmt"];
+    assert_eq!(detect_indent_step(&lines), 4);
+}
+
+#[test]
+fn detect_indent_step_skips_blank_lines_when_pairing() {
+    let lines = ["if a:", "", "    stmt"];
+    assert_eq!(detect_indent_step(&lines), 4);
+}
+
+#[test]
+fn detect_indent_step_skips_comment_lines_when_pairing() {
+    let lines = ["if a:", "", "    # note", "    stmt"];
+    assert_eq!(detect_indent_step(&lines), 4);
+}
+
+#[test]
+fn detect_indent_step_returns_default_without_an_increase() {
+    let lines = ["stmt", "", "stmt"];
+    assert_eq!(detect_indent_step(&lines), 4);
 }
 
 #[test]
@@ -333,6 +358,58 @@ fn loop_guard_suggestion_keeps_trailing_statements_at_loop_indent() {
     assert_eq!(
         suggestion.replacement,
         "for x in y:\n    if not a:\n        continue\n    pass\n    total += 1"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_keeps_statements_between_chain_members() {
+    let source = "for x in y:\n    if a:\n        total += x\n        if b:\n            pass\n";
+    let region = loop_region(
+        vec![ComplexityRegion {
+            kind: RegionKind::If,
+            line_start: 2,
+            line_end: 5,
+            nesting: 1,
+            children: vec![if_stmt(4, 5, 2)],
+            ..Default::default()
+        }],
+        5,
+    );
+
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    if not a:\n        continue\n    total += x\n    if not b:\n        continue\n    pass"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_shifts_between_statements_at_each_level() {
+    let source =
+        "for x in y:\n    if a:\n        if b:\n            stmt\n            if c:\n                pass\n";
+    let region = loop_region(
+        vec![ComplexityRegion {
+            kind: RegionKind::If,
+            line_start: 2,
+            line_end: 6,
+            nesting: 1,
+            children: vec![ComplexityRegion {
+                kind: RegionKind::If,
+                line_start: 3,
+                line_end: 6,
+                nesting: 2,
+                children: vec![if_stmt(5, 6, 3)],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        6,
+    );
+
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    if not a:\n        continue\n    if not b:\n        continue\n    stmt\n    if not c:\n        continue\n    pass"
     );
 }
 

--- a/src/tests/rules/complexity.rs
+++ b/src/tests/rules/complexity.rs
@@ -6,8 +6,8 @@
 
 use super::{
     collect_loop_if_chain, combine_conditions_chain, detect_indent_step,
-    extract_condition_from_line, fallback_boolean_count,
-    generate_loop_guard_suggestion, needs_parens_for_and,
+    extract_condition_from_line, fallback_boolean_count, generate_loop_guard_suggestion,
+    needs_parens_for_and,
 };
 use crate::refactor_plans::{ComplexityRegion, RegionKind};
 
@@ -385,8 +385,7 @@ fn loop_guard_suggestion_keeps_statements_between_chain_members() {
 
 #[test]
 fn loop_guard_suggestion_shifts_between_statements_at_each_level() {
-    let source =
-        "for x in y:\n    if a:\n        if b:\n            stmt\n            if c:\n                pass\n";
+    let source = "for x in y:\n    if a:\n        if b:\n            stmt\n            if c:\n                pass\n";
     let region = loop_region(
         vec![ComplexityRegion {
             kind: RegionKind::If,

--- a/src/tests/rules/complexity.rs
+++ b/src/tests/rules/complexity.rs
@@ -333,7 +333,7 @@ fn loop_guard_suggestion_is_faithful_for_a_pure_chain() {
     assert!(suggestion.spliceable);
     assert_eq!(
         suggestion.replacement,
-        "for x in y:\n    if not a:\n        continue\n    if not b:\n        continue\n    pass"
+        "for x in y:\n    if not (a):\n        continue\n    if not (b):\n        continue\n    pass"
     );
 }
 
@@ -345,7 +345,19 @@ fn loop_guard_suggestion_keeps_leading_statements() {
     let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
     assert_eq!(
         suggestion.replacement,
-        "for x in y:\n    total += x\n    if not a:\n        continue\n    pass"
+        "for x in y:\n    total += x\n    if not (a):\n        continue\n    pass"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_parenthesizes_inverted_or_conditions() {
+    let source = "for x in y:\n    if a or b:\n        pass\n";
+    let region = loop_region(vec![if_stmt(2, 3, 1)], 3);
+
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    if not (a or b):\n        continue\n    pass"
     );
 }
 
@@ -357,7 +369,7 @@ fn loop_guard_suggestion_keeps_trailing_statements_at_loop_indent() {
     let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
     assert_eq!(
         suggestion.replacement,
-        "for x in y:\n    if not a:\n        continue\n    pass\n    total += 1"
+        "for x in y:\n    if not (a):\n        continue\n    pass\n    total += 1"
     );
 }
 
@@ -379,7 +391,7 @@ fn loop_guard_suggestion_keeps_statements_between_chain_members() {
     let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
     assert_eq!(
         suggestion.replacement,
-        "for x in y:\n    if not a:\n        continue\n    total += x\n    if not b:\n        continue\n    pass"
+        "for x in y:\n    if not (a):\n        continue\n    total += x\n    if not (b):\n        continue\n    pass"
     );
 }
 
@@ -408,7 +420,7 @@ fn loop_guard_suggestion_shifts_between_statements_at_each_level() {
     let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
     assert_eq!(
         suggestion.replacement,
-        "for x in y:\n    if not a:\n        continue\n    if not b:\n        continue\n    stmt\n    if not c:\n        continue\n    pass"
+        "for x in y:\n    if not (a):\n        continue\n    if not (b):\n        continue\n    stmt\n    if not (c):\n        continue\n    pass"
     );
 }
 
@@ -430,7 +442,7 @@ fn loop_guard_suggestion_keeps_an_else_on_the_last_chain_member() {
     let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
     assert_eq!(
         suggestion.replacement,
-        "for x in y:\n    if not a:\n        continue\n    if b:\n        pass\n    else:\n        pass"
+        "for x in y:\n    if not (a):\n        continue\n    if b:\n        pass\n    else:\n        pass"
     );
 }
 
@@ -445,7 +457,7 @@ fn loop_guard_suggestion_preserves_a_multiline_header() {
     assert!(suggestion.spliceable);
     assert_eq!(
         suggestion.replacement,
-        "for x in (\n    items):\n    if not a:\n        continue\n    pass"
+        "for x in (\n    items):\n    if not (a):\n        continue\n    pass"
     );
 }
 
@@ -504,6 +516,6 @@ fn loop_guard_suggestion_keeps_unextractable_members_in_the_survivor() {
     let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
     assert_eq!(
         suggestion.replacement,
-        "for x in y:\n    if not a:\n        continue\n    if (b and\n            c):\n        pass"
+        "for x in y:\n    if not (a):\n        continue\n    if (b and\n            c):\n        pass"
     );
 }

--- a/src/tests/rules/complexity.rs
+++ b/src/tests/rules/complexity.rs
@@ -5,9 +5,9 @@
 //! private helpers through `super::` without widening their visibility.
 
 use super::{
-    collect_loop_if_chain, combine_conditions_chain, detect_indent_step,
-    extract_condition_from_line, fallback_boolean_count, generate_loop_guard_suggestion,
-    needs_parens_for_and,
+    collect_loop_if_chain, combine_conditions_chain, contains_multiline_string, detect_indent_step,
+    extract_condition_from_line, fallback_boolean_count, generate_collapsible_if_suggestion_chain,
+    generate_loop_guard_suggestion, has_else_branch, needs_parens_for_and, strip_top_level_not,
 };
 use crate::refactor_plans::{ComplexityRegion, RegionKind};
 
@@ -358,6 +358,87 @@ fn loop_guard_suggestion_parenthesizes_inverted_or_conditions() {
     assert_eq!(
         suggestion.replacement,
         "for x in y:\n    if not (a or b):\n        continue\n    pass"
+    );
+}
+
+#[test]
+fn loop_guard_suggestion_strips_a_redundant_not() {
+    let source = "for x in y:\n    if not a:\n        pass\n";
+    let region = loop_region(vec![if_stmt(2, 3, 1)], 3);
+
+    let suggestion = generate_loop_guard_suggestion(&region, source).unwrap();
+    assert_eq!(
+        suggestion.replacement,
+        "for x in y:\n    if a:\n        continue\n    pass"
+    );
+}
+
+#[test]
+fn strip_top_level_not_refuses_mixed_operators() {
+    assert_eq!(strip_top_level_not("not a"), Some("a".to_string()));
+    assert_eq!(
+        strip_top_level_not("not a == b"),
+        Some("a == b".to_string())
+    );
+    assert_eq!(
+        strip_top_level_not("not (a and b)"),
+        Some("(a and b)".to_string())
+    );
+    assert_eq!(strip_top_level_not("not a or b"), None);
+    assert_eq!(strip_top_level_not("not a and b"), None);
+    assert_eq!(strip_top_level_not("a not in b"), None);
+}
+
+#[test]
+fn has_else_branch_ignores_string_content_lines() {
+    let source = "if a:\n    x = \"\"\"foo\nelse:\nbar\"\"\"\n    if b:\n        pass\n";
+    let lines: Vec<&str> = source.split('\n').collect();
+    let region = if_stmt(1, 6, 0);
+
+    assert!(!has_else_branch(&region, &lines));
+}
+
+#[test]
+fn contains_multiline_string_detects_spanned_content() {
+    let plain: Vec<&str> = "x = 1\ny = 2\n".split('\n').collect();
+    assert!(!contains_multiline_string(&plain));
+
+    let single_line_triple: Vec<&str> = "x = \"\"\"foo\"\"\"\n".split('\n').collect();
+    assert!(!contains_multiline_string(&single_line_triple));
+
+    let spanned: Vec<&str> = "x = \"\"\"a\nb\"\"\"\n".split('\n').collect();
+    assert!(contains_multiline_string(&spanned));
+}
+
+#[test]
+fn loop_guard_suggestion_refuses_multiline_string_between_members() {
+    let source = "for x in y:\n    if a:\n        doc = \"\"\"x\n    else:\n    y\"\"\"\n        if b:\n            pass\n";
+    let region = loop_region(
+        vec![ComplexityRegion {
+            kind: RegionKind::If,
+            line_start: 2,
+            line_end: 6,
+            nesting: 1,
+            children: vec![if_stmt(5, 6, 2)],
+            ..Default::default()
+        }],
+        6,
+    );
+
+    assert!(generate_loop_guard_suggestion(&region, source).is_none());
+}
+
+#[test]
+fn collapsible_if_suggestion_refuses_multiline_string_body() {
+    let source = "if a:\n    if b:\n        doc = \"\"\"x\n            y\"\"\"\n";
+    let outermost = if_stmt(1, 4, 0);
+    let innermost = if_stmt(2, 4, 1);
+    let conditions = vec!["a".to_string(), "b".to_string()];
+    let lines: Vec<&str> = source.split('\n').collect();
+
+    assert!(
+        generate_collapsible_if_suggestion_chain(&outermost, &innermost, &conditions, &lines)
+            .is_none()
     );
 }
 

--- a/tests/fixtures/refactor_plans/collapsible_if_skips_blank_line_before_comment_sibling.py
+++ b/tests/fixtures/refactor_plans/collapsible_if_skips_blank_line_before_comment_sibling.py
@@ -1,0 +1,7 @@
+def resolve(flag: bool, x: int) -> int:
+    if flag:
+
+        # keep this comment with the inner branch
+        if x:
+            return x
+    return 0

--- a/tests/fixtures/refactor_plans/collapsible_if_skips_blank_line_preceding_sibling.py
+++ b/tests/fixtures/refactor_plans/collapsible_if_skips_blank_line_preceding_sibling.py
@@ -1,0 +1,10 @@
+def collect(paths: list[str], root_dir: str, prefix: str) -> list[str]:
+    modules: list[str] = []
+    for path in paths:
+        if root_dir in path:
+
+            mod_path: str = path.removeprefix(prefix).replace("/", ".")
+
+            if mod_path not in modules:
+                modules.append(mod_path)
+    return modules

--- a/tests/fixtures/refactor_plans/collapsible_if_skips_misaligned_comment_sibling.py
+++ b/tests/fixtures/refactor_plans/collapsible_if_skips_misaligned_comment_sibling.py
@@ -1,0 +1,6 @@
+def resolve(flag: bool, x: int) -> int:
+    if flag:
+# keep this comment with the branch
+        if x:
+            return x
+    return 0

--- a/tests/fixtures/refactor_plans/collapsible_if_skips_multiline_string_body.py
+++ b/tests/fixtures/refactor_plans/collapsible_if_skips_multiline_string_body.py
@@ -1,0 +1,6 @@
+def f(x):
+    if x:
+        if x:
+            doc = """a
+                b"""
+            print(doc)

--- a/tests/fixtures/refactor_plans/extract_predicate_elif.py
+++ b/tests/fixtures/refactor_plans/extract_predicate_elif.py
@@ -1,0 +1,6 @@
+def classify(x, y):
+    if x > 10:
+        return "big"
+    elif x > 5 and y < 3 or x == 0:
+        return "mid"
+    return "small"

--- a/tests/fixtures/refactor_plans/extract_predicate_else_context.py
+++ b/tests/fixtures/refactor_plans/extract_predicate_else_context.py
@@ -1,0 +1,7 @@
+def f(x, y):
+    if x > 0:
+        return 1
+    else:
+        if y < 0 and y > -10 or y == 5:
+            return 2
+    return 0

--- a/tests/fixtures/refactor_plans/extract_predicate_name_collision.py
+++ b/tests/fixtures/refactor_plans/extract_predicate_name_collision.py
@@ -1,0 +1,8 @@
+def sample(a, b):
+    if a and b or a:
+        return 1
+    return 0
+
+
+def _check_condition_L2():
+    return False

--- a/tests/fixtures/refactor_plans/extract_predicate_parameters.py
+++ b/tests/fixtures/refactor_plans/extract_predicate_parameters.py
@@ -1,0 +1,4 @@
+def is_eligible(user, order):
+    if user.is_active and user.has_subscription or order.total > 100 and not order.is_gift:
+        return True
+    return False

--- a/tests/fixtures/refactor_plans/extract_predicate_self.py
+++ b/tests/fixtures/refactor_plans/extract_predicate_self.py
@@ -1,0 +1,5 @@
+class Account:
+    def is_ready(self, limit):
+        if self.balance > 0 and self.status == "active" or limit < self.balance:
+            return True
+        return False

--- a/tests/fixtures/refactor_plans/extract_predicate_two_space_indent.py
+++ b/tests/fixtures/refactor_plans/extract_predicate_two_space_indent.py
@@ -1,0 +1,4 @@
+def eligible(user, order):
+  if user.is_active and user.has_subscription or order.total > 100 and not order.is_gift:
+    return True
+  return False

--- a/tests/fixtures/refactor_plans/extract_predicate_walrus.py
+++ b/tests/fixtures/refactor_plans/extract_predicate_walrus.py
@@ -1,0 +1,4 @@
+def f(items):
+    if (n := len(items)) > 3 and n < 10 or n == 0:
+        return n
+    return 0

--- a/tests/fixtures/refactor_plans/extract_predicate_while.py
+++ b/tests/fixtures/refactor_plans/extract_predicate_while.py
@@ -1,0 +1,5 @@
+def wait_until(items, limit):
+    i = 0
+    while i < len(items) and items[i] < limit or i > 1000:
+        i += 1
+    return i

--- a/tests/fixtures/refactor_plans/loop_guards_parenthesizes_and_condition.py
+++ b/tests/fixtures/refactor_plans/loop_guards_parenthesizes_and_condition.py
@@ -1,0 +1,8 @@
+def process(items):
+    total = 0
+    for x in items:
+        if x > 0 and x < 50:
+            total += x
+            if total > 100:
+                return total
+    return total

--- a/tests/fixtures/refactor_plans/loop_guards_parenthesizes_or_condition.py
+++ b/tests/fixtures/refactor_plans/loop_guards_parenthesizes_or_condition.py
@@ -1,0 +1,8 @@
+def process(items):
+    total = 0
+    for x in items:
+        if x < 0 or x > 100:
+            total += x
+            if total > 100:
+                return total
+    return total

--- a/tests/fixtures/refactor_plans/loop_guards_preserves_between_statements.py
+++ b/tests/fixtures/refactor_plans/loop_guards_preserves_between_statements.py
@@ -1,0 +1,8 @@
+def process(items):
+    total = 0
+    for x in items:
+        if x > 0:
+            total += x
+            if total > 100:
+                return total
+    return total

--- a/tests/fixtures/refactor_plans/loop_guards_preserves_multiline_between_statement.py
+++ b/tests/fixtures/refactor_plans/loop_guards_preserves_multiline_between_statement.py
@@ -1,0 +1,14 @@
+def process(items, scale):
+    total = 0
+    for x in items:
+        if x > 0:
+            total += calculate(
+                x, scale,
+            )
+            if total > 100:
+                return total
+    return total
+
+
+def calculate(x, scale):
+    return x * scale

--- a/tests/fixtures/refactor_plans/loop_guards_skips_multiline_string_between.py
+++ b/tests/fixtures/refactor_plans/loop_guards_skips_multiline_string_between.py
@@ -1,0 +1,8 @@
+def f(items):
+    for item in items:
+        if item.active:
+            doc = """x
+        else:
+        y"""
+            if item.ready:
+                print(item)

--- a/tests/fixtures/refactor_plans/loop_guards_strips_redundant_not.py
+++ b/tests/fixtures/refactor_plans/loop_guards_strips_redundant_not.py
@@ -1,0 +1,9 @@
+def process(items):
+    results = []
+    for item in items:
+        if not item.active:
+            if item.ready:
+                results.append(item)
+            else:
+                results.append(None)
+    return results

--- a/tests/test_refactor_plans.py
+++ b/tests/test_refactor_plans.py
@@ -323,7 +323,7 @@ def test_loop_guard_only_converts_outermost_if() -> None:
     )
     assert loop_guard_plan is not None
     assert loop_guard_plan.suggestion is not None
-    assert "if not item.active:" in loop_guard_plan.suggestion.replacement
+    assert "if not (item.active):" in loop_guard_plan.suggestion.replacement
     assert "continue" in loop_guard_plan.suggestion.replacement
 
 
@@ -361,7 +361,7 @@ def test_loop_guard_preserves_inner_if_else() -> None:
     )
     assert loop_guard_plan is not None, "C002 should fire when C007 can't"
     assert loop_guard_plan.suggestion is not None
-    assert "if not item.active:" in loop_guard_plan.suggestion.replacement
+    assert "if not (item.active):" in loop_guard_plan.suggestion.replacement
     assert "continue" in loop_guard_plan.suggestion.replacement
     # The inner if/else should be preserved
     assert (
@@ -379,9 +379,9 @@ def test_loop_guard_preserves_statement_between_members() -> None:
     replacement = plan.suggestion.replacement
 
     assert "total += x" in replacement
-    guard_1 = replacement.index("if not x > 0:")
+    guard_1 = replacement.index("if not (x > 0):")
     statement = replacement.index("total += x")
-    guard_2 = replacement.index("if not total > 100:")
+    guard_2 = replacement.index("if not (total > 100):")
     assert guard_1 < statement < guard_2
 
 
@@ -398,6 +398,24 @@ def test_loop_guard_preserves_multiline_statement_between_members() -> None:
     call_idx = replacement.index("total += calculate(")
     arg_idx = replacement.index("x, scale,")
     assert call_idx < arg_idx
+
+
+def test_loop_guard_parenthesizes_or_condition() -> None:
+    """C002 must parenthesize the inverted guard for `or` conditions."""
+    func = first_func(load_source("loop_guards_parenthesizes_or_condition.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+    replacement = plan.suggestion.replacement
+
+    assert "if not (x < 0 or x > 100):" in replacement
+
+
+def test_loop_guard_parenthesizes_and_condition() -> None:
+    """C002 must parenthesize the inverted guard for `and` conditions."""
+    func = first_func(load_source("loop_guards_parenthesizes_and_condition.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+    replacement = plan.suggestion.replacement
+
+    assert "if not (x > 0 and x < 50):" in replacement
 
 
 def test_collapsible_if_skips_when_outer_has_else() -> None:

--- a/tests/test_refactor_plans.py
+++ b/tests/test_refactor_plans.py
@@ -209,8 +209,9 @@ def test_predicate_while_keeps_while_keyword() -> None:
     plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
 
     assert plan.suggestion is not None
-    assert "while _check_condition_L3():" in plan.suggestion.replacement
-    assert "\n    if _check_condition_L3():" not in plan.suggestion.replacement
+    replacement = plan.suggestion.replacement
+    assert "while _check_condition_L3(i, items, limit):" in replacement
+    assert "\n    if _check_condition_L3(i, items, limit):" not in replacement
 
 
 def test_predicate_elif_emits_help_only() -> None:
@@ -226,8 +227,10 @@ def test_predicate_uses_detected_indent_step() -> None:
     plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
 
     assert plan.suggestion is not None
-    assert plan.suggestion.replacement.startswith("  def _check_condition_L2()")
-    assert "\n    return " in plan.suggestion.replacement
+    assert plan.suggestion.replacement.startswith(
+        "def _check_condition_L2(user, order)"
+    )
+    assert "\n  return " in plan.suggestion.replacement
 
 
 def test_try_nested_through_with_creates_flatten_try_plan() -> None:
@@ -456,8 +459,49 @@ def test_predicate_name_collision_gets_a_suffix() -> None:
 
     assert plan.suggestion is not None
     replacement = plan.suggestion.replacement
-    assert "def _check_condition_L2_()" in replacement
-    assert "if _check_condition_L2_():" in replacement
+    assert "def _check_condition_L2_(a, b)" in replacement
+    assert "if _check_condition_L2_(a, b):" in replacement
+
+
+def test_predicate_collects_parameters() -> None:
+    """C005 should pass free variables (attribute bases) as parameters."""
+    func = first_func(load_source("extract_predicate_parameters.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
+
+    assert plan.suggestion is not None
+    replacement = plan.suggestion.replacement
+    assert "def _check_condition_L2(user, order) -> bool:" in replacement
+    assert "if _check_condition_L2(user, order):" in replacement
+
+
+def test_predicate_passes_self_as_parameter() -> None:
+    func = first_func(load_source("extract_predicate_self.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
+
+    assert plan.suggestion is not None
+    replacement = plan.suggestion.replacement
+    assert "def _check_condition_L3(self, limit) -> bool:" in replacement
+    assert "if _check_condition_L3(self, limit):" in replacement
+
+
+def test_predicate_walrus_emits_help_only() -> None:
+    func = first_func(load_source("extract_predicate_walrus.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
+
+    assert plan.suggestion is None
+    assert plan.help is not None
+
+
+def test_predicate_shows_else_chain_context() -> None:
+    func = first_func(load_source("extract_predicate_else_context.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
+
+    assert plan.suggestion is not None
+    replacement = plan.suggestion.replacement
+    assert "if x > 0:" in replacement
+    assert "else:" in replacement
+    assert "if _check_condition_L5(y):" in replacement
+    ast.parse(textwrap.dedent(replacement))
 
 
 def test_collapsible_if_skips_when_outer_has_else() -> None:

--- a/tests/test_refactor_plans.py
+++ b/tests/test_refactor_plans.py
@@ -61,6 +61,30 @@ def test_issue_228_does_not_merge_recursive_call_with_nested_if() -> None:
     assert all(plan.kind != "collapsible_if" for plan in func.refactor_plans)
 
 
+def test_collapsible_if_skips_blank_line_before_preceding_sibling() -> None:
+    func = first_func(
+        load_source("collapsible_if_skips_blank_line_preceding_sibling.py")
+    )
+
+    assert all(plan.kind != "collapsible_if" for plan in func.refactor_plans)
+
+
+def test_collapsible_if_skips_blank_line_before_comment_sibling() -> None:
+    func = first_func(
+        load_source("collapsible_if_skips_blank_line_before_comment_sibling.py")
+    )
+
+    assert all(plan.kind != "collapsible_if" for plan in func.refactor_plans)
+
+
+def test_collapsible_if_skips_misaligned_comment_sibling() -> None:
+    func = first_func(
+        load_source("collapsible_if_skips_misaligned_comment_sibling.py")
+    )
+
+    assert all(plan.kind != "collapsible_if" for plan in func.refactor_plans)
+
+
 def test_collapsible_if_skips_sibling_after_innermost_if() -> None:
     func = first_func(load_source("collapsible_if_skips_nested_tail.py"))
 
@@ -168,6 +192,32 @@ def test_boolean_heavy_condition_creates_predicate_plan() -> None:
     assert plan.suggestion is not None
     assert "def _check_condition_L" in plan.suggestion.replacement
     assert plan.help is None
+
+
+def test_predicate_while_keeps_while_keyword() -> None:
+    func = first_func(load_source("extract_predicate_while.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
+
+    assert plan.suggestion is not None
+    assert "while _check_condition_L3():" in plan.suggestion.replacement
+    assert "\n    if _check_condition_L3():" not in plan.suggestion.replacement
+
+
+def test_predicate_elif_emits_help_only() -> None:
+    func = first_func(load_source("extract_predicate_elif.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
+
+    assert plan.suggestion is None
+    assert plan.help is not None
+
+
+def test_predicate_uses_detected_indent_step() -> None:
+    func = first_func(load_source("extract_predicate_two_space_indent.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
+
+    assert plan.suggestion is not None
+    assert plan.suggestion.replacement.startswith("  def _check_condition_L2()")
+    assert "\n    return " in plan.suggestion.replacement
 
 
 def test_try_nested_through_with_creates_flatten_try_plan() -> None:
@@ -318,6 +368,36 @@ def test_loop_guard_preserves_inner_if_else() -> None:
         "if item.value > threshold:" in loop_guard_plan.suggestion.replacement
     )
     assert "else:" in loop_guard_plan.suggestion.replacement
+
+
+def test_loop_guard_preserves_statement_between_members() -> None:
+    """C002 should keep statements between chained ifs in the replacement."""
+    func = first_func(
+        load_source("loop_guards_preserves_between_statements.py")
+    )
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+    replacement = plan.suggestion.replacement
+
+    assert "total += x" in replacement
+    guard_1 = replacement.index("if not x > 0:")
+    statement = replacement.index("total += x")
+    guard_2 = replacement.index("if not total > 100:")
+    assert guard_1 < statement < guard_2
+
+
+def test_loop_guard_preserves_multiline_statement_between_members() -> None:
+    """C002 should keep multi-line statements between chained ifs aligned."""
+    func = first_func(
+        load_source("loop_guards_preserves_multiline_between_statement.py")
+    )
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+    replacement = plan.suggestion.replacement
+
+    assert "total += calculate(" in replacement
+    assert "x, scale," in replacement
+    call_idx = replacement.index("total += calculate(")
+    arg_idx = replacement.index("x, scale,")
+    assert call_idx < arg_idx
 
 
 def test_collapsible_if_skips_when_outer_has_else() -> None:

--- a/tests/test_refactor_plans.py
+++ b/tests/test_refactor_plans.py
@@ -85,6 +85,16 @@ def test_collapsible_if_skips_misaligned_comment_sibling() -> None:
     assert all(plan.kind != "collapsible_if" for plan in func.refactor_plans)
 
 
+def test_collapsible_if_skips_multiline_string_body() -> None:
+    func = first_func(
+        load_source("collapsible_if_skips_multiline_string_body.py")
+    )
+    plan = next(p for p in func.refactor_plans if p.kind == "collapsible_if")
+
+    assert plan.suggestion is None
+    assert plan.help is not None
+
+
 def test_collapsible_if_skips_sibling_after_innermost_if() -> None:
     func = first_func(load_source("collapsible_if_skips_nested_tail.py"))
 
@@ -416,6 +426,38 @@ def test_loop_guard_parenthesizes_and_condition() -> None:
     replacement = plan.suggestion.replacement
 
     assert "if not (x > 0 and x < 50):" in replacement
+
+
+def test_loop_guard_strips_redundant_not() -> None:
+    """C002 should invert `not a` guards into plain `if a:`."""
+    func = first_func(load_source("loop_guards_strips_redundant_not.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+    replacement = plan.suggestion.replacement
+
+    assert "if item.active:" in replacement
+    assert "if not (not item.active):" not in replacement
+
+
+def test_loop_guard_skips_multiline_string_between_members() -> None:
+    """C002 must not dedent content lines of multi-line string literals."""
+    func = first_func(
+        load_source("loop_guards_skips_multiline_string_between.py")
+    )
+    plan = next(p for p in func.refactor_plans if p.kind == "loop_guards")
+
+    assert plan.suggestion is None
+    assert plan.help is not None
+
+
+def test_predicate_name_collision_gets_a_suffix() -> None:
+    """C005 must not reuse a predicate name the source already defines."""
+    func = first_func(load_source("extract_predicate_name_collision.py"))
+    plan = next(p for p in func.refactor_plans if p.kind == "extract_predicate")
+
+    assert plan.suggestion is not None
+    replacement = plan.suggestion.replacement
+    assert "def _check_condition_L2_()" in replacement
+    assert "if _check_condition_L2_():" in replacement
 
 
 def test_collapsible_if_skips_when_outer_has_else() -> None:


### PR DESCRIPTION
## What

Makes every MachineApplicable refactor suggestion preserve all statements of the original code, so a spliced replacement never deletes code or changes program semantics.

## Why

Three rules emitted "Safe to apply" replacements that were not faithful source replacements, all verified on `main`:

- C007 dropped statements between merged `if`s when blank or misaligned-comment lines defeated the indent-step guard (issue #245).
- C002 loop-guards dropped statements located between chained `if`s entirely — no guard existed at all.
- C005 extract-predicate replaced `while` loops with one-shot `if` branches and produced broken standalone `if` replacements for `elif` conditions; it also hardcoded a 4-space body indent.

## Changes

- `detect_indent_step` skips blank and comment-only lines when pairing indents, so the C007 guard and suggestion generator get correct indent steps.
- C007 guard strengthened: any non-blank line between the outer and inner `if` (or after the inner `if` inside the outer body) rejects the merge — no content can be dropped, regardless of indent.
- C002 generator interleaves statements between chain members after each guard's `continue`, dedented by one step per guard, preserving continuation alignment for multi-line statements.
- C005 keeps the statement keyword (`while` stays `while`), emits help text only for `elif` (a `def` cannot sit inside an if-chain), and uses the detected indent step instead of a hardcoded 4.
- Registry ranking: spliceable plans now beat help-only plans of higher effectiveness in `select_non_overlapping`, so 3-level C002 suggestions surface instead of being masked by C001 (only the C002-vs-C001 pair changes; C007-vs-C002 and help-only pairs are unchanged).
- New fixtures and tests for all shapes: blank-line siblings, misaligned comments, between-member statements (2-level and 3-level), `while`/`elif`/two-space C005 cases; Rust unit tests for `detect_indent_step` and the C002 interleave.
- Docs updated in EN + ES; changelog entries under Unreleased; AGENTS.md ranking note.

Closes #245.