### PR TITLE
chore: point docs and embedded links at the complexipy.com domain

### DIFF
--- a/.agents/skills/release-notes/SKILL.md
+++ b/.agents/skills/release-notes/SKILL.md
@@ -96,11 +96,11 @@ Before writing the release notes, make sure `## Unreleased` in
 - Removed flags, keys, and API breaks go under `### Removed`; a major
   release with breaking changes gets a `!!! note "Migration"` callout
   linking to the migration guide
-  (`https://rohaquinlop.github.io/complexipy/migration/`).
+  (`https://complexipy.com/migration/`).
 - Mirror every entry in `docs/es/changelog.md` under `## Sin publicar`
   (`### Añadido`, `### Cambiado`, `### Corregido`, `### Eliminado`); the ES
   migration link points to
-  `https://rohaquinlop.github.io/complexipy/es/migracion/`.
+  `https://complexipy.com/es/migracion/`.
 
 If a change is missing from `## Unreleased`, add it before drafting the
 notes. The release notes are drafted from this section, and at publish time
@@ -206,8 +206,8 @@ into a dated release section:
    `## Sin publicar` to empty.
 5. If this is a major release with breaking changes, add a
    `!!! note "Migration"` callout at the top of the new section linking to
-   the migration guide (`https://rohaquinlop.github.io/complexipy/migration/`;
-   Spanish: `https://rohaquinlop.github.io/complexipy/es/migracion/`).
+   the migration guide (`https://complexipy.com/migration/`;
+   Spanish: `https://complexipy.com/es/migracion/`).
 
 Never edit `docs/changelog.md` - it embeds the root file via the
 pymdownx.snippets include (`--8<-- "CHANGELOG.md"`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 authors = ["Robin Quintero <rohaquinlop301@gmail.com>"]
 license = "MIT"
 homepage = "https://github.com/rohaquinlop/complexipy"
-documentation = "https://rohaquinlop.github.io/complexipy/"
+documentation = "https://complexipy.com/"
 repository = "https://github.com/rohaquinlop/complexipy"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
     <a href="#quick-start">Quick Start</a> •
     <a href="#integrations">Integrations</a> •
     <a href="#learn-more">Learn More</a> •
-    <a href="https://rohaquinlop.github.io/complexipy/">Documentation</a> •
-    <a href="https://rohaquinlop.github.io/complexipy/changelog/">Changelog</a> •
+    <a href="https://complexipy.com/">Documentation</a> •
+    <a href="https://complexipy.com/changelog/">Changelog</a> •
     <a href="https://www.complexipy-teams.com/">Complexipy Teams</a>
   </p>
 </div>
@@ -36,13 +36,13 @@ Unlike traditional metrics like cyclomatic complexity, cognitive complexity acco
 
 ## Common Questions
 
-**[How is complexity calculated?](https://rohaquinlop.github.io/complexipy/understanding-scores/)**
+**[How is complexity calculated?](https://complexipy.com/understanding-scores/)**
 Learn about the scoring algorithm, what each control structure contributes, and how nesting affects the final score.
 
-**[How does this compare to Ruff's PLR0912?](https://rohaquinlop.github.io/complexipy/comparison-with-ruff/)**
+**[How does this compare to Ruff's PLR0912?](https://complexipy.com/comparison-with-ruff/)**
 Understand the key differences between cyclomatic complexity (Ruff) and cognitive complexity (complexipy), and why you might want to use both.
 
-**[Is this a SonarSource/Sonar product?](https://rohaquinlop.github.io/complexipy/about/)**
+**[Is this a SonarSource/Sonar product?](https://complexipy.com/about/)**
 No. complexipy is an independent project inspired by G. Ann Campbell's research, but it's not affiliated with or endorsed by SonarSource.
 
 ## Installation
@@ -127,12 +127,12 @@ Install from the [marketplace](https://marketplace.visualstudio.com/items?itemNa
 
 ## Learn More
 
-- [Usage Guide](https://rohaquinlop.github.io/complexipy/usage-guide/) - every CLI flag, configuration files, snapshots, complexity diff, and inline ignores
-- [API Reference](https://rohaquinlop.github.io/complexipy/api-reference/) - the complete Python API
-- [Understanding Scores](https://rohaquinlop.github.io/complexipy/understanding-scores/) - how the scoring algorithm works
-- [Comparison with Ruff](https://rohaquinlop.github.io/complexipy/comparison-with-ruff/) - cognitive vs cyclomatic complexity
-- [Refactoring Rules](https://rohaquinlop.github.io/complexipy/refactoring-rules/) - the rules behind `--suggest-refactors`
-- [Changelog](https://rohaquinlop.github.io/complexipy/changelog/) - what changed in each release
+- [Usage Guide](https://complexipy.com/usage-guide/) - every CLI flag, configuration files, snapshots, complexity diff, and inline ignores
+- [API Reference](https://complexipy.com/api-reference/) - the complete Python API
+- [Understanding Scores](https://complexipy.com/understanding-scores/) - how the scoring algorithm works
+- [Comparison with Ruff](https://complexipy.com/comparison-with-ruff/) - cognitive vs cyclomatic complexity
+- [Refactoring Rules](https://complexipy.com/refactoring-rules/) - the rules behind `--suggest-refactors`
+- [Changelog](https://complexipy.com/changelog/) - what changed in each release
 
 ______________________________________________________________________
 
@@ -141,7 +141,7 @@ ______________________________________________________________________
 <sub>Inspired by the <a href="https://www.sonarsource.com/resources/cognitive-complexity/">Cognitive Complexity</a> research by G. Ann Campbell</sub><br>
 <sub>complexipy is an independent project and is not affiliated with or endorsed by SonarSource</sub>
 
-**[Documentation](https://rohaquinlop.github.io/complexipy/) • [PyPI](https://pypi.org/project/complexipy/) • [GitHub](https://github.com/rohaquinlop/complexipy)**
+**[Documentation](https://complexipy.com/) • [PyPI](https://pypi.org/project/complexipy/) • [GitHub](https://github.com/rohaquinlop/complexipy)**
 
 <sub>Built with ❤️ by <a href="https://github.com/rohaquinlop">@rohaquinlop</a> and <a href="https://github.com/rohaquinlop/complexipy/graphs/contributors">contributors</a></sub>
 

--- a/crates/complexipy-cli/src/utils/sarif.rs
+++ b/crates/complexipy-cli/src/utils/sarif.rs
@@ -9,8 +9,8 @@ use complexipy_core::utils::ExportError;
 
 const RULE_ID: &str = "CC001";
 const SCHEMA: &str = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json";
-const INFO_URI: &str = "https://rohaquinlop.github.io/complexipy/";
-const HELP_URI: &str = "https://rohaquinlop.github.io/complexipy/understanding-scores/";
+const INFO_URI: &str = "https://complexipy.com/";
+const HELP_URI: &str = "https://complexipy.com/understanding-scores/";
 
 pub fn store_sarif(
     output_path: &str,

--- a/crates/complexipy-cli/src/utils/sarif/tests.rs
+++ b/crates/complexipy-cli/src/utils/sarif/tests.rs
@@ -178,7 +178,7 @@ fn sarif_rule_defined() {
     assert_eq!(rules[0]["name"], "CognitiveComplexity");
     assert_eq!(
         rules[0]["helpUri"],
-        "https://rohaquinlop.github.io/complexipy/understanding-scores/"
+        "https://complexipy.com/understanding-scores/"
     );
 }
 

--- a/crates/complexipy-core/src/rules/complexity.rs
+++ b/crates/complexipy-core/src/rules/complexity.rs
@@ -16,10 +16,13 @@ impl RefactorRule for FlattenConditionRule {
             id: "C001".to_string(),
             name: "flatten_condition".to_string(),
             category: RuleCategory::Complexity,
-            description: "Flatten nested condition blocks by using guard clauses with early returns".to_string(),
+            description:
+                "Flatten nested condition blocks by using guard clauses with early returns"
+                    .to_string(),
             applicability: Applicability::Informational,
             effectiveness: 4,
-            doc_url: "https://complexipy.com/refactoring-rules/#c001-flatten-nested-conditions".to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c001-flatten-nested-conditions"
+                .to_string(),
         })
     }
 
@@ -70,8 +73,7 @@ impl RefactorRule for LoopGuardsRule {
             description: "Use continue guards at the top of loops to reduce nesting".to_string(),
             applicability: Applicability::MachineApplicable,
             effectiveness: 3,
-            doc_url: "https://complexipy.com/refactoring-rules/#c002-loop-guards"
-                .to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c002-loop-guards".to_string(),
         })
     }
 
@@ -148,7 +150,8 @@ impl RefactorRule for ExtractHelperRule {
             description: "Extract complex code blocks into separate helper functions".to_string(),
             applicability: Applicability::Informational,
             effectiveness: 2,
-            doc_url: "https://complexipy.com/refactoring-rules/#c003-extract-helper-function".to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c003-extract-helper-function"
+                .to_string(),
         })
     }
 
@@ -203,9 +206,7 @@ impl RefactorRule for SplitDispatcherRule {
             description: "Split long elif chains into separate handlers".to_string(),
             applicability: Applicability::Informational,
             effectiveness: 2,
-            doc_url:
-                "https://complexipy.com/refactoring-rules/#c004-split-dispatcher"
-                    .to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c004-split-dispatcher".to_string(),
         })
     }
 
@@ -352,9 +353,7 @@ impl RefactorRule for ExtractPredicateRule {
                 .to_string(),
             applicability: Applicability::MachineApplicable,
             effectiveness: 2,
-            doc_url:
-                "https://complexipy.com/refactoring-rules/#c005-extract-predicate"
-                    .to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c005-extract-predicate".to_string(),
         })
     }
 
@@ -413,9 +412,7 @@ impl RefactorRule for FlattenTryRule {
                 .to_string(),
             applicability: Applicability::Informational,
             effectiveness: 2,
-            doc_url:
-                "https://complexipy.com/refactoring-rules/#c011-flatten-tryexcept"
-                    .to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c011-flatten-tryexcept".to_string(),
         })
     }
 
@@ -483,9 +480,7 @@ impl RefactorRule for CollapsibleIfRule {
                 .to_string(),
             applicability: Applicability::MachineApplicable,
             effectiveness: 5,
-            doc_url:
-                "https://complexipy.com/refactoring-rules/#c007-collapsible-if"
-                    .to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c007-collapsible-if".to_string(),
         })
     }
 

--- a/crates/complexipy-core/src/rules/complexity.rs
+++ b/crates/complexipy-core/src/rules/complexity.rs
@@ -19,7 +19,7 @@ impl RefactorRule for FlattenConditionRule {
             description: "Flatten nested condition blocks by using guard clauses with early returns".to_string(),
             applicability: Applicability::Informational,
             effectiveness: 4,
-            doc_url: "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c001-flatten-nested-conditions".to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c001-flatten-nested-conditions".to_string(),
         })
     }
 
@@ -70,7 +70,7 @@ impl RefactorRule for LoopGuardsRule {
             description: "Use continue guards at the top of loops to reduce nesting".to_string(),
             applicability: Applicability::MachineApplicable,
             effectiveness: 3,
-            doc_url: "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c002-loop-guards"
+            doc_url: "https://complexipy.com/refactoring-rules/#c002-loop-guards"
                 .to_string(),
         })
     }
@@ -148,7 +148,7 @@ impl RefactorRule for ExtractHelperRule {
             description: "Extract complex code blocks into separate helper functions".to_string(),
             applicability: Applicability::Informational,
             effectiveness: 2,
-            doc_url: "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c003-extract-helper-function".to_string(),
+            doc_url: "https://complexipy.com/refactoring-rules/#c003-extract-helper-function".to_string(),
         })
     }
 
@@ -204,7 +204,7 @@ impl RefactorRule for SplitDispatcherRule {
             applicability: Applicability::Informational,
             effectiveness: 2,
             doc_url:
-                "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c004-split-dispatcher"
+                "https://complexipy.com/refactoring-rules/#c004-split-dispatcher"
                     .to_string(),
         })
     }
@@ -353,7 +353,7 @@ impl RefactorRule for ExtractPredicateRule {
             applicability: Applicability::MachineApplicable,
             effectiveness: 2,
             doc_url:
-                "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c005-extract-predicate"
+                "https://complexipy.com/refactoring-rules/#c005-extract-predicate"
                     .to_string(),
         })
     }
@@ -414,7 +414,7 @@ impl RefactorRule for FlattenTryRule {
             applicability: Applicability::Informational,
             effectiveness: 2,
             doc_url:
-                "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c011-flatten-tryexcept"
+                "https://complexipy.com/refactoring-rules/#c011-flatten-tryexcept"
                     .to_string(),
         })
     }
@@ -484,7 +484,7 @@ impl RefactorRule for CollapsibleIfRule {
             applicability: Applicability::MachineApplicable,
             effectiveness: 5,
             doc_url:
-                "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c007-collapsible-if"
+                "https://complexipy.com/refactoring-rules/#c007-collapsible-if"
                     .to_string(),
         })
     }

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+complexipy.com

--- a/docs/es/index.md
+++ b/docs/es/index.md
@@ -138,7 +138,7 @@ ______________________________________________________________________
 
 <p style="margin: 0.25rem 0"><sub>Inspirado en la investigación de <a href="https://www.sonarsource.com/resources/cognitive-complexity/">Complejidad Cognitiva</a> de G. Ann Campbell</sub></p>
 <p style="margin: 0.25rem 0"><sub>complexipy es un proyecto independiente y no está afiliado ni respaldado por SonarSource</sub></p>
-<p style="margin: 0.25rem 0"><strong><a href="https://rohaquinlop.github.io/complexipy/">Documentación</a> • <a href="https://pypi.org/project/complexipy/">PyPI</a> • <a href="https://github.com/rohaquinlop/complexipy">GitHub</a></strong></p>
+<p style="margin: 0.25rem 0"><strong><a href="https://complexipy.com/">Documentación</a> • <a href="https://pypi.org/project/complexipy/">PyPI</a> • <a href="https://github.com/rohaquinlop/complexipy">GitHub</a></strong></p>
 <p style="margin: 0.25rem 0"><sub>Desarrollado con ❤️ por <a href="https://github.com/rohaquinlop">@rohaquinlop</a> y <a href="https://github.com/rohaquinlop/complexipy/graphs/contributors">colaboradores</a></sub></p>
 
 </div>

--- a/docs/es/refactoring-rules.md
+++ b/docs/es/refactoring-rules.md
@@ -461,7 +461,7 @@ La salida JSON incluye todos los metadatos de las reglas para consumo programát
   "help": null,
   "explanation": "Nested if statements with a single body can be merged into a single if with combined conditions using 'and'. This reduces nesting and improves readability.",
   "references": [],
-  "doc_url": "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c007-collapsible-if"
+  "doc_url": "https://complexipy.com/refactoring-rules/#c007-collapsible-if"
 }
 ```
 

--- a/docs/es/usage-guide.md
+++ b/docs/es/usage-guide.md
@@ -274,7 +274,7 @@ Los planes se basan solo en el análisis AST de Rust; no se usa IA y no se reesc
                     "description": "Merge nested conditions into `if item.active and item.ready:`"
                 },
                 "help": null,
-                "doc_url": "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c007-collapsible-if"
+                "doc_url": "https://complexipy.com/refactoring-rules/#c007-collapsible-if"
             }
         ]
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -138,7 +138,7 @@ ______________________________________________________________________
 
 <p style="margin: 0.25rem 0"><sub>Inspired by the <a href="https://www.sonarsource.com/resources/cognitive-complexity/">Cognitive Complexity</a> research by G. Ann Campbell</sub></p>
 <p style="margin: 0.25rem 0"><sub>complexipy is an independent project and is not affiliated with or endorsed by SonarSource</sub></p>
-<p style="margin: 0.25rem 0"><strong><a href="https://rohaquinlop.github.io/complexipy/">Documentation</a> • <a href="https://pypi.org/project/complexipy/">PyPI</a> • <a href="https://github.com/rohaquinlop/complexipy">GitHub</a></strong></p>
+<p style="margin: 0.25rem 0"><strong><a href="https://complexipy.com/">Documentation</a> • <a href="https://pypi.org/project/complexipy/">PyPI</a> • <a href="https://github.com/rohaquinlop/complexipy">GitHub</a></strong></p>
 <p style="margin: 0.25rem 0"><sub>Built with ❤️ by <a href="https://github.com/rohaquinlop">@rohaquinlop</a> and <a href="https://github.com/rohaquinlop/complexipy/graphs/contributors">contributors</a></sub></p>
 
 </div>

--- a/docs/refactoring-rules.md
+++ b/docs/refactoring-rules.md
@@ -461,7 +461,7 @@ The JSON output includes all rule metadata for programmatic consumption:
   "help": null,
   "explanation": "Nested if statements with a single body can be merged into a single if with combined conditions using 'and'. This reduces nesting and improves readability.",
   "references": [],
-  "doc_url": "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c007-collapsible-if"
+  "doc_url": "https://complexipy.com/refactoring-rules/#c007-collapsible-if"
 }
 ```
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -275,7 +275,7 @@ Plans are based on the Rust AST analysis only; no AI is used and no code is rewr
                     "description": "Merge nested conditions into `if item.active and item.ready:`"
                 },
                 "help": null,
-                "doc_url": "https://rohaquinlop.github.io/complexipy/refactoring-rules/#c007-collapsible-if"
+                "doc_url": "https://complexipy.com/refactoring-rules/#c007-collapsible-if"
             }
         ]
     }

--- a/mkdocs.es.yml
+++ b/mkdocs.es.yml
@@ -1,7 +1,7 @@
 ---
 site_name: complexipy
 site_description: Análisis ultrarrápido de complejidad cognitiva para Python, escrito en Rust.
-site_url: https://rohaquinlop.github.io/complexipy/es/
+site_url: https://complexipy.com/es/
 repo_name: rohaquinlop/complexipy
 repo_url: https://github.com/rohaquinlop/complexipy
 edit_uri: edit/main/docs/es/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 ---
 site_name: complexipy
 site_description: Blazingly fast cognitive complexity analysis for Python, written in Rust.
-site_url: https://rohaquinlop.github.io/complexipy/
+site_url: https://complexipy.com/
 repo_name: rohaquinlop/complexipy
 repo_url: https://github.com/rohaquinlop/complexipy
 edit_uri: edit/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ complexipy = "complexipy.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/rohaquinlop/complexipy"
-Documentation = "https://rohaquinlop.github.io/complexipy/"
+Documentation = "https://complexipy.com/"
 Repository = "https://github.com/rohaquinlop/complexipy"
 
 [tool.maturin]


### PR DESCRIPTION
## What

Migrates all docs-facing URLs from `rohaquinlop.github.io/complexipy` to the newly acquired `complexipy.com` custom domain.

## Why

The project now owns `complexipy.com` and is pointing GitHub Pages at it via a custom domain (DNS configured in Cloudflare). All hardcoded references to the old `github.io` docs URL need to move to the new domain, including the ones baked into the Rust binary's output (rule doc links, SARIF report URIs).

## Changes

- Add `docs/CNAME` for the GitHub Pages custom domain and update `site_url` in `mkdocs.yml` / `mkdocs.es.yml`
- Update package metadata documentation URLs in `Cargo.toml` and `pyproject.toml`
- Update all doc links in `README.md` and in-page links across `docs/` (English and Spanish)
- Update the `release-notes` skill's migration-guide URL references
- Update embedded rule doc URLs (C001-C011) in `crates/complexipy-core/src/rules/complexity.rs`
- Update SARIF report URIs in `crates/complexipy-cli/src/utils/sarif.rs` and its test