### PR TITLE
docs: slim readme and docs home to landing funnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     <a href="#installation">Installation</a> •
     <a href="#quick-start">Quick Start</a> •
     <a href="#integrations">Integrations</a> •
+    <a href="#learn-more">Learn More</a> •
     <a href="https://rohaquinlop.github.io/complexipy/">Documentation</a> •
     <a href="https://rohaquinlop.github.io/complexipy/changelog/">Changelog</a> •
     <a href="https://www.complexipy-teams.com/">Complexipy Teams</a>
@@ -57,52 +58,29 @@ uv add complexipy
 ### Command Line
 
 ```bash
-# Analyze current directory
+# Analyze the current directory
 complexipy .
 
-# Analyze specific file/directory
-complexipy path/to/code.py
-
-# Analyze with custom threshold
+# Set a custom threshold
 complexipy . --max-complexity-allowed 10
 
-# Save results to JSON/CSV
-complexipy . --output-format json --output-format csv
-
-# Show the top 5 most complex functions
-complexipy . --top 5
-
-# Show deterministic refactor suggestions for failing functions
+# Show failing functions with refactor suggestions
 complexipy . --failed --suggest-refactors
 
-# Emit plain text for scripting/AI agents
-complexipy . --plain
+# Save results to JSON
+complexipy . --output-format json
 
-# Include module-level script complexity as <module>
-complexipy . --check-script
-
-# Write a GitLab report to a deterministic path
-complexipy . --output-format gitlab --output complexipy-code-quality.json
-
-# Compare complexity against a git reference
-complexipy . --diff HEAD~1
-
-# Fail only on threshold-breaking regressions in a diff
+# Block regressions against a git reference
 complexipy . --diff main
-# Analyze current directory while excluding files or directories with glob patterns
-complexipy . --exclude "tests/**" --exclude "path/to/exclude.py"
 
-# Disregard all inline ignore comments
-complexipy . --no-ignore
-
-# Report all ignored functions
-complexipy . --report-ignored
+# Exclude paths with glob patterns
+complexipy . --exclude "tests/**"
 ```
 
 ### Python API
 
 ```python
-from complexipy import file_complexity, code_complexity
+from complexipy import file_complexity
 
 # Analyze a file
 result = file_complexity("app.py", check_script=True)
@@ -110,18 +88,6 @@ print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
     print(f"{func.name}: {func.complexity}")
-
-# Analyze code string
-snippet = """
-def complex_function(data):
-    if data:
-        for item in data:
-            if item.is_valid():
-                process(item)
-"""
-
-result = code_complexity(snippet, check_script=True)
-print(f"Complexity: {result.complexity}")
 ```
 
 ## Integrations
@@ -135,42 +101,6 @@ print(f"Complexity: {result.complexity}")
       paths: .
       max_complexity_allowed: 10
       output_format: json
-```
-
-</details>
-
-<details>
-<summary><strong>🔍 GitHub Code Scanning (SARIF)</strong></summary>
-
-Upload complexity violations as inline PR annotations using SARIF:
-
-```yaml
-- name: Run complexipy
-  run: complexipy . --output-format sarif --output complexipy-results.sarif --ignore-complexity
-
-- name: Upload SARIF results
-  uses: github/codeql-action/upload-sarif@v3
-  with:
-      sarif_file: complexipy-results.sarif
-```
-
-</details>
-
-<details>
-<summary><strong>🦊 GitLab Code Quality</strong></summary>
-
-Publish complexity violations as a GitLab Code Quality artifact:
-
-```yaml
-complexity:
-    image: python:3.11
-    script:
-        - pip install complexipy
-        - complexipy . --output-format gitlab --output complexipy-code-quality.json --ignore-complexity
-    artifacts:
-        when: always
-        reports:
-            codequality: complexipy-code-quality.json
 ```
 
 </details>
@@ -195,321 +125,14 @@ Install from the [marketplace](https://marketplace.visualstudio.com/items?itemNa
 
 </details>
 
-## Configuration
-
-### TOML Configuration Files
-
-complexipy supports configuration via TOML files. Configuration files are loaded in this order of precedence:
-
-1. `complexipy.toml` (project-specific config)
-1. `.complexipy.toml` (hidden config file)
-1. `pyproject.toml` (under `[tool.complexipy]` section)
-
-#### Example Configuration
-
-```toml
-# complexipy.toml or .complexipy.toml
-paths = ["src", "tests"]
-max-complexity-allowed = 10
-snapshot-create = false
-snapshot-ignore = false
-quiet = false
-ignore-complexity = false
-failed = false
-color = "auto"
-sort = "asc"
-exclude = []
-check-script = false
-no-ignore = false
-report-ignored = false
-output-format = ["json", "sarif"]
-output = "reports/"
-```
-
-```toml
-# pyproject.toml
-[tool.complexipy]
-paths = ["src", "tests"]
-max-complexity-allowed = 10
-snapshot-create = false
-snapshot-ignore = false
-quiet = false
-ignore-complexity = false
-failed = false
-color = "auto"
-sort = "asc"
-exclude = []
-check-script = false
-no-ignore = false
-report-ignored = false
-output-format = ["json"]
-output = "complexipy-results.json"
-```
-
-Legacy TOML keys and CLI flags such as `output-json = true` and
-`--output-json` were removed. Use `output-format` and `--output-format`
-instead. See the [migration note](https://rohaquinlop.github.io/complexipy/migration/) for the full list of removed flags and keys with their replacements.
-
-#### Diff Configuration
-
-The comparison policy can be declared once in the repo, so CI jobs and
-contributors don't repeat `--diff` flags:
-
-```toml
-# complexipy.toml or .complexipy.toml
-[diff]
-branch = "main"
-staged = true
-```
-
-```toml
-# pyproject.toml
-[tool.complexipy.diff]
-branch = "main"
-staged = true
-```
-
-`branch` makes a plain `complexipy .` behave like `complexipy . --diff main`
-(enforcement included); `staged` enables staged comparison by default. CLI
-flags always take precedence. See the [usage guide](docs/usage-guide.md)
-for details, including the empty-branch opt-out and missing-reference
-behavior.
-
-`check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
-
-### CLI Options
-
-| Flag | Description | Default |
-| -- | -- | -- |
-| `--exclude` | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files. |  |
-| `--max-complexity-allowed` | Complexity threshold | `15` |
-| `--snapshot-create` | Save the current violations above the threshold into `complexipy-snapshot.json` | `false` |
-| `--snapshot-ignore` | Skip comparing against the snapshot even if it exists | `false` |
-| `--failed` | Show only functions above the complexity threshold | `false` |
-| `--suggest-refactors` | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain` | `false` |
-| `--color <auto\|yes\|no>` | Use color | `auto` |
-| `--sort <asc\|desc\|file_name>` | Sort results | `asc` |
-| `--quiet` | Suppress output | `false` |
-| `--ignore-complexity` | Don't exit with error on threshold breach | `false` |
-| `--version` | Show installed complexipy version and exit | - |
-| `--top <n>` | Show only the `n` most complex functions, globally sorted by complexity descending | - |
-| `--plain` | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet` | `false` |
-| `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`) | - |
-| `--output <path>` | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats | - |
-| `--diff <ref>` | Show a complexity diff against a git reference and enforce the threshold. Fails on regressions above `--max-complexity-allowed` (see [Complexity Diff](#complexity-diff)) | - |
-| `--diff-only <ref>` | Show a complexity diff visually without affecting the exit code (see [Complexity Diff](#complexity-diff)) | - |
-| `--staged` | Compare staged (git index) changes against the `--diff` ref (default `HEAD`). Answers "what complexity am I about to commit?" (see [Complexity Diff](#complexity-diff)) | `false` |
-| `--check-script` | Report module-level (script) complexity as a synthetic `<module>` entry | `false` |
-| `--no-ignore` | Analyze every function, disregarding inline ignore comments (`# complexipy: ignore`, `# noqa: complexipy`) | `false` |
-| `--report-ignored` | List every file:line where an ignore comment suppresses a function. Prints even under `--quiet` | `false` |
-
-Example:
-
-```
-# Exclude a directory recursively under the provided root
-complexipy . --exclude "tests/**"
-# Exclude a specific file
-complexipy . --exclude "src/legacy/old_code.py"
-```
-
-### Refactor Suggestions
-
-Use `--suggest-refactors` to print a small, ranked set of deterministic refactor plans next to rich CLI results:
-
-```bash
-complexipy . --failed --suggest-refactors
-```
-
-Sample output (abbreviated -- the real output also shows a caret-underlined span, the surrounding source, and a documentation link):
-
-```text
-      [1] C007 Merge nested if statements
-          --> sample.py:4:9
-          Category: • Readability | Applicability: * Safe to apply
-          Lines 4-6 -> Estimated reduction: -2 complexity (6 -> 4)
-
-          Suggestion: * Safe to apply
-          Merge nested conditions into `if item.active and item.ready:`
-```
-
-Plans are based on the Rust AST analysis only; no AI is used and no code is rewritten automatically. Estimated reductions are approximate, ranked, and limited, so treat them as guidance rather than exact future scores. `--plain --suggest-refactors` keeps plain output unchanged.
-
-### Snapshot Baselines
-
-Use snapshots to adopt complexipy in large, existing codebases without touching every legacy function at once.
-
-```bash
-# Record the current state (creates complexipy-snapshot.json in the working directory)
-complexipy . --snapshot-create --max-complexity-allowed 15
-
-# Block regressions while allowing previously-recorded functions
-complexipy . --max-complexity-allowed 15
-
-# Temporarily skip the snapshot gate
-complexipy . --snapshot-ignore
-```
-
-The snapshot file only stores functions whose complexity exceeds the configured threshold. When a snapshot file exists, complexipy will automatically:
-
-- fail if a new function crosses the threshold,
-- fail if a tracked function becomes more complex, and
-- pass (and update the snapshot) when everything is stable or improved, automatically removing entries that now meet the standard.
-
-Use `--snapshot-ignore` if you need to temporarily bypass the snapshot gate (for example during a refactor or while regenerating the baseline).
-
-### Complexity Diff
-
-Compare complexity against any git reference to see whether a branch or commit made things better or worse:
-
-```bash
-# Compare the working tree against the previous commit
-complexipy . --diff HEAD~1
-
-# Compare against a named branch
-complexipy . --diff main
-```
-
-By default `--diff` **enforces** the complexity threshold: the run exits with code `1` only when a change breaches the contract relative to `--max-complexity-allowed`:
-
-- A new function is introduced above the threshold, or
-- an existing function's complexity increases **and** ends above the threshold (already-over functions getting worse also fail).
-
-Functions that regress but stay at or below the threshold (e.g. `3 → 4` with `-mx 15`) are **not** flagged - the threshold is still the main contract, and `--diff` only catches regressions that actually break it.
-
-To see the diff visually without affecting the exit code, use `--diff-only` instead:
-
-```bash
-complexipy . --diff-only HEAD~1
-```
-
-To compare the **staged** (git index) content instead of the working tree - "what complexity am I about to commit?" - add `--staged`:
-
-```bash
-# Staged changes vs HEAD (the default baseline for --staged)
-complexipy . --staged
-
-# Staged changes vs a specific ref
-complexipy . --diff main --staged
-```
-
-Like `--diff`, `--staged` enforces the threshold against the staged content and fails when a staged change pushes a function above `--max-complexity-allowed`. Staged deletions produce `REMOVED` entries and staged additions `NEW` entries.
-
-Requires `git` to be available and the analysed paths to be inside a git repository.
-
-### Script Complexity
-
-Use `--check-script` when you also want to score module-level control flow, not just functions:
-
-```bash
-# Report top-level script logic as <module>
-complexipy scripts/bootstrap.py --check-script
-```
-
-The same capability is available in the Python API via `check_script=True` on both `file_complexity()` and `code_complexity()`.
-
-### Inline Ignores
-
-You can explicitly ignore a known complex function inline, similar to Ruff's `C901` ignores:
-
-```python
-def legacy_adapter(x, y):  # complexipy: ignore
-    if x and y:
-        return x + y
-    return 0
-```
-
-Place `# complexipy: ignore` on the function definition line (or the line immediately above). An optional reason can be provided in parentheses or plain text, it's ignored by the parser.
-
-### Disabling Inline Ignores
-
-Use `--no-ignore` to disregard all inline ignore comments and analyze every function:
-
-```bash
-# Treat every function equally, regardless of suppression
-complexipy . --no-ignore
-```
-
-Functions previously suppressed by `# complexipy: ignore` or `# noqa: complexipy` will be analyzed normally and may fail the threshold.
-
-### Reporting Ignored Functions
-
-Use `--report-ignored` to list every location where an ignore comment suppresses a function:
-
-```bash
-# List ignored functions
-complexipy . --report-ignored
-
-# Combine with --no-ignore to report while analyzing everything
-complexipy . --report-ignored --no-ignore
-```
-
-When `--output-format json` is also active, ignored locations are exported to `complexipy-ignored.json`. The report prints even under `--quiet`.
-
-Both flags are also available in the Python API via `no_ignore=True` on `file_complexity()` and `code_complexity()`. To programmatically collect ignored locations, use `collect_all_ignored_locations()` from the `complexipy` package.
-
-## API Reference
-
-```text
-# Core functions
-file_complexity(path: str, check_script: bool = False, no_ignore: bool = False) -> FileComplexity
-code_complexity(source: str, check_script: bool = False, no_ignore: bool = False) -> CodeComplexity
-collect_all_ignored_locations(paths: List[str], exclude: List[str] = [], invocation_path: str = "") -> Tuple[List[IgnoredLocation], List[str]]
-
-# Return types
-FileComplexity:
-  ├─ path: str
-  ├─ file_name: str
-  ├─ complexity: int
-  └─ functions: List[FunctionComplexity]
-
-FunctionComplexity:
-  ├─ name: str
-  ├─ complexity: int
-  ├─ line_start: int
-  ├─ line_end: int
-  ├─ line_complexities: List[LineComplexity]
-  └─ refactor_plans: List[RefactorPlan]
-
-RefactorPlan:
-  ├─ kind: str
-  ├─ title: str
-  ├─ line_start: int
-  ├─ line_end: int
-  ├─ column_start: int
-  ├─ current_complexity: int
-  ├─ estimated_reduction: int
-  ├─ estimated_complexity_after: int
-  ├─ rule_id: str
-  ├─ category: RuleCategory
-  ├─ applicability: Applicability
-  ├─ description: str
-  ├─ explanation: str
-  ├─ references: List[str]
-  ├─ suggestion: Optional[CodeSuggestion]
-  ├─ help: Optional[str]
-  └─ doc_url: str
-
-CodeSuggestion:
-  ├─ replacement: str
-  ├─ applicability: Applicability
-  └─ description: str
-
-RuleCategory: Complexity | Readability
-Applicability: MachineApplicable | MaybeIncorrect | Informational
-
-LineComplexity:
-  ├─ line: int
-  └─ complexity: int
-
-IgnoredLocation:
-  ├─ path: str
-  ├─ line: int
-  └─ comment: str
-
-CodeComplexity:
-  ├─ complexity: int
-  └─ functions: List[FunctionComplexity]
-```
+## Learn More
+
+- [Usage Guide](https://rohaquinlop.github.io/complexipy/usage-guide/) - every CLI flag, configuration files, snapshots, complexity diff, and inline ignores
+- [API Reference](https://rohaquinlop.github.io/complexipy/api-reference/) - the complete Python API
+- [Understanding Scores](https://rohaquinlop.github.io/complexipy/understanding-scores/) - how the scoring algorithm works
+- [Comparison with Ruff](https://rohaquinlop.github.io/complexipy/comparison-with-ruff/) - cognitive vs cyclomatic complexity
+- [Refactoring Rules](https://rohaquinlop.github.io/complexipy/refactoring-rules/) - the rules behind `--suggest-refactors`
+- [Changelog](https://rohaquinlop.github.io/complexipy/changelog/) - what changed in each release
 
 ______________________________________________________________________
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,79 @@
+# API Reference
+
+The complete Python API exposed by complexipy. Import everything from the
+`complexipy` package. For usage examples, see the
+[Python API](usage-guide.md#python-api) section of the usage guide.
+
+```text
+# Core functions
+file_complexity(path: str, check_script: bool = False, no_ignore: bool = False) -> FileComplexity
+code_complexity(source: str, check_script: bool = False, no_ignore: bool = False) -> CodeComplexity
+collect_all_ignored_locations(paths: List[str], exclude: List[str] = [], invocation_path: str = "") -> Tuple[List[IgnoredLocation], List[str]]
+compute_diff(files: List[FileComplexity], git_ref: str, invocation_path: Optional[str] = None) -> List[DiffEntry]
+has_regressions(entries: List[DiffEntry], max_complexity: int) -> bool
+
+# Return types
+FileComplexity:
+  ├─ path: str (relative to the working directory, or absolute when outside it)
+  ├─ file_name: str
+  ├─ complexity: int
+  └─ functions: List[FunctionComplexity]
+
+FunctionComplexity:
+  ├─ name: str
+  ├─ complexity: int
+  ├─ line_start: int
+  ├─ line_end: int
+  ├─ line_complexities: List[LineComplexity]
+  └─ refactor_plans: List[RefactorPlan]
+
+RefactorPlan:
+  ├─ kind: str
+  ├─ title: str
+  ├─ line_start: int
+  ├─ line_end: int
+  ├─ column_start: int
+  ├─ current_complexity: int
+  ├─ estimated_reduction: int
+  ├─ estimated_complexity_after: int
+  ├─ rule_id: str
+  ├─ category: RuleCategory
+  ├─ applicability: Applicability
+  ├─ description: str
+  ├─ explanation: str
+  ├─ references: List[str]
+  ├─ suggestion: Optional[CodeSuggestion]
+  ├─ help: Optional[str]
+  └─ doc_url: str
+
+CodeSuggestion:
+  ├─ replacement: str
+  ├─ applicability: Applicability
+  └─ description: str
+
+RuleCategory: Complexity | Readability
+Applicability: MachineApplicable | MaybeIncorrect | Informational
+
+LineComplexity:
+  ├─ line: int
+  └─ complexity: int
+
+IgnoredLocation:
+  ├─ path: str
+  ├─ line: int
+  └─ comment: str
+
+CodeComplexity:
+  ├─ complexity: int
+  └─ functions: List[FunctionComplexity]
+
+DiffEntry:
+  ├─ file_path: str
+  ├─ func_name: str
+  ├─ old_complexity: Optional[int]
+  ├─ new_complexity: Optional[int]
+  ├─ status: DiffStatus (property)
+  └─ delta: Optional[int] (property)
+
+DiffStatus: REGRESSED | IMPROVED | UNCHANGED | NEW | REMOVED
+```

--- a/docs/es/api-reference.md
+++ b/docs/es/api-reference.md
@@ -1,0 +1,79 @@
+# Referencia de la API
+
+La API completa de Python que expone complexipy. Importa todo desde el paquete
+`complexipy`. Para ejemplos de uso, consulta la sección
+[API de Python](usage-guide.md#api-de-python) de la guía de uso.
+
+```text
+# Funciones principales
+file_complexity(path: str, check_script: bool = False, no_ignore: bool = False) -> FileComplexity
+code_complexity(source: str, check_script: bool = False, no_ignore: bool = False) -> CodeComplexity
+collect_all_ignored_locations(paths: List[str], exclude: List[str] = [], invocation_path: str = "") -> Tuple[List[IgnoredLocation], List[str]]
+compute_diff(files: List[FileComplexity], git_ref: str, invocation_path: Optional[str] = None) -> List[DiffEntry]
+has_regressions(entries: List[DiffEntry], max_complexity: int) -> bool
+
+# Tipos de retorno
+FileComplexity:
+  ├─ path: str (relative to the working directory, or absolute when outside it)
+  ├─ file_name: str
+  ├─ complexity: int
+  └─ functions: List[FunctionComplexity]
+
+FunctionComplexity:
+  ├─ name: str
+  ├─ complexity: int
+  ├─ line_start: int
+  ├─ line_end: int
+  ├─ line_complexities: List[LineComplexity]
+  └─ refactor_plans: List[RefactorPlan]
+
+RefactorPlan:
+  ├─ kind: str
+  ├─ title: str
+  ├─ line_start: int
+  ├─ line_end: int
+  ├─ column_start: int
+  ├─ current_complexity: int
+  ├─ estimated_reduction: int
+  ├─ estimated_complexity_after: int
+  ├─ rule_id: str
+  ├─ category: RuleCategory
+  ├─ applicability: Applicability
+  ├─ description: str
+  ├─ explanation: str
+  ├─ references: List[str]
+  ├─ suggestion: Optional[CodeSuggestion]
+  ├─ help: Optional[str]
+  └─ doc_url: str
+
+CodeSuggestion:
+  ├─ replacement: str
+  ├─ applicability: Applicability
+  └─ description: str
+
+RuleCategory: Complexity | Readability
+Applicability: MachineApplicable | MaybeIncorrect | Informational
+
+LineComplexity:
+  ├─ line: int
+  └─ complexity: int
+
+IgnoredLocation:
+  ├─ path: str
+  ├─ line: int
+  └─ comment: str
+
+CodeComplexity:
+  ├─ complexity: int
+  └─ functions: List[FunctionComplexity]
+
+DiffEntry:
+  ├─ file_path: str
+  ├─ func_name: str
+  ├─ old_complexity: Optional[int]
+  ├─ new_complexity: Optional[int]
+  ├─ status: DiffStatus (property)
+  └─ delta: Optional[int] (property)
+
+DiffStatus: REGRESSED | IMPROVED | UNCHANGED | NEW | REMOVED
+```

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -15,7 +15,7 @@
     <a href="#instalación">Instalación</a> •
     <a href="#inicio-rápido">Inicio Rápido</a> •
     <a href="#integraciones">Integraciones</a> •
-    <a href="https://rohaquinlop.github.io/complexipy/">Documentación</a> •
+    <a href="#aprende-más">Aprende Más</a> •
     <a href="https://www.complexipy-teams.com/">Complexipy Teams</a>
   </p>
 </div>
@@ -59,46 +59,26 @@ uv add complexipy
 # Analiza el directorio actual
 complexipy .
 
-# Analiza un directorio o archivo específico
-complexipy path/to/code.py
-
-# Analisis con un límite (threshold) personalizado
+# Establece un umbral personalizado
 complexipy . --max-complexity-allowed 10
 
-# Guarda los resultados en JSON/CSV
-complexipy . --output-format json --output-format csv
-
-# Muestra las 5 funciones más complejas
-complexipy . --top 5
-
-# Muestra sugerencias deterministas de refactorización para funciones fallidas
+# Muestra las funciones fallidas con sugerencias de refactorización
 complexipy . --failed --suggest-refactors
 
-# Emite texto plano para scripts o agentes de IA
-complexipy . --plain
+# Guarda los resultados en JSON
+complexipy . --output-format json
 
-# Incluye la complejidad del código a nivel de módulo como <module>
-complexipy . --check-script
+# Bloquea regresiones contra una referencia de git
+complexipy . --diff main
 
-# Guarda un reporte de GitLab en una ruta determinista
-complexipy . --output-format gitlab --output complexipy-code-quality.json
-
-# Compara la complejidad contra una referencia de git
-complexipy . --diff HEAD~1
-# Analiza el directorio actual excluyendo archivos o directorios con patrones glob
-complexipy . --exclude "tests/**" --exclude "path/to/exclude.py"
-
-# Ignorar todos los comentarios de ignore en línea
-complexipy . --no-ignore
-
-# Reportar todas las funciones ignoradas
-complexipy . --report-ignored
+# Excluye rutas con patrones glob
+complexipy . --exclude "tests/**"
 ```
 
 ### API de Python
 
 ```python
-from complexipy import file_complexity, code_complexity
+from complexipy import file_complexity
 
 # Analiza un archivo
 result = file_complexity("app.py", check_script=True)
@@ -106,18 +86,6 @@ print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
     print(f"{func.name}: {func.complexity}")
-
-# Analiza código en una cadena
-snippet = """
-def complex_function(data):
-    if data:
-        for item in data:
-            if item.is_valid():
-                process(item)
-"""
-
-result = code_complexity(snippet, check_script=True)
-print(f"Complexity: {result.complexity}")
 ```
 
 ## Integraciones
@@ -136,7 +104,7 @@ print(f"Complexity: {result.complexity}")
 </details>
 
 <details>
-<summary><strong>🪝 Pre-commit Hook</strong></summary>
+<summary><strong>🪝 Hook de Pre-commit</strong></summary>
 
 ```yaml
 repos:
@@ -149,306 +117,20 @@ repos:
 </details>
 
 <details>
-<summary><strong>🔌 VS Code Extension</strong></summary>
+<summary><strong>🔌 Extensión de VS Code</strong></summary>
 
 Instálala desde el [marketplace](https://marketplace.visualstudio.com/items?itemName=rohaquinlop.complexipy) para tener análisis de complejidad en tiempo real con indicadores visuales.
 
 </details>
 
-## Configuración
-
-### Archivos de Configuración TOML
-
-complexipy admite configuración mediante archivos TOML. Los archivos de configuración se cargan en este orden de precedencia:
-
-1. `complexipy.toml` (configuración específica del proyecto)
-1. `.complexipy.toml` (archivo de configuración oculto)
-1. `pyproject.toml` (bajo la sección `[tool.complexipy]`)
-
-#### Configuración de Ejemplo
-
-```toml
-# complexipy.toml o .complexipy.toml
-paths = ["src", "tests"]
-max-complexity-allowed = 10
-snapshot-create = false
-snapshot-ignore = false
-quiet = false
-ignore-complexity = false
-failed = false
-color = "auto"
-sort = "asc"
-exclude = []
-check-script = false
-no-ignore = false
-report-ignored = false
-output-format = ["json", "gitlab"]
-output = "reports/"
-```
-
-```toml
-# pyproject.toml
-[tool.complexipy]
-paths = ["src", "tests"]
-max-complexity-allowed = 10
-snapshot-create = false
-snapshot-ignore = false
-quiet = false
-ignore-complexity = false
-failed = false
-color = "auto"
-sort = "asc"
-exclude = []
-check-script = false
-no-ignore = false
-report-ignored = false
-output-format = ["json"]
-output = "complexipy-results.json"
-```
-
-`check-script` está soportado en TOML. `--top` y `--plain` son flags solo de CLI.
-
-### Opciones de CLI
-
-| Opción | Descripción | Predeterminado |
-| -- | -- | -- |
-| `--exclude` | Excluye patrones glob relativos a cada ruta proporcionada. Usa patrones como `tests/**` para directorios o `src/legacy/file.py` para archivos específicos. |  |
-| `--max-complexity-allowed` | Umbral de complejidad | `15` |
-| `--snapshot-create` | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json` | `false` |
-| `--snapshot-ignore` | Omite la comparación con un snapshot aunque exista | `false` |
-| `--failed` | Muestra solo las funciones que superen el umbral de complejidad | `false` |
-| `--suggest-refactors` | Muestra planes deterministas de refactorización basados en el AST de Rust en la salida CLI enriquecida. Ignorado por `--plain` | `false` |
-| `--color <auto\|yes\|no>` | Usa color | `auto` |
-| `--sort <asc\|desc\|file_name>` | Ordena los resultados | `asc` |
-| `--quiet` | Suprime la salida | `false` |
-| `--ignore-complexity` | No termina con error al superar el umbral | `false` |
-| `--version` | Muestra la versión instalada de complexipy y sale | - |
-| `--top <n>` | Muestra solo las `n` funciones más complejas, ordenadas globalmente por complejidad descendente | - |
-| `--plain` | Emite líneas de texto plano como `<path> <function> <complexity>`. No se puede combinar con `--quiet` | `false` |
-| `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`) | - |
-| `--output <path>` | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos | - |
-| `--diff <ref>` | Muestra un diff de complejidad contra una referencia de git y aplica el umbral. Falla si hay regresiones por encima de `--max-complexity-allowed` (ver [Diff de Complejidad](#diff-de-complejidad)) | - |
-| `--diff-only <ref>` | Muestra un diff de complejidad visualmente sin afectar el código de salida (ver [Diff de Complejidad](#diff-de-complejidad)) | - |
-| `--staged` | Compara los cambios staged (índice de git) contra la referencia de `--diff` (por defecto `HEAD`). Responde "¿qué complejidad estoy a punto de commitear?" (ver [Diff de Complejidad](#diff-de-complejidad)) | `false` |
-| `--check-script` | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>` | `false` |
-| `--no-ignore` | Analiza cada función, ignorando los comentarios de ignore en línea (`# complexipy: ignore`, `# noqa: complexipy`) | `false` |
-| `--report-ignored` | Lista cada archivo:línea donde un comentario de ignore suprime una función. Se imprime incluso bajo `--quiet` | `false` |
-
-Ejemplo:
-
-```
-# Excluye un directorio recursivamente bajo la raíz proporcionada
-complexipy . --exclude "tests/**"
-# Excluye un archivo específico
-complexipy . --exclude "src/legacy/old_code.py"
-```
-
-### Sugerencias de Refactorización
-
-Usa `--suggest-refactors` para imprimir un conjunto pequeño y ordenado de planes deterministas de refactorización junto a los resultados enriquecidos de la CLI:
-
-```bash
-complexipy . --failed --suggest-refactors
-```
-
-Salida de ejemplo (abreviada -- la salida real también muestra un tramo subrayado con acentos circunflejos, el código fuente circundante y un enlace a la documentación):
-
-```text
-      [1] C007 Merge nested if statements
-          --> sample.py:4:9
-          Category: ◆ Readability | Applicability: * Safe to apply
-          Lines 4-6 -> Estimated reduction: -2 complexity (6 -> 4)
-
-          Suggestion: * Safe to apply
-          Merge nested conditions into `if item.active and item.ready:`
-```
-
-Los planes se basan solo en el análisis AST de Rust; no se usa IA y no se reescribe código automáticamente. Las reducciones estimadas son aproximadas, ordenadas y limitadas, así que trátalas como orientación, no como puntuaciones futuras exactas. `--plain --suggest-refactors` mantiene la salida plana sin cambios.
-
-### Snapshots Base
-
-Usa snapshots para adoptar complexipy gradualmente en bases de código grandes y existentes sin tocar cada función heredada de una vez.
-
-```bash
-# Registra el estado actual (crea complexipy-snapshot.json en el directorio de trabajo)
-complexipy . --snapshot-create --max-complexity-allowed 15
-
-# Bloquea regresiones mientras permite las funciones previamente registradas
-complexipy . --max-complexity-allowed 15
-
-# Omite temporalmente el control de snapshots
-complexipy . --snapshot-ignore
-```
-
-El archivo de snapshot solo almacena las funciones cuya complejidad supera el umbral configurado. Cuando existe un archivo de snapshot, complexipy automáticamente:
-
-- falla si una nueva función supera el umbral,
-- falla si una función registrada se vuelve más compleja, y
-- pasa (y actualiza la snapshot) cuando todo es estable o ha mejorado, eliminando automáticamente las entradas que ahora cumplen el estándar.
-
-Las actualizaciones de la snapshot solo afectan a los archivos analizados en la ejecución: las entradas de archivos fuera del análisis se conservan, por lo que ejecutar sobre un subconjunto de archivos (por ejemplo, a través de un hook de pre-commit) nunca reduce la línea base.
-
-Usa `--snapshot-ignore` si necesitas omitir temporalmente el control de snapshot (por ejemplo, durante una refactorización o al regenerar la línea base).
-
-### Diff de Complejidad
-
-Compara la complejidad contra cualquier referencia de git para ver si una rama o commit mejoró o empeoró el código:
-
-```bash
-# Compara el working tree con el commit anterior
-complexipy . --diff HEAD~1
-
-# Compara contra una rama nombrada
-complexipy . --diff main
-```
-
-Por defecto `--diff` **aplica** el umbral de complejidad: la ejecución termina con código `1` solo cuando un cambio rompe el contrato definido por `--max-complexity-allowed`:
-
-- Se introduce una función nueva por encima del umbral, o
-- una función existente aumenta su complejidad **y** queda por encima del umbral (también falla cuando una función ya sobre el umbral empeora).
-
-Las funciones que aumentan su complejidad pero se mantienen en o por debajo del umbral (por ejemplo `3 → 4` con `-mx 15`) no se marcan - el umbral sigue siendo el contrato principal, y `--diff` solo detecta las regresiones que realmente lo rompen.
-
-Para ver el diff visualmente sin afectar el código de salida, usa `--diff-only` en su lugar:
-
-```bash
-complexipy . --diff-only HEAD~1
-```
-
-Para comparar el contenido **staged** (el índice de git) en lugar del árbol de trabajo - "¿qué complejidad estoy a punto de commitear?" - añade `--staged`:
-
-```bash
-# Cambios staged vs HEAD (la línea base por defecto de --staged)
-complexipy . --staged
-
-# Cambios staged vs una referencia específica
-complexipy . --diff main --staged
-```
-
-Igual que `--diff`, `--staged` aplica el umbral contra el contenido staged y falla cuando un cambio staged empuja una función por encima de `--max-complexity-allowed`. Las eliminaciones staged producen entradas `REMOVED` y las adiciones staged entradas `NEW`.
-
-Requiere que `git` esté disponible y que las rutas analizadas estén dentro de un repositorio git.
-
-### Complejidad de Script
-
-Usa `--check-script` cuando también quieras medir el flujo de control a nivel de módulo, no solo las funciones:
-
-```bash
-complexipy scripts/bootstrap.py --check-script
-```
-
-La misma capacidad está disponible en la API de Python mediante `check_script=True` tanto en `file_complexity()` como en `code_complexity()`.
-
-### Ignorar en Línea
-
-Puedes ignorar explícitamente una función compleja conocida en línea usando `# complexipy: ignore`:
-
-```python
-def legacy_adapter(x, y):  # complexipy: ignore (safe wrapper)
-    if x and y:
-        return x + y
-    return 0
-```
-
-Coloca `# complexipy: ignore` en la línea de definición de la función (o en la línea inmediatamente anterior). Se puede proporcionar un motivo opcional entre paréntesis; el analizador lo ignora.
-
-> **Nota:** La sintaxis `# noqa: complexipy` está obsoleta. Herramientas como [yesqa](https://github.com/asottile/yesqa) eliminan los comentarios `# noqa` no reconocidos, lo que eliminaría silenciosamente tus supresiones. Migra a `# complexipy: ignore` para evitar este problema.
-
-### Deshabilitar Ignorados en Línea
-
-Usa `--no-ignore` para ignorar todos los comentarios de ignore en línea y analizar cada función:
-
-```bash
-complexipy . --no-ignore
-```
-
-Las funciones previamente suprimidas se analizarán normalmente y pueden superar el umbral.
-
-### Reportar Funciones Ignoradas
-
-Usa `--report-ignored` para listar cada ubicación donde un comentario de ignore suprime una función:
-
-```bash
-complexipy . --report-ignored
-```
-
-Cuando `--output-format json` también está activo, las ubicaciones ignoradas se exportan a `complexipy-ignored.json`.
-
-## Referencia de la API
-
-```text
-# Funciones principales
-file_complexity(path: str, check_script: bool = False, no_ignore: bool = False) -> FileComplexity
-code_complexity(source: str, check_script: bool = False, no_ignore: bool = False) -> CodeComplexity
-collect_all_ignored_locations(paths: List[str], exclude: List[str] = [], invocation_path: str = "") -> Tuple[List[IgnoredLocation], List[str]]
-compute_diff(files: List[FileComplexity], git_ref: str, invocation_path: Optional[str] = None) -> List[DiffEntry]
-has_regressions(entries: List[DiffEntry], max_complexity: int) -> bool
-
-# Tipos de retorno
-FileComplexity:
-  ├─ path: str (relative to the working directory, or absolute when outside it)
-  ├─ file_name: str
-  ├─ complexity: int
-  └─ functions: List[FunctionComplexity]
-
-FunctionComplexity:
-  ├─ name: str
-  ├─ complexity: int
-  ├─ line_start: int
-  ├─ line_end: int
-  ├─ line_complexities: List[LineComplexity]
-  └─ refactor_plans: List[RefactorPlan]
-
-RefactorPlan:
-  ├─ kind: str
-  ├─ title: str
-  ├─ line_start: int
-  ├─ line_end: int
-  ├─ column_start: int
-  ├─ current_complexity: int
-  ├─ estimated_reduction: int
-  ├─ estimated_complexity_after: int
-  ├─ rule_id: str
-  ├─ category: RuleCategory
-  ├─ applicability: Applicability
-  ├─ description: str
-  ├─ explanation: str
-  ├─ references: List[str]
-  ├─ suggestion: Optional[CodeSuggestion]
-  ├─ help: Optional[str]
-  └─ doc_url: str
-
-CodeSuggestion:
-  ├─ replacement: str
-  ├─ applicability: Applicability
-  └─ description: str
-
-RuleCategory: Complexity | Readability
-Applicability: MachineApplicable | MaybeIncorrect | Informational
-
-LineComplexity:
-  ├─ line: int
-  └─ complexity: int
-
-IgnoredLocation:
-  ├─ path: str
-  ├─ line: int
-  └─ comment: str
-
-CodeComplexity:
-  ├─ complexity: int
-  └─ functions: List[FunctionComplexity]
-
-DiffEntry:
-  ├─ file_path: str
-  ├─ func_name: str
-  ├─ old_complexity: Optional[int]
-  ├─ new_complexity: Optional[int]
-  ├─ status: DiffStatus (property)
-  └─ delta: Optional[int] (property)
-
-DiffStatus: REGRESSED | IMPROVED | UNCHANGED | NEW | REMOVED
-```
+## Aprende Más
+
+- [Guía de Uso](usage-guide.md) - todas las flags de CLI, archivos de configuración, snapshots, diff de complejidad e ignores en línea
+- [Referencia de la API](api-reference.md) - la API completa de Python
+- [Qué Significan las Puntuaciones](understanding-scores.md) - cómo funciona el algoritmo de puntuación
+- [Comparación con Ruff](comparison-with-ruff.md) - complejidad cognitiva vs ciclomática
+- [Reglas de Refactorización](refactoring-rules.md) - las reglas detrás de `--suggest-refactors`
+- [Registro de Cambios](changelog.md) - qué cambió en cada versión
 
 ______________________________________________________________________
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -388,6 +388,41 @@ en lugar de pasar los mismos flags en cada llamada. Añade una sección
   aplicación del umbral sigue activa. Haz fetch de la rama o pasa
   `--diff <ref>` con una referencia existente.
 
+## Opciones de CLI
+
+| Opción | Descripción | Predeterminado |
+| -- | -- | -- |
+| `--exclude` | Excluye patrones glob relativos a cada ruta proporcionada. Usa patrones como `tests/**` para directorios o `src/legacy/file.py` para archivos específicos. |  |
+| `--max-complexity-allowed` | Umbral de complejidad | `15` |
+| `--snapshot-create` | Guarda las violaciones actuales que superen el umbral en `complexipy-snapshot.json` | `false` |
+| `--snapshot-ignore` | Omite la comparación con un snapshot aunque exista | `false` |
+| `--failed` | Muestra solo las funciones que superen el umbral de complejidad | `false` |
+| `--suggest-refactors` | Muestra planes deterministas de refactorización basados en el AST de Rust en la salida CLI enriquecida. Ignorado por `--plain` | `false` |
+| `--color <auto\|yes\|no>` | Usa color | `auto` |
+| `--sort <asc\|desc\|file_name>` | Ordena los resultados | `asc` |
+| `--quiet` | Suprime la salida | `false` |
+| `--ignore-complexity` | No termina con error al superar el umbral | `false` |
+| `--version` | Muestra la versión instalada de complexipy y sale | - |
+| `--top <n>` | Muestra solo las `n` funciones más complejas, ordenadas globalmente por complejidad descendente | - |
+| `--plain` | Emite líneas de texto plano como `<path> <function> <complexity>`. No se puede combinar con `--quiet` | `false` |
+| `--output-format <format>` | Selecciona un formato de salida legible por máquinas. Repite la flag para varios formatos (`json`, `csv`, `gitlab`, `sarif`) | - |
+| `--output <path>` | Escribe la salida legible por máquinas en un archivo o directorio. Usa un directorio cuando emitas varios formatos | - |
+| `--diff <ref>` | Muestra un diff de complejidad contra una referencia de git y aplica el umbral. Falla si hay regresiones por encima de `--max-complexity-allowed` (ver [Diff de Complejidad](#diff-de-complejidad)) | - |
+| `--diff-only <ref>` | Muestra un diff de complejidad visualmente sin afectar el código de salida (ver [Diff de Complejidad](#diff-de-complejidad)) | - |
+| `--staged` | Compara los cambios staged (índice de git) contra la referencia de `--diff` (por defecto `HEAD`). Responde "¿qué complejidad estoy a punto de commitear?" (ver [Diff de Complejidad](#diff-de-complejidad)) | `false` |
+| `--check-script` | Reporta la complejidad a nivel módulo (script) como una entrada sintética `<module>` | `false` |
+| `--no-ignore` | Analiza cada función, ignorando los comentarios de ignore en línea (`# complexipy: ignore`, `# noqa: complexipy`) | `false` |
+| `--report-ignored` | Lista cada archivo:línea donde un comentario de ignore suprime una función. Se imprime incluso bajo `--quiet` | `false` |
+
+Ejemplo:
+
+```
+# Excluye un directorio recursivamente bajo la raíz proporcionada
+complexipy . --exclude "tests/**"
+# Excluye un archivo específico
+complexipy . --exclude "src/legacy/old_code.py"
+```
+
 ## Configuración de la caché
 
 complexipy almacena los datos de complejidad de cada función entre ejecuciones
@@ -836,6 +871,20 @@ O ejecuta directamente:
   run: |
       pip install complexipy
       complexipy . --max-complexity-allowed 15
+```
+
+### GitHub Code Scanning (SARIF)
+
+Sube violaciones de complejidad como anotaciones inline en PRs usando SARIF:
+
+```yaml
+- name: Run complexipy
+  run: complexipy . --output-format sarif --output complexipy-results.sarif --ignore-complexity
+
+- name: Upload SARIF results
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+      sarif_file: complexipy-results.sarif
 ```
 
 ### Hook de Pre-commit

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@
     <a href="#installation">Installation</a> •
     <a href="#quick-start">Quick Start</a> •
     <a href="#integrations">Integrations</a> •
-    <a href="https://rohaquinlop.github.io/complexipy/">Documentation</a> •
+    <a href="#learn-more">Learn More</a> •
     <a href="https://www.complexipy-teams.com/">Complexipy Teams</a>
   </p>
 </div>
@@ -56,48 +56,29 @@ uv add complexipy
 ### Command Line
 
 ```bash
-# Analyze current directory
+# Analyze the current directory
 complexipy .
 
-# Analyze specific file/directory
-complexipy path/to/code.py
-
-# Analyze with custom threshold
+# Set a custom threshold
 complexipy . --max-complexity-allowed 10
 
-# Save results to JSON/CSV
-complexipy . --output-format json --output-format csv
-
-# Show the top 5 most complex functions
-complexipy . --top 5
-
-# Show deterministic refactor suggestions for failing functions
+# Show failing functions with refactor suggestions
 complexipy . --failed --suggest-refactors
 
-# Emit plain text for scripting/AI agents
-complexipy . --plain
+# Save results to JSON
+complexipy . --output-format json
 
-# Include module-level script complexity as <module>
-complexipy . --check-script
+# Block regressions against a git reference
+complexipy . --diff main
 
-# Save a GitLab report to a deterministic path
-complexipy . --output-format gitlab --output complexipy-code-quality.json
-
-# Compare complexity against a git reference
-complexipy . --diff HEAD~1
-# Analyze current directory while excluding files or directories with glob patterns
-complexipy . --exclude "tests/**" --exclude "path/to/exclude.py"
-# Disregard all inline ignore comments
-complexipy . --no-ignore
-
-# Report all ignored functions
-complexipy . --report-ignored
+# Exclude paths with glob patterns
+complexipy . --exclude "tests/**"
 ```
 
 ### Python API
 
 ```python
-from complexipy import file_complexity, code_complexity
+from complexipy import file_complexity
 
 # Analyze a file
 result = file_complexity("app.py", check_script=True)
@@ -105,18 +86,6 @@ print(f"File complexity: {result.complexity}")
 
 for func in result.functions:
     print(f"{func.name}: {func.complexity}")
-
-# Analyze code string
-snippet = """
-def complex_function(data):
-    if data:
-        for item in data:
-            if item.is_valid():
-                process(item)
-"""
-
-result = code_complexity(snippet, check_script=True)
-print(f"Complexity: {result.complexity}")
 ```
 
 ## Integrations
@@ -154,300 +123,14 @@ Install from the [marketplace](https://marketplace.visualstudio.com/items?itemNa
 
 </details>
 
-## Configuration
-
-### TOML Configuration Files
-
-complexipy supports configuration via TOML files. Configuration files are loaded in this order of precedence:
-
-1. `complexipy.toml` (project-specific config)
-1. `.complexipy.toml` (hidden config file)
-1. `pyproject.toml` (under `[tool.complexipy]` section)
-
-#### Example Configuration
-
-```toml
-# complexipy.toml or .complexipy.toml
-paths = ["src", "tests"]
-max-complexity-allowed = 10
-snapshot-create = false
-snapshot-ignore = false
-quiet = false
-ignore-complexity = false
-failed = false
-color = "auto"
-sort = "asc"
-exclude = []
-check-script = false
-no-ignore = false
-report-ignored = false
-output-format = ["json", "gitlab"]
-output = "reports/"
-```
-
-```toml
-# pyproject.toml
-[tool.complexipy]
-paths = ["src", "tests"]
-max-complexity-allowed = 10
-snapshot-create = false
-snapshot-ignore = false
-quiet = false
-ignore-complexity = false
-failed = false
-color = "auto"
-sort = "asc"
-exclude = []
-check-script = false
-no-ignore = false
-report-ignored = false
-output-format = ["json"]
-output = "complexipy-results.json"
-```
-
-`check-script` is supported in TOML. `--top` and `--plain` are CLI-only flags.
-
-### CLI Options
-
-| Flag | Description | Default |
-| -- | -- | -- |
-| `--exclude` | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files. |  |
-| `--max-complexity-allowed` | Complexity threshold | `15` |
-| `--snapshot-create` | Save the current violations above the threshold into `complexipy-snapshot.json` | `false` |
-| `--snapshot-ignore` | Skip comparing against the snapshot even if it exists | `false` |
-| `--failed` | Show only functions above the complexity threshold | `false` |
-| `--suggest-refactors` | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain` | `false` |
-| `--color <auto\|yes\|no>` | Use color | `auto` |
-| `--sort <asc\|desc\|file_name>` | Sort results | `asc` |
-| `--quiet` | Suppress output | `false` |
-| `--ignore-complexity` | Don't exit with error on threshold breach | `false` |
-| `--version` | Show installed complexipy version and exit | - |
-| `--top <n>` | Show only the `n` most complex functions, globally sorted by complexity descending | - |
-| `--plain` | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet` | `false` |
-| `--output-format <format>` | Select a machine-readable output format. Repeat the flag for multiple formats (`json`, `csv`, `gitlab`, `sarif`) | - |
-| `--output <path>` | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats | - |
-| `--diff <ref>` | Show a complexity diff against a git reference and enforce the threshold. Fails on regressions above `--max-complexity-allowed` (see [Complexity Diff](#complexity-diff)) | - |
-| `--diff-only <ref>` | Show a complexity diff visually without affecting the exit code (see [Complexity Diff](#complexity-diff)) | - |
-| `--staged` | Compare staged (git index) changes against the `--diff` ref (default `HEAD`). Answers "what complexity am I about to commit?" (see [Complexity Diff](#complexity-diff)) | `false` |
-| `--check-script` | Report module-level (script) complexity as a synthetic `<module>` entry | `false` |
-| `--no-ignore` | Analyze every function, disregarding inline ignore comments (`# complexipy: ignore`, `# noqa: complexipy`) | `false` |
-| `--report-ignored` | List every file:line where an ignore comment suppresses a function. Prints even under `--quiet` | `false` |
-
-Example:
-
-```
-# Exclude a directory recursively under the provided root
-complexipy . --exclude "tests/**"
-# Exclude a specific file
-complexipy . --exclude "src/legacy/old_code.py"
-```
-
-### Refactor Suggestions
-
-Use `--suggest-refactors` to print a small, ranked set of deterministic refactor plans next to rich CLI results:
-
-```bash
-complexipy . --failed --suggest-refactors
-```
-
-Sample output (abbreviated -- the real output also shows a caret-underlined span, the surrounding source, and a documentation link):
-
-```text
-      [1] C007 Merge nested if statements
-          --> sample.py:4:9
-          Category: ◆ Readability | Applicability: * Safe to apply
-          Lines 4-6 -> Estimated reduction: -2 complexity (6 -> 4)
-
-          Suggestion: * Safe to apply
-          Merge nested conditions into `if item.active and item.ready:`
-```
-
-Plans are based on the Rust AST analysis only; no AI is used and no code is rewritten automatically. Estimated reductions are approximate, ranked, and limited, so treat them as guidance rather than exact future scores. `--plain --suggest-refactors` keeps plain output unchanged.
-
-### Snapshot Baselines
-
-Use snapshots to adopt complexipy in large, existing codebases without touching every legacy function at once.
-
-```bash
-# Record the current state (creates complexipy-snapshot.json in the working directory)
-complexipy . --snapshot-create --max-complexity-allowed 15
-
-# Block regressions while allowing previously-recorded functions
-complexipy . --max-complexity-allowed 15
-
-# Temporarily skip the snapshot gate
-complexipy . --snapshot-ignore
-```
-
-The snapshot file only stores functions whose complexity exceeds the configured threshold. When a snapshot file exists, complexipy will automatically:
-
-- fail if a new function crosses the threshold,
-- fail if a tracked function becomes more complex, and
-- pass (and update the snapshot) when everything is stable or improved, automatically removing entries that now meet the standard.
-
-Snapshot updates only touch the files analyzed in the run: entries for files outside the analysis are preserved, so running on a subset of files (for example through a pre-commit hook) never shrinks the baseline.
-
-Use `--snapshot-ignore` if you need to temporarily bypass the snapshot gate (for example during a refactor or while regenerating the baseline).
-
-### Complexity Diff
-
-Compare complexity against any git reference to see whether a branch or commit made things better or worse:
-
-```bash
-# Compare the working tree against the previous commit
-complexipy . --diff HEAD~1
-
-# Compare against a named branch
-complexipy . --diff main
-```
-
-By default `--diff` **enforces** the complexity threshold: the run exits with code `1` only when a change breaches the contract relative to `--max-complexity-allowed`:
-
-- A new function is introduced above the threshold, or
-- an existing function's complexity increases **and** ends above the threshold (already-over functions getting worse also fail).
-
-Functions that regress but stay at or below the threshold (e.g. `3 → 4` with `-mx 15`) are **not** flagged - the threshold is still the main contract, and `--diff` only catches regressions that actually break it.
-
-To see the diff visually without affecting the exit code, use `--diff-only` instead:
-
-```bash
-complexipy . --diff-only HEAD~1
-```
-
-To compare the **staged** (git index) content instead of the working tree - "what complexity am I about to commit?" - add `--staged`:
-
-```bash
-# Staged changes vs HEAD (the default baseline for --staged)
-complexipy . --staged
-
-# Staged changes vs a specific ref
-complexipy . --diff main --staged
-```
-
-Like `--diff`, `--staged` enforces the threshold against the staged content and fails when a staged change pushes a function above `--max-complexity-allowed`. Staged deletions produce `REMOVED` entries and staged additions `NEW` entries.
-
-Requires `git` to be available and the analysed paths to be inside a git repository.
-
-### Script Complexity
-
-Use `--check-script` when you also want to score module-level control flow, not just functions:
-
-```bash
-complexipy scripts/bootstrap.py --check-script
-```
-
-The same capability is available in the Python API via `check_script=True` on both `file_complexity()` and `code_complexity()`.
-
-### Inline Ignores
-
-You can explicitly ignore a known complex function inline using `# complexipy: ignore`:
-
-```python
-def legacy_adapter(x, y):  # complexipy: ignore (safe wrapper)
-    if x and y:
-        return x + y
-    return 0
-```
-
-Place `# complexipy: ignore` on the function definition line (or the line immediately above). An optional reason can be provided in parentheses, it’s ignored by the parser.
-
-> **Note:** The `# noqa: complexipy` syntax is deprecated. Tools like [yesqa](https://github.com/asottile/yesqa) strip unrecognized `# noqa` comments, which would silently remove your suppressions. Migrate to `# complexipy: ignore` to avoid this issue.
-
-### Disabling Inline Ignores
-
-Use `--no-ignore` to disregard all inline ignore comments and analyze every function:
-
-```bash
-complexipy . --no-ignore
-```
-
-Functions previously suppressed will be analyzed normally and may fail the threshold.
-
-### Reporting Ignored Functions
-
-Use `--report-ignored` to list every location where an ignore comment suppresses a function:
-
-```bash
-complexipy . --report-ignored
-```
-
-When `--output-format json` is also active, ignored locations are exported to `complexipy-ignored.json`.
-
-## API Reference
-
-```text
-# Core functions
-file_complexity(path: str, check_script: bool = False, no_ignore: bool = False) -> FileComplexity
-code_complexity(source: str, check_script: bool = False, no_ignore: bool = False) -> CodeComplexity
-collect_all_ignored_locations(paths: List[str], exclude: List[str] = [], invocation_path: str = "") -> Tuple[List[IgnoredLocation], List[str]]
-compute_diff(files: List[FileComplexity], git_ref: str, invocation_path: Optional[str] = None) -> List[DiffEntry]
-has_regressions(entries: List[DiffEntry], max_complexity: int) -> bool
-
-# Return types
-FileComplexity:
-  ├─ path: str (relative to the working directory, or absolute when outside it)
-  ├─ file_name: str
-  ├─ complexity: int
-  └─ functions: List[FunctionComplexity]
-
-FunctionComplexity:
-  ├─ name: str
-  ├─ complexity: int
-  ├─ line_start: int
-  ├─ line_end: int
-  ├─ line_complexities: List[LineComplexity]
-  └─ refactor_plans: List[RefactorPlan]
-
-RefactorPlan:
-  ├─ kind: str
-  ├─ title: str
-  ├─ line_start: int
-  ├─ line_end: int
-  ├─ column_start: int
-  ├─ current_complexity: int
-  ├─ estimated_reduction: int
-  ├─ estimated_complexity_after: int
-  ├─ rule_id: str
-  ├─ category: RuleCategory
-  ├─ applicability: Applicability
-  ├─ description: str
-  ├─ explanation: str
-  ├─ references: List[str]
-  ├─ suggestion: Optional[CodeSuggestion]
-  ├─ help: Optional[str]
-  └─ doc_url: str
-
-CodeSuggestion:
-  ├─ replacement: str
-  ├─ applicability: Applicability
-  └─ description: str
-
-RuleCategory: Complexity | Readability
-Applicability: MachineApplicable | MaybeIncorrect | Informational
-
-LineComplexity:
-  ├─ line: int
-  └─ complexity: int
-
-IgnoredLocation:
-  ├─ path: str
-  ├─ line: int
-  └─ comment: str
-
-CodeComplexity:
-  ├─ complexity: int
-  └─ functions: List[FunctionComplexity]
-
-DiffEntry:
-  ├─ file_path: str
-  ├─ func_name: str
-  ├─ old_complexity: Optional[int]
-  ├─ new_complexity: Optional[int]
-  ├─ status: DiffStatus (property)
-  └─ delta: Optional[int] (property)
-
-DiffStatus: REGRESSED | IMPROVED | UNCHANGED | NEW | REMOVED
-```
+## Learn More
+
+- [Usage Guide](usage-guide.md) - every CLI flag, configuration files, snapshots, complexity diff, and inline ignores
+- [API Reference](api-reference.md) - the complete Python API
+- [Understanding Scores](understanding-scores.md) - how the scoring algorithm works
+- [Comparison with Ruff](comparison-with-ruff.md) - cognitive vs cyclomatic complexity
+- [Refactoring Rules](refactoring-rules.md) - the rules behind `--suggest-refactors`
+- [Changelog](changelog.md) - what changed in each release
 
 ______________________________________________________________________
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -390,6 +390,41 @@ section to the same configuration file:
   the enforcement still applies. Fetch the branch or pass `--diff <ref>`
   with an existing reference instead.
 
+## CLI Options
+
+| Flag | Description | Default |
+| -- | -- | -- |
+| `--exclude` | Exclude glob patterns relative to each provided path. Use patterns like `tests/**` for directories or `src/legacy/file.py` for specific files. |  |
+| `--max-complexity-allowed` | Complexity threshold | `15` |
+| `--snapshot-create` | Save the current violations above the threshold into `complexipy-snapshot.json` | `false` |
+| `--snapshot-ignore` | Skip comparing against the snapshot even if it exists | `false` |
+| `--failed` | Show only functions above the complexity threshold | `false` |
+| `--suggest-refactors` | Show deterministic Rust AST-based refactor plans in rich CLI output. Ignored by `--plain` | `false` |
+| `--color <auto\|yes\|no>` | Use color | `auto` |
+| `--sort <asc\|desc\|file_name>` | Sort results | `asc` |
+| `--quiet` | Suppress output | `false` |
+| `--ignore-complexity` | Don't exit with error on threshold breach | `false` |
+| `--version` | Show installed complexipy version and exit | - |
+| `--top <n>` | Show only the `n` most complex functions, globally sorted by complexity descending | - |
+| `--plain` | Emit plain text lines as `<path> <function> <complexity>`. Cannot be combined with `--quiet` | `false` |
+| `--output-format <format>` | Select a machine-readable output format. Repeat the flag to request multiple formats (`json`, `csv`, `gitlab`, `sarif`) | - |
+| `--output <path>` | Write machine-readable output to a file or directory. Use a directory when emitting multiple formats | - |
+| `--diff <ref>` | Show a complexity diff against a git reference and enforce the threshold. Fails on regressions above `--max-complexity-allowed` (see [Complexity Diff](#complexity-diff)) | - |
+| `--diff-only <ref>` | Show a complexity diff visually without affecting the exit code (see [Complexity Diff](#complexity-diff)) | - |
+| `--staged` | Compare staged (git index) changes against the `--diff` ref (default `HEAD`). Answers "what complexity am I about to commit?" (see [Complexity Diff](#complexity-diff)) | `false` |
+| `--check-script` | Report module-level (script) complexity as a synthetic `<module>` entry | `false` |
+| `--no-ignore` | Analyze every function, disregarding inline ignore comments (`# complexipy: ignore`, `# noqa: complexipy`) | `false` |
+| `--report-ignored` | List every file:line where an ignore comment suppresses a function. Prints even under `--quiet` | `false` |
+
+Example:
+
+```
+# Exclude a directory recursively under the provided root
+complexipy . --exclude "tests/**"
+# Exclude a specific file
+complexipy . --exclude "src/legacy/old_code.py"
+```
+
 ## Cache Configuration
 
 complexipy stores per-function complexity data between runs to power
@@ -836,6 +871,20 @@ Or run directly:
   run: |
       pip install complexipy
       complexipy . --max-complexity-allowed 15
+```
+
+### GitHub Code Scanning (SARIF)
+
+Upload complexity violations as inline PR annotations using SARIF:
+
+```yaml
+- name: Run complexipy
+  run: complexipy . --output-format sarif --output complexipy-results.sarif --ignore-complexity
+
+- name: Upload SARIF results
+  uses: github/codeql-action/upload-sarif@v3
+  with:
+      sarif_file: complexipy-results.sarif
 ```
 
 ### Pre-commit Hook

--- a/mkdocs.es.yml
+++ b/mkdocs.es.yml
@@ -13,6 +13,7 @@ nav:
   - Inicio: index.md
   - Primeros Pasos:
       - Guía de Uso: usage-guide.md
+      - Referencia de la API: api-reference.md
       - Guía de Migración: migracion.md
   - Registro de Cambios: changelog.md
   - Entendiendo la Complejidad:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - Usage Guide: usage-guide.md
+      - API Reference: api-reference.md
       - Migration Guide: migration.md
   - Changelog: changelog.md
   - Understanding Complexity:


### PR DESCRIPTION
## What

Turns the README and the docs home page from full reference manuals into a slim landing funnel that pitches the tool and links to the docs site for everything else.

## Why

The README (525 lines) and docs home (461 lines) duplicated the whole manual: 16 quick-start examples, a 19-row CLI options table, six advanced feature sections, and a ~60-line API reference tree. The README is also the PyPI page, whose audience wants a pitch and a fast start. All the cut content already existed on the docs site, so nothing is lost.

## Changes

- `README.md` (525 -> 148 lines) and `docs/index.md` (461 -> 144 lines) now keep only: what-it-is, common questions, install, quick start (6 CLI examples + 1 API snippet), integrations, and learn-more links
- New `docs/api-reference.md` and `docs/es/api-reference.md` hold the complete API tree, including `DiffEntry` and `DiffStatus`
- The full CLI options table moved into `docs/usage-guide.md` and `docs/es/usage-guide.md`
- The GitHub Code Scanning (SARIF) upload snippet was added to the CI/CD section of both usage guides
- `mkdocs.yml` and `mkdocs.es.yml` gained nav entries for the API reference pages
- Spanish docs mirror every change